### PR TITLE
feat: add declarative assertion system for health validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Declarative assertions for workload health validation (`assertions:` field in workload YAML)
+- Condition engine with 9 predicate types: `command_exists`, `file_exists`, `dir_exists`, `env_var`, `path_contains`, `registry_value`, `shell`, plus `all_of`/`any_of` composition
+- `--assertions-only` flag for `anvil health` to run only assertion checks
+- `assertion_check` toggle in workload health configuration
+
 ## [0.5.0] - 2026-04-17
 
 This is the first release from the new repository home at [kafkade/anvil](https://github.com/kafkade/anvil). It marks a fresh start with modernized CI/CD, updated documentation, and a clear cross-platform direction. Prior changelog entries (v0.1.0–v0.3.1) are preserved below for historical context.

--- a/src/assertions/mod.rs
+++ b/src/assertions/mod.rs
@@ -1,0 +1,333 @@
+//! Assertion evaluation engine for Anvil
+//!
+//! Evaluates named assertions (backed by the condition engine) and produces
+//! structured results suitable for health reporting.
+
+use std::time::Instant;
+
+use serde::Serialize;
+
+use crate::cli::output::{CheckResult, CheckStatus};
+use crate::conditions;
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Status of an evaluated assertion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[allow(dead_code)]
+pub enum AssertionStatus {
+    Pass,
+    Fail,
+    Skip,
+}
+
+/// Result of evaluating a single assertion.
+#[derive(Debug, Clone, Serialize)]
+#[allow(dead_code)]
+pub struct AssertionResult {
+    /// Display name of the assertion.
+    pub name: String,
+    /// Whether the assertion passed.
+    pub status: AssertionStatus,
+    /// Human-readable message.
+    pub message: String,
+    /// How long evaluation took.
+    pub duration: std::time::Duration,
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+/// Evaluate a list of assertions and return results.
+///
+/// Each assertion is a `(name, condition)` tuple. The condition is evaluated
+/// via [`conditions::evaluate`] and the outcome is wrapped in an
+/// [`AssertionResult`] with timing information.
+#[allow(dead_code)]
+pub fn evaluate_assertions(assertions: &[(String, conditions::Condition)]) -> Vec<AssertionResult> {
+    assertions
+        .iter()
+        .map(|(name, condition)| {
+            let start = Instant::now();
+
+            let cond_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                conditions::evaluate(condition)
+            }));
+
+            let duration = start.elapsed();
+
+            match cond_result {
+                Ok(cr) => AssertionResult {
+                    name: name.clone(),
+                    status: if cr.passed {
+                        AssertionStatus::Pass
+                    } else {
+                        AssertionStatus::Fail
+                    },
+                    message: cr.message,
+                    duration,
+                },
+                Err(_) => AssertionResult {
+                    name: name.clone(),
+                    status: AssertionStatus::Fail,
+                    message: "Condition evaluation panicked".to_string(),
+                    duration,
+                },
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+/// Convert assertion results to [`CheckResult`]s for health reporting.
+#[allow(dead_code)]
+pub fn to_check_results(results: &[AssertionResult]) -> Vec<CheckResult> {
+    results
+        .iter()
+        .map(|r| {
+            let status = match r.status {
+                AssertionStatus::Pass => CheckStatus::Ok,
+                AssertionStatus::Fail => CheckStatus::Fail,
+                AssertionStatus::Skip => CheckStatus::Skip,
+            };
+
+            CheckResult {
+                name: r.name.clone(),
+                status,
+                message: Some(r.message.clone()),
+                category: "Assertions".to_string(),
+                details: None,
+                script_counts: None,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conditions::Condition;
+
+    #[test]
+    fn test_evaluate_passing_assertion() {
+        // PATH env var is always set
+        let assertions = vec![(
+            "PATH is set".to_string(),
+            Condition::EnvVar {
+                name: "PATH".to_string(),
+                value: None,
+            },
+        )];
+
+        let results = evaluate_assertions(&assertions);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "PATH is set");
+        assert_eq!(results[0].status, AssertionStatus::Pass);
+    }
+
+    #[test]
+    fn test_evaluate_failing_assertion() {
+        let assertions = vec![(
+            "missing var".to_string(),
+            Condition::EnvVar {
+                name: "ANVIL_TEST_NONEXISTENT_VAR_XYZ_12345".to_string(),
+                value: None,
+            },
+        )];
+
+        let results = evaluate_assertions(&assertions);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "missing var");
+        assert_eq!(results[0].status, AssertionStatus::Fail);
+    }
+
+    #[test]
+    fn test_evaluate_mixed_pass_fail() {
+        let assertions = vec![
+            (
+                "should pass".to_string(),
+                Condition::EnvVar {
+                    name: "PATH".to_string(),
+                    value: None,
+                },
+            ),
+            (
+                "should fail".to_string(),
+                Condition::EnvVar {
+                    name: "ANVIL_TEST_NONEXISTENT_VAR_XYZ_12345".to_string(),
+                    value: None,
+                },
+            ),
+        ];
+
+        let results = evaluate_assertions(&assertions);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].status, AssertionStatus::Pass);
+        assert_eq!(results[1].status, AssertionStatus::Fail);
+    }
+
+    #[test]
+    fn test_duration_is_positive() {
+        let assertions = vec![(
+            "timing check".to_string(),
+            Condition::EnvVar {
+                name: "PATH".to_string(),
+                value: None,
+            },
+        )];
+
+        let results = evaluate_assertions(&assertions);
+
+        assert!(!results[0].duration.is_zero() || results[0].duration == std::time::Duration::ZERO);
+        // Duration should be non-negative (always true for Duration, but verifies we set it)
+        assert!(results[0].duration.as_nanos() < 60_000_000_000); // < 60s sanity
+    }
+
+    #[test]
+    fn test_to_check_results_pass() {
+        let results = vec![AssertionResult {
+            name: "test pass".to_string(),
+            status: AssertionStatus::Pass,
+            message: "it passed".to_string(),
+            duration: std::time::Duration::from_millis(1),
+        }];
+
+        let checks = to_check_results(&results);
+
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "test pass");
+        assert_eq!(checks[0].status, CheckStatus::Ok);
+        assert_eq!(checks[0].message.as_deref(), Some("it passed"));
+        assert_eq!(checks[0].category, "Assertions");
+        assert!(checks[0].details.is_none());
+        assert!(checks[0].script_counts.is_none());
+    }
+
+    #[test]
+    fn test_to_check_results_fail() {
+        let results = vec![AssertionResult {
+            name: "test fail".to_string(),
+            status: AssertionStatus::Fail,
+            message: "it failed".to_string(),
+            duration: std::time::Duration::from_millis(1),
+        }];
+
+        let checks = to_check_results(&results);
+
+        assert_eq!(checks[0].status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn test_to_check_results_skip() {
+        let results = vec![AssertionResult {
+            name: "test skip".to_string(),
+            status: AssertionStatus::Skip,
+            message: "skipped".to_string(),
+            duration: std::time::Duration::ZERO,
+        }];
+
+        let checks = to_check_results(&results);
+
+        assert_eq!(checks[0].status, CheckStatus::Skip);
+    }
+
+    #[test]
+    fn test_to_check_results_mixed() {
+        let results = vec![
+            AssertionResult {
+                name: "a".to_string(),
+                status: AssertionStatus::Pass,
+                message: "ok".to_string(),
+                duration: std::time::Duration::ZERO,
+            },
+            AssertionResult {
+                name: "b".to_string(),
+                status: AssertionStatus::Fail,
+                message: "nope".to_string(),
+                duration: std::time::Duration::ZERO,
+            },
+            AssertionResult {
+                name: "c".to_string(),
+                status: AssertionStatus::Skip,
+                message: "skip".to_string(),
+                duration: std::time::Duration::ZERO,
+            },
+        ];
+
+        let checks = to_check_results(&results);
+
+        assert_eq!(checks.len(), 3);
+        assert_eq!(checks[0].status, CheckStatus::Ok);
+        assert_eq!(checks[1].status, CheckStatus::Fail);
+        assert_eq!(checks[2].status, CheckStatus::Skip);
+    }
+
+    #[test]
+    fn test_empty_assertions() {
+        let results = evaluate_assertions(&[]);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_shell_condition_fail() {
+        // A shell command that will fail
+        let assertions = vec![(
+            "bad command".to_string(),
+            Condition::Shell {
+                command: "exit 1".to_string(),
+                description: Some("intentionally fails".to_string()),
+            },
+        )];
+
+        let results = evaluate_assertions(&assertions);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, AssertionStatus::Fail);
+    }
+
+    #[test]
+    fn test_command_exists_pass() {
+        // `cmd` is always available on Windows
+        let assertions = vec![(
+            "cmd exists".to_string(),
+            Condition::CommandExists {
+                command: if cfg!(windows) {
+                    "cmd".to_string()
+                } else {
+                    "sh".to_string()
+                },
+            },
+        )];
+
+        let results = evaluate_assertions(&assertions);
+
+        assert_eq!(results[0].status, AssertionStatus::Pass);
+    }
+
+    #[test]
+    fn test_command_exists_fail() {
+        let assertions = vec![(
+            "bogus not found".to_string(),
+            Condition::CommandExists {
+                command: "anvil_nonexistent_binary_xyz_12345".to_string(),
+            },
+        )];
+
+        let results = evaluate_assertions(&assertions);
+
+        assert_eq!(results[0].status, AssertionStatus::Fail);
+    }
+}

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -178,6 +178,10 @@ pub struct HealthArgs {
     #[arg(long)]
     pub scripts_only: bool,
 
+    /// Only evaluate declarative assertions
+    #[arg(long)]
+    pub assertions_only: bool,
+
     /// Treat warnings as errors
     #[arg(short, long)]
     pub strict: bool,

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -1,0 +1,881 @@
+//! Condition/predicate engine for Anvil
+//!
+//! Provides a composable, serde-tagged condition system for evaluating
+//! system state: command existence, file/dir checks, environment variables,
+//! PATH contents, Windows registry values, and arbitrary shell commands.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::config::expand_variables;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur during condition evaluation.
+#[derive(Debug, Error)]
+#[allow(dead_code)]
+pub enum ConditionError {
+    #[error("Failed to execute command: {0}")]
+    CommandExecution(String),
+
+    #[error("Invalid condition configuration: {0}")]
+    InvalidConfig(String),
+
+    #[error("Registry query failed: {0}")]
+    RegistryError(String),
+}
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+/// Structured result of evaluating a single [`Condition`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct ConditionResult {
+    /// Which condition variant was evaluated (e.g. `"command_exists"`).
+    pub condition_type: String,
+    /// Whether the condition passed.
+    pub passed: bool,
+    /// The actual value observed on the system, if applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual: Option<String>,
+    /// The expected value, if the condition specifies one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected: Option<String>,
+    /// Human-readable description of the outcome.
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
+// Condition enum
+// ---------------------------------------------------------------------------
+
+/// A declarative predicate that can be evaluated against the current system.
+///
+/// Serializes as an internally-tagged enum so that YAML/JSON representations
+/// use a `type` discriminator field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum Condition {
+    /// Check whether a command is available on `PATH`.
+    CommandExists { command: String },
+
+    /// Check whether a file exists at the given path (`~` is expanded).
+    FileExists { path: String },
+
+    /// Check whether a directory exists at the given path (`~` is expanded).
+    DirExists { path: String },
+
+    /// Check whether an environment variable is set, optionally matching a value.
+    EnvVar {
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<String>,
+    },
+
+    /// Check whether `PATH` contains a given substring.
+    PathContains { substring: String },
+
+    /// Query a Windows registry value under `HKCU` or `HKLM`.
+    RegistryValue {
+        /// Registry hive – `"HKCU"` or `"HKLM"`.
+        hive: String,
+        /// Full key path, e.g. `"SOFTWARE\\Microsoft\\Windows\\CurrentVersion"`.
+        key: String,
+        /// Value name inside the key.
+        name: String,
+        /// Expected data; if omitted the check only asserts presence.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected: Option<String>,
+    },
+
+    /// Run a shell command; the condition passes when the exit code is 0.
+    Shell {
+        command: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
+
+    /// All child conditions must pass (logical AND).
+    AllOf { conditions: Vec<Condition> },
+
+    /// At least one child condition must pass (logical OR).
+    AnyOf { conditions: Vec<Condition> },
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+/// Evaluate a [`Condition`] and return a structured [`ConditionResult`].
+#[allow(dead_code)]
+pub fn evaluate(condition: &Condition) -> ConditionResult {
+    match condition {
+        Condition::CommandExists { command } => eval_command_exists(command),
+        Condition::FileExists { path } => eval_file_exists(path),
+        Condition::DirExists { path } => eval_dir_exists(path),
+        Condition::EnvVar { name, value } => eval_env_var(name, value.as_deref()),
+        Condition::PathContains { substring } => eval_path_contains(substring),
+        Condition::RegistryValue {
+            hive,
+            key,
+            name,
+            expected,
+        } => eval_registry_value(hive, key, name, expected.as_deref()),
+        Condition::Shell {
+            command,
+            description,
+        } => eval_shell(command, description.as_deref()),
+        Condition::AllOf { conditions } => eval_all_of(conditions),
+        Condition::AnyOf { conditions } => eval_any_of(conditions),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Individual evaluators
+// ---------------------------------------------------------------------------
+
+fn eval_command_exists(command: &str) -> ConditionResult {
+    let found = if cfg!(windows) {
+        Command::new("where")
+            .arg(command)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    } else {
+        Command::new("which")
+            .arg(command)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    };
+
+    ConditionResult {
+        condition_type: "command_exists".to_string(),
+        passed: found,
+        actual: Some(if found {
+            "found".to_string()
+        } else {
+            "not found".to_string()
+        }),
+        expected: Some(command.to_string()),
+        message: if found {
+            format!("Command '{}' is available on PATH", command)
+        } else {
+            format!("Command '{}' was not found on PATH", command)
+        },
+    }
+}
+
+fn eval_file_exists(path: &str) -> ConditionResult {
+    let expanded = expand_variables(path, None);
+    let exists = Path::new(&expanded).is_file();
+
+    ConditionResult {
+        condition_type: "file_exists".to_string(),
+        passed: exists,
+        actual: Some(if exists {
+            "exists".to_string()
+        } else {
+            "not found".to_string()
+        }),
+        expected: Some(expanded.clone()),
+        message: if exists {
+            format!("File '{}' exists", expanded)
+        } else {
+            format!("File '{}' does not exist", expanded)
+        },
+    }
+}
+
+fn eval_dir_exists(path: &str) -> ConditionResult {
+    let expanded = expand_variables(path, None);
+    let exists = Path::new(&expanded).is_dir();
+
+    ConditionResult {
+        condition_type: "dir_exists".to_string(),
+        passed: exists,
+        actual: Some(if exists {
+            "exists".to_string()
+        } else {
+            "not found".to_string()
+        }),
+        expected: Some(expanded.clone()),
+        message: if exists {
+            format!("Directory '{}' exists", expanded)
+        } else {
+            format!("Directory '{}' does not exist", expanded)
+        },
+    }
+}
+
+fn eval_env_var(name: &str, expected: Option<&str>) -> ConditionResult {
+    match std::env::var(name) {
+        Ok(actual_value) => {
+            if let Some(exp) = expected {
+                let matches = actual_value == exp;
+                ConditionResult {
+                    condition_type: "env_var".to_string(),
+                    passed: matches,
+                    actual: Some(actual_value),
+                    expected: Some(exp.to_string()),
+                    message: if matches {
+                        format!("Environment variable '{}' matches expected value", name)
+                    } else {
+                        format!(
+                            "Environment variable '{}' exists but does not match expected value",
+                            name
+                        )
+                    },
+                }
+            } else {
+                ConditionResult {
+                    condition_type: "env_var".to_string(),
+                    passed: true,
+                    actual: Some(actual_value),
+                    expected: None,
+                    message: format!("Environment variable '{}' is set", name),
+                }
+            }
+        }
+        Err(_) => ConditionResult {
+            condition_type: "env_var".to_string(),
+            passed: false,
+            actual: None,
+            expected: expected.map(|s| s.to_string()),
+            message: format!("Environment variable '{}' is not set", name),
+        },
+    }
+}
+
+fn eval_path_contains(substring: &str) -> ConditionResult {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    let found = path_var
+        .split(separator)
+        .any(|entry| entry.contains(substring));
+
+    ConditionResult {
+        condition_type: "path_contains".to_string(),
+        passed: found,
+        actual: None,
+        expected: Some(substring.to_string()),
+        message: if found {
+            format!("PATH contains an entry matching '{}'", substring)
+        } else {
+            format!("PATH does not contain an entry matching '{}'", substring)
+        },
+    }
+}
+
+fn eval_registry_value(
+    hive: &str,
+    key: &str,
+    name: &str,
+    expected: Option<&str>,
+) -> ConditionResult {
+    let full_key = format!("{}\\{}", hive, key);
+
+    let output = Command::new("reg")
+        .args(["query", &full_key, "/v", name])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            // `reg query` output contains a line like:
+            //     ValueName    REG_SZ    ActualData
+            let actual_value = parse_reg_query_output(&stdout, name);
+
+            if let Some(exp) = expected {
+                let matches = actual_value.as_deref() == Some(exp);
+                ConditionResult {
+                    condition_type: "registry_value".to_string(),
+                    passed: matches,
+                    actual: actual_value,
+                    expected: Some(exp.to_string()),
+                    message: if matches {
+                        format!("Registry value '{}\\{}' matches expected", full_key, name)
+                    } else {
+                        format!(
+                            "Registry value '{}\\{}' does not match expected",
+                            full_key, name
+                        )
+                    },
+                }
+            } else {
+                ConditionResult {
+                    condition_type: "registry_value".to_string(),
+                    passed: true,
+                    actual: actual_value,
+                    expected: None,
+                    message: format!("Registry value '{}\\{}' exists", full_key, name),
+                }
+            }
+        }
+        _ => ConditionResult {
+            condition_type: "registry_value".to_string(),
+            passed: false,
+            actual: None,
+            expected: expected.map(|s| s.to_string()),
+            message: format!("Registry value '{}\\{}' was not found", full_key, name),
+        },
+    }
+}
+
+/// Parse `reg query` stdout to extract the value data for a given value name.
+fn parse_reg_query_output(output: &str, value_name: &str) -> Option<String> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        // Lines look like: "    ValueName    REG_SZ    SomeValue"
+        if trimmed.starts_with(value_name) {
+            // Split by whitespace: [name, type, ...data]
+            let parts: Vec<&str> = trimmed.splitn(3, "    ").collect();
+            if parts.len() == 3 {
+                return Some(parts[2].trim().to_string());
+            }
+        }
+    }
+    None
+}
+
+fn eval_shell(command: &str, description: Option<&str>) -> ConditionResult {
+    let label = description.unwrap_or(command);
+
+    let result = if cfg!(windows) {
+        Command::new("cmd")
+            .args(["/C", command])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+    } else {
+        Command::new("sh")
+            .args(["-c", command])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+    };
+
+    match result {
+        Ok(status) => {
+            let passed = status.success();
+            ConditionResult {
+                condition_type: "shell".to_string(),
+                passed,
+                actual: Some(
+                    status
+                        .code()
+                        .map(|c| c.to_string())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                ),
+                expected: Some("0".to_string()),
+                message: if passed {
+                    format!("Shell command passed: {}", label)
+                } else {
+                    format!(
+                        "Shell command failed (exit {}): {}",
+                        status.code().unwrap_or(-1),
+                        label,
+                    )
+                },
+            }
+        }
+        Err(e) => ConditionResult {
+            condition_type: "shell".to_string(),
+            passed: false,
+            actual: Some(e.to_string()),
+            expected: Some("0".to_string()),
+            message: format!("Shell command could not be executed: {}", label),
+        },
+    }
+}
+
+fn eval_all_of(conditions: &[Condition]) -> ConditionResult {
+    let results: Vec<ConditionResult> = conditions.iter().map(evaluate).collect();
+    let passed = results.iter().all(|r| r.passed);
+    let total = results.len();
+    let passed_count = results.iter().filter(|r| r.passed).count();
+
+    ConditionResult {
+        condition_type: "all_of".to_string(),
+        passed,
+        actual: Some(format!("{}/{} passed", passed_count, total)),
+        expected: Some(format!("{}/{} passed", total, total)),
+        message: if passed {
+            format!("All {} conditions passed", total)
+        } else {
+            let failed: Vec<String> = results
+                .iter()
+                .filter(|r| !r.passed)
+                .map(|r| r.message.clone())
+                .collect();
+            format!(
+                "{}/{} conditions failed: {}",
+                total - passed_count,
+                total,
+                failed.join("; ")
+            )
+        },
+    }
+}
+
+fn eval_any_of(conditions: &[Condition]) -> ConditionResult {
+    let results: Vec<ConditionResult> = conditions.iter().map(evaluate).collect();
+    let passed = results.iter().any(|r| r.passed);
+    let total = results.len();
+    let passed_count = results.iter().filter(|r| r.passed).count();
+
+    ConditionResult {
+        condition_type: "any_of".to_string(),
+        passed,
+        actual: Some(format!("{}/{} passed", passed_count, total)),
+        expected: Some(format!("≥1/{} passed", total)),
+        message: if passed {
+            format!(
+                "{}/{} conditions passed (at least one required)",
+                passed_count, total
+            )
+        } else {
+            format!("None of {} conditions passed", total)
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    // -- command_exists --
+
+    #[test]
+    fn test_command_exists_found() {
+        // `cmd` is always available on Windows; on Unix `sh` is universal
+        let cmd = if cfg!(windows) { "cmd" } else { "sh" };
+        let result = evaluate(&Condition::CommandExists {
+            command: cmd.to_string(),
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "command_exists");
+        assert_eq!(result.actual.as_deref(), Some("found"));
+    }
+
+    #[test]
+    fn test_command_exists_not_found() {
+        let result = evaluate(&Condition::CommandExists {
+            command: "anvil_nonexistent_command_xyz_12345".to_string(),
+        });
+        assert!(!result.passed);
+        assert_eq!(result.condition_type, "command_exists");
+        assert_eq!(result.actual.as_deref(), Some("not found"));
+    }
+
+    // -- file_exists --
+
+    #[test]
+    fn test_file_exists_pass() {
+        // Cargo.toml is always present in the repo root
+        let result = evaluate(&Condition::FileExists {
+            path: "Cargo.toml".to_string(),
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "file_exists");
+    }
+
+    #[test]
+    fn test_file_exists_fail() {
+        let result = evaluate(&Condition::FileExists {
+            path: "nonexistent_file_xyz_12345.txt".to_string(),
+        });
+        assert!(!result.passed);
+    }
+
+    // -- dir_exists --
+
+    #[test]
+    fn test_dir_exists_pass() {
+        let result = evaluate(&Condition::DirExists {
+            path: "src".to_string(),
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "dir_exists");
+    }
+
+    #[test]
+    fn test_dir_exists_fail() {
+        let result = evaluate(&Condition::DirExists {
+            path: "nonexistent_dir_xyz_12345".to_string(),
+        });
+        assert!(!result.passed);
+    }
+
+    // -- env_var --
+
+    #[test]
+    fn test_env_var_exists() {
+        // PATH is always set
+        let result = evaluate(&Condition::EnvVar {
+            name: "PATH".to_string(),
+            value: None,
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "env_var");
+        assert!(result.actual.is_some());
+    }
+
+    #[test]
+    fn test_env_var_not_set() {
+        let result = evaluate(&Condition::EnvVar {
+            name: "ANVIL_TEST_NONEXISTENT_VAR_XYZ_12345".to_string(),
+            value: None,
+        });
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn test_env_var_value_match() {
+        std::env::set_var("ANVIL_TEST_COND_VAR", "hello");
+        let result = evaluate(&Condition::EnvVar {
+            name: "ANVIL_TEST_COND_VAR".to_string(),
+            value: Some("hello".to_string()),
+        });
+        assert!(result.passed);
+        std::env::remove_var("ANVIL_TEST_COND_VAR");
+    }
+
+    #[test]
+    fn test_env_var_value_mismatch() {
+        std::env::set_var("ANVIL_TEST_COND_VAR2", "world");
+        let result = evaluate(&Condition::EnvVar {
+            name: "ANVIL_TEST_COND_VAR2".to_string(),
+            value: Some("hello".to_string()),
+        });
+        assert!(!result.passed);
+        assert_eq!(result.actual.as_deref(), Some("world"));
+        assert_eq!(result.expected.as_deref(), Some("hello"));
+        std::env::remove_var("ANVIL_TEST_COND_VAR2");
+    }
+
+    // -- path_contains --
+
+    #[test]
+    fn test_path_contains_pass() {
+        // Windows always has something like "System32" on PATH
+        let substring = if cfg!(windows) { "System32" } else { "/usr" };
+        let result = evaluate(&Condition::PathContains {
+            substring: substring.to_string(),
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "path_contains");
+    }
+
+    #[test]
+    fn test_path_contains_fail() {
+        let result = evaluate(&Condition::PathContains {
+            substring: "anvil_nonexistent_path_xyz_12345".to_string(),
+        });
+        assert!(!result.passed);
+    }
+
+    // -- shell --
+
+    #[test]
+    fn test_shell_pass() {
+        let cmd = if cfg!(windows) { "echo ok" } else { "true" };
+        let result = evaluate(&Condition::Shell {
+            command: cmd.to_string(),
+            description: Some("echo test".to_string()),
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "shell");
+        assert_eq!(result.actual.as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn test_shell_fail() {
+        let cmd = if cfg!(windows) {
+            "cmd /C exit 1"
+        } else {
+            "false"
+        };
+        let result = evaluate(&Condition::Shell {
+            command: cmd.to_string(),
+            description: None,
+        });
+        assert!(!result.passed);
+    }
+
+    // -- all_of --
+
+    #[test]
+    fn test_all_of_pass() {
+        let result = evaluate(&Condition::AllOf {
+            conditions: vec![
+                Condition::EnvVar {
+                    name: "PATH".to_string(),
+                    value: None,
+                },
+                Condition::DirExists {
+                    path: "src".to_string(),
+                },
+            ],
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "all_of");
+        assert_eq!(result.actual.as_deref(), Some("2/2 passed"));
+    }
+
+    #[test]
+    fn test_all_of_fail() {
+        let result = evaluate(&Condition::AllOf {
+            conditions: vec![
+                Condition::EnvVar {
+                    name: "PATH".to_string(),
+                    value: None,
+                },
+                Condition::FileExists {
+                    path: "nonexistent_xyz_12345.txt".to_string(),
+                },
+            ],
+        });
+        assert!(!result.passed);
+        assert_eq!(result.actual.as_deref(), Some("1/2 passed"));
+    }
+
+    // -- any_of --
+
+    #[test]
+    fn test_any_of_pass() {
+        let result = evaluate(&Condition::AnyOf {
+            conditions: vec![
+                Condition::FileExists {
+                    path: "nonexistent_xyz_12345.txt".to_string(),
+                },
+                Condition::EnvVar {
+                    name: "PATH".to_string(),
+                    value: None,
+                },
+            ],
+        });
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "any_of");
+    }
+
+    #[test]
+    fn test_any_of_fail() {
+        let result = evaluate(&Condition::AnyOf {
+            conditions: vec![
+                Condition::FileExists {
+                    path: "nonexistent_a_12345.txt".to_string(),
+                },
+                Condition::FileExists {
+                    path: "nonexistent_b_12345.txt".to_string(),
+                },
+            ],
+        });
+        assert!(!result.passed);
+    }
+
+    // -- serde roundtrip --
+
+    #[test]
+    fn test_serde_command_exists_roundtrip() {
+        let cond = Condition::CommandExists {
+            command: "git".to_string(),
+        };
+        let yaml = serde_yaml::to_string(&cond).unwrap();
+        assert!(yaml.contains("type: command_exists"));
+        assert!(yaml.contains("command: git"));
+        let deser: Condition = serde_yaml::from_str(&yaml).unwrap();
+        if let Condition::CommandExists { command } = deser {
+            assert_eq!(command, "git");
+        } else {
+            panic!("Expected CommandExists variant");
+        }
+    }
+
+    #[test]
+    fn test_serde_env_var_with_value_roundtrip() {
+        let cond = Condition::EnvVar {
+            name: "EDITOR".to_string(),
+            value: Some("vim".to_string()),
+        };
+        let yaml = serde_yaml::to_string(&cond).unwrap();
+        let deser: Condition = serde_yaml::from_str(&yaml).unwrap();
+        if let Condition::EnvVar { name, value } = deser {
+            assert_eq!(name, "EDITOR");
+            assert_eq!(value.as_deref(), Some("vim"));
+        } else {
+            panic!("Expected EnvVar variant");
+        }
+    }
+
+    #[test]
+    fn test_serde_all_of_roundtrip() {
+        let cond = Condition::AllOf {
+            conditions: vec![
+                Condition::CommandExists {
+                    command: "git".to_string(),
+                },
+                Condition::FileExists {
+                    path: "~/.gitconfig".to_string(),
+                },
+            ],
+        };
+        let yaml = serde_yaml::to_string(&cond).unwrap();
+        assert!(yaml.contains("type: all_of"));
+        let deser: Condition = serde_yaml::from_str(&yaml).unwrap();
+        if let Condition::AllOf { conditions } = deser {
+            assert_eq!(conditions.len(), 2);
+        } else {
+            panic!("Expected AllOf variant");
+        }
+    }
+
+    #[test]
+    fn test_serde_from_yaml_block() {
+        let yaml = r#"
+type: all_of
+conditions:
+  - type: command_exists
+    command: git
+  - type: file_exists
+    path: ~/.gitconfig
+  - type: env_var
+    name: EDITOR
+    value: vim
+"#;
+        let cond: Condition = serde_yaml::from_str(yaml).unwrap();
+        if let Condition::AllOf { conditions } = cond {
+            assert_eq!(conditions.len(), 3);
+        } else {
+            panic!("Expected AllOf variant");
+        }
+    }
+
+    #[test]
+    fn test_serde_registry_value_roundtrip() {
+        let cond = Condition::RegistryValue {
+            hive: "HKCU".to_string(),
+            key: "SOFTWARE\\Microsoft".to_string(),
+            name: "TestValue".to_string(),
+            expected: Some("1".to_string()),
+        };
+        let yaml = serde_yaml::to_string(&cond).unwrap();
+        assert!(yaml.contains("type: registry_value"));
+        let deser: Condition = serde_yaml::from_str(&yaml).unwrap();
+        if let Condition::RegistryValue {
+            hive,
+            key,
+            name,
+            expected,
+        } = deser
+        {
+            assert_eq!(hive, "HKCU");
+            assert_eq!(key, "SOFTWARE\\Microsoft");
+            assert_eq!(name, "TestValue");
+            assert_eq!(expected.as_deref(), Some("1"));
+        } else {
+            panic!("Expected RegistryValue variant");
+        }
+    }
+
+    #[test]
+    fn test_serde_shell_roundtrip() {
+        let cond = Condition::Shell {
+            command: "echo hello".to_string(),
+            description: Some("Test echo".to_string()),
+        };
+        let yaml = serde_yaml::to_string(&cond).unwrap();
+        assert!(yaml.contains("type: shell"));
+        let deser: Condition = serde_yaml::from_str(&yaml).unwrap();
+        if let Condition::Shell {
+            command,
+            description,
+        } = deser
+        {
+            assert_eq!(command, "echo hello");
+            assert_eq!(description.as_deref(), Some("Test echo"));
+        } else {
+            panic!("Expected Shell variant");
+        }
+    }
+
+    #[test]
+    fn test_condition_result_fields() {
+        let result = ConditionResult {
+            condition_type: "test".to_string(),
+            passed: true,
+            actual: Some("42".to_string()),
+            expected: Some("42".to_string()),
+            message: "Test passed".to_string(),
+        };
+        assert!(result.passed);
+        assert_eq!(result.actual.as_deref(), Some("42"));
+        assert_eq!(result.expected.as_deref(), Some("42"));
+    }
+
+    // -- nested composition --
+
+    #[test]
+    fn test_nested_all_of_any_of() {
+        let cond = Condition::AllOf {
+            conditions: vec![
+                Condition::EnvVar {
+                    name: "PATH".to_string(),
+                    value: None,
+                },
+                Condition::AnyOf {
+                    conditions: vec![
+                        Condition::FileExists {
+                            path: "Cargo.toml".to_string(),
+                        },
+                        Condition::FileExists {
+                            path: "nonexistent_xyz_12345.txt".to_string(),
+                        },
+                    ],
+                },
+            ],
+        };
+        let result = evaluate(&cond);
+        assert!(result.passed);
+        assert_eq!(result.condition_type, "all_of");
+    }
+
+    // -- parse_reg_query_output --
+
+    #[test]
+    fn test_parse_reg_query_output() {
+        let output = r#"
+HKEY_CURRENT_USER\SOFTWARE\Microsoft
+
+    TestValue    REG_SZ    SomeData
+"#;
+        let val = parse_reg_query_output(output, "TestValue");
+        assert_eq!(val.as_deref(), Some("SomeData"));
+    }
+
+    #[test]
+    fn test_parse_reg_query_output_not_found() {
+        let output = "ERROR: The system was unable to find the specified registry key or value.";
+        let val = parse_reg_query_output(output, "TestValue");
+        assert!(val.is_none());
+    }
+}

--- a/src/config/inheritance.rs
+++ b/src/config/inheritance.rs
@@ -514,6 +514,17 @@ fn merge_workloads(parent: Workload, child: Workload) -> Workload {
 
         // Child overwrites health config, or use parent if child has none
         health: child.health.or(parent.health),
+
+        // Merge assertions: append child after parent
+        assertions: match (parent.assertions, child.assertions) {
+            (None, None) => None,
+            (Some(p), None) => Some(p),
+            (None, Some(c)) => Some(c),
+            (Some(mut p), Some(c)) => {
+                p.extend(c);
+                Some(p)
+            }
+        },
     }
 }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -193,6 +193,9 @@ impl SchemaValidator {
         // Validate environment
         self.validate_environment(workload, &mut result);
 
+        // Validate assertions
+        self.validate_assertions(workload, &mut result);
+
         result
     }
 
@@ -550,6 +553,115 @@ impl SchemaValidator {
                     if path_entry.is_empty() {
                         result.add_error(path, "PATH addition cannot be empty");
                     }
+                }
+            }
+        }
+    }
+
+    /// Validate assertion definitions
+    fn validate_assertions(&self, workload: &Workload, result: &mut ValidationResult) {
+        if let Some(assertions) = &workload.assertions {
+            for (i, assertion) in assertions.iter().enumerate() {
+                let path = format!("assertions[{}]", i);
+
+                // Name is required
+                if assertion.name.is_empty() {
+                    result.add_error(format!("{}.name", path), "Assertion name is required");
+                }
+
+                // Validate the condition structure
+                self.validate_condition(&format!("{}.check", path), &assertion.check, result);
+            }
+        }
+    }
+
+    /// Validate a condition is structurally valid
+    fn validate_condition(
+        &self,
+        path: &str,
+        condition: &crate::conditions::Condition,
+        result: &mut ValidationResult,
+    ) {
+        use crate::conditions::Condition;
+
+        match condition {
+            Condition::CommandExists { command } => {
+                if command.is_empty() {
+                    result.add_error(format!("{}.command", path), "Command cannot be empty");
+                }
+            }
+            Condition::FileExists { path: file_path } => {
+                if file_path.is_empty() {
+                    result.add_error(format!("{}.path", path), "File path cannot be empty");
+                }
+            }
+            Condition::DirExists { path: dir_path } => {
+                if dir_path.is_empty() {
+                    result.add_error(format!("{}.path", path), "Directory path cannot be empty");
+                }
+            }
+            Condition::EnvVar { name, .. } => {
+                if name.is_empty() {
+                    result.add_error(
+                        format!("{}.name", path),
+                        "Environment variable name cannot be empty",
+                    );
+                }
+            }
+            Condition::PathContains { substring } => {
+                if substring.is_empty() {
+                    result.add_error(
+                        format!("{}.substring", path),
+                        "PATH substring cannot be empty",
+                    );
+                }
+            }
+            Condition::RegistryValue {
+                hive, key, name, ..
+            } => {
+                if hive.is_empty() {
+                    result.add_error(format!("{}.hive", path), "Registry hive cannot be empty");
+                } else {
+                    let valid_hives = ["HKCU", "HKLM"];
+                    if !valid_hives.contains(&hive.as_str()) {
+                        result.add_warning(
+                            format!("{}.hive", path),
+                            format!(
+                                "Unknown registry hive '{}'. Expected one of: {:?}",
+                                hive, valid_hives
+                            ),
+                        );
+                    }
+                }
+                if key.is_empty() {
+                    result.add_error(format!("{}.key", path), "Registry key cannot be empty");
+                }
+                if name.is_empty() {
+                    result.add_error(
+                        format!("{}.name", path),
+                        "Registry value name cannot be empty",
+                    );
+                }
+            }
+            Condition::Shell { command, .. } => {
+                if command.is_empty() {
+                    result.add_error(format!("{}.command", path), "Shell command cannot be empty");
+                }
+            }
+            Condition::AllOf { conditions } => {
+                if conditions.is_empty() {
+                    result.add_warning(path.to_string(), "all_of has no conditions");
+                }
+                for (j, cond) in conditions.iter().enumerate() {
+                    self.validate_condition(&format!("{}[{}]", path, j), cond, result);
+                }
+            }
+            Condition::AnyOf { conditions } => {
+                if conditions.is_empty() {
+                    result.add_warning(path.to_string(), "any_of has no conditions");
+                }
+                for (j, cond) in conditions.iter().enumerate() {
+                    self.validate_condition(&format!("{}[{}]", path, j), cond, result);
                 }
             }
         }

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -41,6 +41,10 @@ pub struct Workload {
     /// Health check configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health: Option<HealthConfig>,
+
+    /// Declarative assertions for health validation
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assertions: Option<Vec<Assertion>>,
 }
 
 #[allow(dead_code)]
@@ -61,6 +65,7 @@ impl Workload {
             scripts: None,
             environment: None,
             health: None,
+            assertions: None,
         }
     }
 
@@ -76,6 +81,7 @@ impl Workload {
             scripts: None,
             environment: None,
             health: None,
+            assertions: None,
         }
     }
 
@@ -121,6 +127,22 @@ impl Workload {
             })
             .unwrap_or(0)
     }
+
+    /// Get the total number of assertions
+    pub fn assertion_count(&self) -> usize {
+        self.assertions.as_ref().map(|a| a.len()).unwrap_or(0)
+    }
+}
+
+/// A declarative assertionusing the condition engine
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Assertion {
+    /// Display name for the assertion
+    pub name: String,
+
+    /// The condition to evaluate
+    pub check: crate::conditions::Condition,
 }
 
 /// Package manager definitions
@@ -384,6 +406,10 @@ pub struct HealthConfig {
     /// Whether to run health check scripts (default: true)
     #[serde(default = "default_true")]
     pub script_check: bool,
+
+    /// Whether to evaluate declarative assertions (default: true)
+    #[serde(default = "default_true")]
+    pub assertion_check: bool,
 }
 
 impl Default for HealthConfig {
@@ -392,6 +418,7 @@ impl Default for HealthConfig {
             package_check: true,
             file_check: true,
             script_check: true,
+            assertion_check: true,
         }
     }
 }
@@ -453,5 +480,144 @@ override:
         assert_eq!(package.id, "Git.Git");
         assert!(package.override_str.is_some());
         assert_eq!(package.override_str.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_deserialize_workload_with_assertions() {
+        let yaml = r#"
+name: test-workload
+version: "1.0.0"
+description: "Workload with assertions"
+assertions:
+  - name: "Git is installed"
+    check:
+      type: command_exists
+      command: git
+  - name: "Config dir exists"
+    check:
+      type: dir_exists
+      path: "~/.config/app"
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(workload.assertion_count(), 2);
+        let assertions = workload.assertions.unwrap();
+        assert_eq!(assertions[0].name, "Git is installed");
+        assert_eq!(assertions[1].name, "Config dir exists");
+    }
+
+    #[test]
+    fn test_deserialize_assertion_condition_types() {
+        let yaml_command = r#"
+name: "command check"
+check:
+  type: command_exists
+  command: rustc
+"#;
+        let assertion: Assertion = serde_yaml::from_str(yaml_command).unwrap();
+        assert_eq!(assertion.name, "command check");
+        assert!(matches!(
+            assertion.check,
+            crate::conditions::Condition::CommandExists { .. }
+        ));
+
+        let yaml_file = r#"
+name: "file check"
+check:
+  type: file_exists
+  path: "~/.bashrc"
+"#;
+        let assertion: Assertion = serde_yaml::from_str(yaml_file).unwrap();
+        assert!(matches!(
+            assertion.check,
+            crate::conditions::Condition::FileExists { .. }
+        ));
+
+        let yaml_env = r#"
+name: "env check"
+check:
+  type: env_var
+  name: HOME
+"#;
+        let assertion: Assertion = serde_yaml::from_str(yaml_env).unwrap();
+        assert!(matches!(
+            assertion.check,
+            crate::conditions::Condition::EnvVar { .. }
+        ));
+
+        let yaml_shell = r#"
+name: "shell check"
+check:
+  type: shell
+  command: "echo hello"
+"#;
+        let assertion: Assertion = serde_yaml::from_str(yaml_shell).unwrap();
+        assert!(matches!(
+            assertion.check,
+            crate::conditions::Condition::Shell { .. }
+        ));
+
+        let yaml_path = r#"
+name: "path check"
+check:
+  type: path_contains
+  substring: ".cargo/bin"
+"#;
+        let assertion: Assertion = serde_yaml::from_str(yaml_path).unwrap();
+        assert!(matches!(
+            assertion.check,
+            crate::conditions::Condition::PathContains { .. }
+        ));
+
+        let yaml_registry = r#"
+name: "registry check"
+check:
+  type: registry_value
+  hive: HKCU
+  key: "SOFTWARE\\Test"
+  name: TestValue
+"#;
+        let assertion: Assertion = serde_yaml::from_str(yaml_registry).unwrap();
+        assert!(matches!(
+            assertion.check,
+            crate::conditions::Condition::RegistryValue { .. }
+        ));
+    }
+
+    #[test]
+    fn test_assertion_count() {
+        let mut workload = Workload::new("test", "1.0.0", "test");
+        assert_eq!(workload.assertion_count(), 0);
+
+        workload.assertions = Some(vec![
+            Assertion {
+                name: "check1".to_string(),
+                check: crate::conditions::Condition::CommandExists {
+                    command: "git".to_string(),
+                },
+            },
+            Assertion {
+                name: "check2".to_string(),
+                check: crate::conditions::Condition::FileExists {
+                    path: "~/.bashrc".to_string(),
+                },
+            },
+        ]);
+        assert_eq!(workload.assertion_count(), 2);
+    }
+
+    #[test]
+    fn test_workload_without_assertions_backward_compat() {
+        let yaml = r#"
+name: legacy-workload
+version: "1.0.0"
+description: "No assertions"
+packages:
+  winget:
+    - id: Git.Git
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        assert!(workload.assertions.is_none());
+        assert_eq!(workload.assertion_count(), 0);
+        assert_eq!(workload.package_count(), 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@
 //! A declarative configuration management tool for developer workstations that automates
 //! the setup and validation of development environments through composable workload definitions.
 
+mod assertions;
 mod cli;
+mod conditions;
 mod config;
 mod operations;
 mod providers;

--- a/src/operations/health.rs
+++ b/src/operations/health.rs
@@ -61,7 +61,7 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
     let mut _packages_to_update: Vec<String> = Vec::new();
 
     // Package checks
-    if !args.files_only && !args.scripts_only {
+    if !args.files_only && !args.scripts_only && !args.assertions_only {
         let (package_checks, fix_list, update_list) = check_packages(&workload, verbosity, quiet)?;
         checks.extend(package_checks);
         _packages_to_fix = fix_list;
@@ -76,7 +76,7 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
     }
 
     // File checks
-    if !args.packages_only && !args.scripts_only {
+    if !args.packages_only && !args.scripts_only && !args.assertions_only {
         let file_checks = check_files(&workload, &workload_path, verbosity, args.show_diff)?;
         checks.extend(file_checks);
 
@@ -88,8 +88,36 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
         }
     }
 
+    // Assertion checks
+    if !args.packages_only && !args.files_only && !args.scripts_only {
+        let health_config = workload.health.as_ref().cloned().unwrap_or_default();
+        if health_config.assertion_check {
+            if let Some(assertions) = &workload.assertions {
+                if let Some(s) = &spinner {
+                    s.set_message("Evaluating assertions...");
+                }
+
+                let assertion_pairs: Vec<(String, crate::conditions::Condition)> = assertions
+                    .iter()
+                    .map(|a| (a.name.clone(), a.check.clone()))
+                    .collect();
+
+                let assertion_results = crate::assertions::evaluate_assertions(&assertion_pairs);
+                let assertion_checks = crate::assertions::to_check_results(&assertion_results);
+                checks.extend(assertion_checks);
+
+                if args.fail_fast && checks.iter().any(|c| c.status == CheckStatus::Fail) {
+                    if let Some(s) = spinner {
+                        s.finish_and_clear();
+                    }
+                    return report_and_exit(args, cli, &workload.name, checks);
+                }
+            }
+        }
+    }
+
     // Script checks
-    if !args.packages_only && !args.files_only {
+    if !args.packages_only && !args.files_only && !args.assertions_only {
         if let Some(s) = &spinner {
             s.set_message("Running health check scripts...");
         }

--- a/src/operations/validate.rs
+++ b/src/operations/validate.rs
@@ -770,6 +770,31 @@ fn print_json_schema() -> Result<()> {
         "file_check": { "type": "boolean", "default": true },
         "script_check": { "type": "boolean", "default": true }
       }
+    },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "check"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name for the assertion"
+          },
+          "check": {
+            "type": "object",
+            "description": "Condition to evaluate (uses condition engine types)",
+            "required": ["type"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["command_exists", "file_exists", "dir_exists", "env_var", "path_contains", "registry_value", "shell", "all_of", "any_of"]
+              }
+            }
+          }
+        }
+      },
+      "description": "Declarative assertions for health validation"
     }
   },
   "definitions": {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -483,6 +483,104 @@ mod health_command {
 
         assert!(output_file.exists());
     }
+
+    #[test]
+    fn health_assertions_only() {
+        let temp = TempDir::new().unwrap();
+        common::create_workload_with_assertions(temp.path(), "assert-test").unwrap();
+        let workload_path = temp.path().join("assert-test");
+
+        anvil()
+            .args([
+                "health",
+                workload_path.to_str().unwrap(),
+                "--assertions-only",
+            ])
+            .assert()
+            .code(predicate::in_iter([0, 1]));
+    }
+
+    #[test]
+    fn health_assertions_evaluated() {
+        let temp = TempDir::new().unwrap();
+        common::create_workload_with_assertions(temp.path(), "assert-eval").unwrap();
+        let workload_path = temp.path().join("assert-eval");
+
+        // JSON output should contain Assertions category
+        anvil()
+            .args([
+                "health",
+                workload_path.to_str().unwrap(),
+                "--output",
+                "json",
+            ])
+            .assert()
+            .code(predicate::in_iter([0, 1]))
+            .stdout(predicate::str::contains("Assertions"));
+    }
+
+    #[test]
+    fn health_assertions_disabled() {
+        let temp = TempDir::new().unwrap();
+        common::create_workload_assertions_disabled(temp.path(), "assert-off").unwrap();
+        let workload_path = temp.path().join("assert-off");
+
+        // When assertion_check is false, no assertion results should appear
+        let output = anvil()
+            .args([
+                "health",
+                workload_path.to_str().unwrap(),
+                "--output",
+                "json",
+                "--assertions-only",
+            ])
+            .assert()
+            .code(predicate::in_iter([0, 1]))
+            .get_output()
+            .stdout
+            .clone();
+
+        let stdout = String::from_utf8_lossy(&output);
+        assert!(
+            !stdout.contains("should be skipped"),
+            "Assertions should be skipped when assertion_check is false"
+        );
+    }
+
+    #[test]
+    fn health_assertions_fail_fast() {
+        let temp = TempDir::new().unwrap();
+        common::create_workload_with_assertions(temp.path(), "assert-ff").unwrap();
+        let workload_path = temp.path().join("assert-ff");
+
+        // With fail_fast and a failing assertion, command should still exit
+        anvil()
+            .args([
+                "health",
+                workload_path.to_str().unwrap(),
+                "--fail-fast",
+                "--assertions-only",
+            ])
+            .assert()
+            .code(predicate::in_iter([0, 1]));
+    }
+
+    #[test]
+    fn health_passing_assertions() {
+        let temp = TempDir::new().unwrap();
+        common::create_workload_passing_assertions(temp.path(), "assert-pass").unwrap();
+        let workload_path = temp.path().join("assert-pass");
+
+        // All passing assertions should exit 0
+        anvil()
+            .args([
+                "health",
+                workload_path.to_str().unwrap(),
+                "--assertions-only",
+            ])
+            .assert()
+            .success();
+    }
 }
 
 mod completions_command {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -333,6 +333,89 @@ dir = "{{workload_dir}}"
     Ok(())
 }
 
+/// Create a workload with declarative assertions for testing
+///
+/// # Arguments
+/// * `dir` - Parent directory where the workload will be created
+/// * `name` - Name of the workload
+///
+/// # Returns
+/// Result indicating success or IO error
+#[allow(dead_code)]
+pub fn create_workload_with_assertions(dir: &Path, name: &str) -> std::io::Result<()> {
+    let workload_dir = dir.join(name);
+    fs::create_dir_all(&workload_dir)?;
+
+    let yaml = format!(
+        r#"name: {name}
+version: "1.0.0"
+description: "Workload with assertions for testing"
+
+assertions:
+  - name: "PATH is set"
+    check:
+      type: env_var
+      name: PATH
+  - name: "missing var should fail"
+    check:
+      type: env_var
+      name: ANVIL_TEST_NONEXISTENT_VAR_XYZ_12345
+"#
+    );
+
+    fs::write(workload_dir.join("workload.yaml"), yaml)?;
+    Ok(())
+}
+
+/// Create a workload with assertions disabled via health config
+#[allow(dead_code)]
+pub fn create_workload_assertions_disabled(dir: &Path, name: &str) -> std::io::Result<()> {
+    let workload_dir = dir.join(name);
+    fs::create_dir_all(&workload_dir)?;
+
+    let yaml = format!(
+        r#"name: {name}
+version: "1.0.0"
+description: "Workload with assertions disabled"
+
+health:
+  assertion_check: false
+
+assertions:
+  - name: "should be skipped"
+    check:
+      type: env_var
+      name: ANVIL_TEST_NONEXISTENT_VAR_XYZ_12345
+"#
+    );
+
+    fs::write(workload_dir.join("workload.yaml"), yaml)?;
+    Ok(())
+}
+
+/// Create a workload with only passing assertions
+#[allow(dead_code)]
+pub fn create_workload_passing_assertions(dir: &Path, name: &str) -> std::io::Result<()> {
+    let workload_dir = dir.join(name);
+    fs::create_dir_all(&workload_dir)?;
+
+    let yaml = format!(
+        r#"name: {name}
+version: "1.0.0"
+description: "Workload with only passing assertions"
+
+assertions:
+  - name: "PATH is set"
+    check:
+      type: env_var
+      name: PATH
+"#
+    );
+
+    fs::write(workload_dir.join("workload.yaml"), yaml)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Description

Add a declarative assertion system for workload health validation, replacing the need for custom health check scripts for common checks.

### What's included

- **Condition engine** — Reusable predicate system with 9 condition types (`command_exists`, `file_exists`, `dir_exists`, `env_var`, `path_contains`, `registry_value`, `shell`) plus `all_of`/`any_of` composition for boolean logic
- **Assertions in workload YAML** — New `assertions:` field in workload definitions, each with a display name and a condition to evaluate
- **Assertion evaluation engine** — Evaluates assertions with structured results, timing, and error handling
- **Health command integration** — Assertions run during `anvil health` alongside legacy scripts, with `--assertions-only` flag and `assertion_check` toggle in health config
- **Schema validation** — Assertions validated during `anvil validate` with structural checks on all condition types
- **Inheritance support** — Assertions merge correctly through workload inheritance (child appended after parent)

Example workload usage:
`yaml
assertions:
  - name: Git installed
    check:
      type: command_exists
      command: git
  - name: Dev tools ready
    check:
      type: all_of
      conditions:
        - type: command_exists
          command: cargo
        - type: file_exists
          path: ~/.gitconfig
`

## Related Issues

Closes #6, Closes #7, Closes #8, Closes #9

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (292 tests: 212 unit + 80 integration)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)