### PR TITLE
feat: document assertion compat contract and update examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Condition engine with 9 predicate types: `command_exists`, `file_exists`, `dir_exists`, `env_var`, `path_contains`, `registry_value`, `shell`, plus `all_of`/`any_of` composition
 - `--assertions-only` flag for `anvil health` to run only assertion checks
 - `assertion_check` toggle in workload health configuration
+- Assertion examples in `anvil init --template full` scaffold
+
+### Deprecated
+- `scripts.health_check` when used alongside `assertions` (migrate to declarative assertions; removal planned for v1.0)
 
 ## [0.5.0] - 2026-04-17
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -413,6 +413,39 @@ health:
   package_check: boolean        # Verify packages installed (default: true)
   file_check: boolean           # Verify files match (default: true)
   script_check: boolean         # Run health check scripts (default: true)
+  assertion_check: boolean      # Evaluate declarative assertions (default: true)
+```
+
+### 5.1.1 Assertions and Legacy Health Check Coexistence
+
+Anvil supports two mechanisms for health validation:
+
+| Mechanism | Field | Introduced | Status |
+|-----------|-------|-----------|--------|
+| Declarative assertions | `assertions:` | v0.5 | **Recommended** |
+| Health check scripts | `scripts.health_check` | v0.1 | Deprecated when used with assertions |
+
+**Execution order**: When both exist, assertions run first, then legacy scripts. Results are merged into a single health report.
+
+**Deprecation timeline**:
+- **v0.5**: Warning emitted when `scripts.health_check` is used alongside `assertions`
+- **v0.6**: Warning emitted for any use of `scripts.health_check` (even without assertions)
+- **v1.0**: `scripts.health_check` removed; use assertions exclusively
+
+**Migration**: Convert health check scripts to declarative assertions:
+```yaml
+# Before (legacy script)
+scripts:
+  health_check:
+    - path: check-git.ps1
+      name: "Git installed"
+
+# After (declarative assertion)
+assertions:
+  - name: Git installed
+    check:
+      type: command_exists
+      command: git
 ```
 
 ### 5.2 Example Workloads
@@ -1012,6 +1045,7 @@ v1.0 — Polish & Distribution
     │
     ├── crates.io publishing
     ├── Cross-platform CI
+    ├── Remove scripts.health_check (use assertions exclusively)
     └── Documentation review
 ```
 

--- a/docs/WORKLOAD_AUTHORING.md
+++ b/docs/WORKLOAD_AUTHORING.md
@@ -10,10 +10,11 @@ A comprehensive guide to creating custom workloads for Anvil.
 4. [File Definitions](#4-file-definitions)
 5. [Script Definitions](#5-script-definitions)
 6. [Environment Configuration](#6-environment-configuration)
-7. [Inheritance](#7-inheritance)
-8. [Variable Expansion](#8-variable-expansion)
-9. [Best Practices](#9-best-practices)
-10. [Example Workloads](#10-example-workloads)
+7. [Assertions](#7-assertions)
+8. [Inheritance](#8-inheritance)
+9. [Variable Expansion](#9-variable-expansion)
+10. [Best Practices](#10-best-practices)
+11. [Example Workloads](#11-example-workloads)
 
 ---
 
@@ -71,6 +72,7 @@ packages: object                # Package definitions
 files: array                    # File deployment definitions
 scripts: object                 # Script execution definitions
 environment: object             # Environment variable configuration
+assertions: array               # Declarative health assertions
 health: object                  # Health check configuration
 ```
 
@@ -626,7 +628,201 @@ PATH additions are appended to the existing PATH for the specified scope.
 
 ---
 
-## 7. Inheritance
+## 7. Assertions
+
+Assertions are declarative health checks defined directly in `workload.yaml`. They let you validate system state — such as installed commands, existing files, environment variables, and PATH entries — without writing PowerShell scripts.
+
+Use assertions when your checks are simple conditions (command exists, file exists, env var set). Use health check scripts for complex validation that requires multi-step logic or custom output.
+
+### Assertion Structure
+
+Each assertion has a `name` and a `check` that specifies a condition:
+
+```yaml
+assertions:
+  - name: Git is installed
+    check:
+      type: command_exists
+      command: git
+```
+
+### Condition Types
+
+#### `command_exists`
+
+Checks whether a command is available on `PATH`.
+
+```yaml
+- name: cargo is available
+  check:
+    type: command_exists
+    command: cargo
+```
+
+#### `file_exists`
+
+Checks whether a file exists at the given path. Supports `~` expansion.
+
+```yaml
+- name: Git config exists
+  check:
+    type: file_exists
+    path: "~/.gitconfig"
+```
+
+#### `dir_exists`
+
+Checks whether a directory exists at the given path. Supports `~` expansion.
+
+```yaml
+- name: Cargo directory exists
+  check:
+    type: dir_exists
+    path: "~/.cargo"
+```
+
+#### `env_var`
+
+Checks whether an environment variable is set, optionally matching a specific value.
+
+```yaml
+# Check existence only
+- name: RUST_BACKTRACE is set
+  check:
+    type: env_var
+    name: RUST_BACKTRACE
+
+# Check existence and value
+- name: RUST_BACKTRACE is 1
+  check:
+    type: env_var
+    name: RUST_BACKTRACE
+    value: "1"
+```
+
+#### `path_contains`
+
+Checks whether the system `PATH` contains a given substring.
+
+```yaml
+- name: Cargo bin on PATH
+  check:
+    type: path_contains
+    substring: ".cargo/bin"
+```
+
+#### `registry_value`
+
+Queries a Windows registry value under `HKCU` or `HKLM`. If `expected` is omitted, the check only asserts the value exists.
+
+```yaml
+- name: Developer mode enabled
+  check:
+    type: registry_value
+    hive: HKLM
+    key: "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock"
+    name: AllowDevelopmentWithoutDevLicense
+    expected: "1"
+```
+
+#### `shell`
+
+Runs an arbitrary shell command; the condition passes when the exit code is 0.
+
+```yaml
+- name: Rust compiler responds
+  check:
+    type: shell
+    command: "rustc --version"
+    description: "Rust compiler version check"
+```
+
+### Composition with `all_of` and `any_of`
+
+Combine conditions with logical operators for complex checks.
+
+#### `all_of` — all conditions must pass (AND)
+
+```yaml
+- name: Full Rust toolchain
+  check:
+    type: all_of
+    conditions:
+      - type: command_exists
+        command: rustc
+      - type: command_exists
+        command: cargo
+      - type: dir_exists
+        path: "~/.cargo"
+```
+
+#### `any_of` — at least one must pass (OR)
+
+```yaml
+- name: Python is available
+  check:
+    type: any_of
+    conditions:
+      - type: command_exists
+        command: python
+      - type: command_exists
+        command: python3
+```
+
+### Enabling Assertion Checks
+
+Assertions are evaluated during `anvil health` when `assertion_check` is enabled in the health config (it defaults to `true`):
+
+```yaml
+health:
+  package_check: true
+  file_check: true
+  script_check: true
+  assertion_check: true   # Evaluate declarative assertions
+```
+
+### Complete Example
+
+```yaml
+name: rust-developer
+version: "1.0.0"
+description: "Rust development environment"
+
+packages:
+  winget:
+    - id: Rustlang.Rustup
+
+assertions:
+  - name: cargo command exists
+    check:
+      type: command_exists
+      command: cargo
+  - name: rustc command exists
+    check:
+      type: command_exists
+      command: rustc
+  - name: Cargo directory exists
+    check:
+      type: dir_exists
+      path: "~/.cargo"
+  - name: Cargo bin on PATH
+    check:
+      type: path_contains
+      substring: ".cargo/bin"
+  - name: RUST_BACKTRACE is set
+    check:
+      type: env_var
+      name: RUST_BACKTRACE
+      value: "1"
+
+health:
+  package_check: true
+  assertion_check: true
+```
+
+---
+
+## 8. Inheritance
 
 Workloads can extend other workloads to inherit their configuration.
 
@@ -729,7 +925,7 @@ anvil show my-workload --resolved
 
 ---
 
-## 8. Variable Expansion
+## 9. Variable Expansion
 
 Use variables in paths and values for dynamic configuration.
 
@@ -779,7 +975,7 @@ environment:
 
 ---
 
-## 9. Best Practices
+## 10. Best Practices
 
 ### Workload Design
 
@@ -897,7 +1093,7 @@ environment:
 
 ---
 
-## 10. Example Workloads
+## 11. Example Workloads
 
 ### Minimal Workload
 

--- a/examples/python-developer/workload.yaml
+++ b/examples/python-developer/workload.yaml
@@ -32,7 +32,26 @@ environment:
       value: "managed"
       scope: user
 
+assertions:
+  - name: uv command exists
+    check:
+      type: command_exists
+      command: uv
+  - name: Python is available
+    check:
+      type: any_of
+      conditions:
+        - type: command_exists
+          command: python
+        - type: command_exists
+          command: python3
+  - name: UV_PYTHON_PREFERENCE is set
+    check:
+      type: env_var
+      name: UV_PYTHON_PREFERENCE
+
 health:
   package_check: true
   file_check: true
   script_check: true
+  assertion_check: true

--- a/examples/rust-developer/workload.yaml
+++ b/examples/rust-developer/workload.yaml
@@ -43,7 +43,35 @@ environment:
   path_additions:
     - "~/.cargo/bin"
 
+assertions:
+  - name: cargo command exists
+    check:
+      type: command_exists
+      command: cargo
+  - name: rustc command exists
+    check:
+      type: command_exists
+      command: rustc
+  - name: rustup command exists
+    check:
+      type: command_exists
+      command: rustup
+  - name: Cargo directory exists
+    check:
+      type: dir_exists
+      path: "~/.cargo"
+  - name: Cargo bin on PATH
+    check:
+      type: path_contains
+      substring: ".cargo/bin"
+  - name: RUST_BACKTRACE is set
+    check:
+      type: env_var
+      name: RUST_BACKTRACE
+      value: "1"
+
 health:
   package_check: true
   file_check: true
   script_check: true
+  assertion_check: true

--- a/src/operations/health.rs
+++ b/src/operations/health.rs
@@ -48,6 +48,25 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
         tracing::info!("Checking health for workload: {}", workload.name);
     }
 
+    // Deprecation warning: scripts.health_check alongside assertions
+    let has_assertions = workload
+        .assertions
+        .as_ref()
+        .map(|a| !a.is_empty())
+        .unwrap_or(false);
+    let has_health_check_scripts = workload
+        .scripts
+        .as_ref()
+        .and_then(|s| s.health_check.as_ref())
+        .map(|h| !h.is_empty())
+        .unwrap_or(false);
+    if has_assertions && has_health_check_scripts {
+        print_warning(
+            "Deprecation notice: `scripts.health_check` is deprecated when used alongside `assertions`. \
+             Migrate health check scripts to declarative assertions. See docs/SPECIFICATION.md for details.",
+        );
+    }
+
     // Show spinner while checking
     let spinner = if !quiet {
         Some(SimpleProgress::spinner("Checking system health..."))

--- a/src/operations/init.rs
+++ b/src/operations/init.rs
@@ -471,11 +471,30 @@ environment:
     - "~/.local/bin"
     # - "${{PROGRAMFILES}}/MyApp/bin"
 
+# Declarative health assertions
+# Assertions replace or complement health check scripts with simple checks
+assertions:
+  - name: Example tool check
+    check:
+      type: command_exists
+      command: git
+
+  # - name: Config directory exists
+  #   check:
+  #     type: dir_exists
+  #     path: "~/.config/app"
+
+  # - name: Environment variable set
+  #   check:
+  #     type: env_var
+  #     name: MY_APP_CONFIG
+
 # Health check configuration
 health:
   package_check: true    # Verify all packages are installed
   file_check: true       # Verify all files are deployed correctly
   script_check: true     # Run all health check scripts
+  assertion_check: true  # Evaluate declarative assertions
 "#,
         name = name,
         extends_section = extends_section.trim_start()

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -581,6 +581,22 @@ mod health_command {
             .assert()
             .success();
     }
+
+    #[test]
+    fn health_deprecation_warning_when_both_assertions_and_scripts() {
+        let temp = TempDir::new().unwrap();
+        common::create_workload_with_both_assertions_and_scripts(temp.path(), "both-test").unwrap();
+        let workload_path = temp.path().join("both-test");
+
+        // When both assertions and scripts.health_check exist, stderr should contain deprecation warning
+        anvil()
+            .args(["health", workload_path.to_str().unwrap()])
+            .assert()
+            .code(predicate::in_iter([0, 1]))
+            .stderr(predicate::str::contains(
+                "scripts.health_check` is deprecated when used alongside `assertions`",
+            ));
+    }
 }
 
 mod completions_command {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -416,6 +416,48 @@ assertions:
     Ok(())
 }
 
+/// Create a workload with both assertions and health_check scripts
+/// for testing the deprecation warning
+#[allow(dead_code)]
+pub fn create_workload_with_both_assertions_and_scripts(
+    dir: &Path,
+    name: &str,
+) -> std::io::Result<()> {
+    let workload_dir = dir.join(name);
+    let scripts_dir = workload_dir.join("scripts");
+    fs::create_dir_all(&scripts_dir)?;
+
+    let yaml = format!(
+        r#"name: {name}
+version: "1.0.0"
+description: "Workload with both assertions and health_check scripts"
+
+assertions:
+  - name: "PATH is set"
+    check:
+      type: env_var
+      name: PATH
+
+scripts:
+  health_check:
+    - path: scripts/health.ps1
+      name: "Legacy Check"
+      description: "Legacy health check script"
+"#
+    );
+
+    fs::write(workload_dir.join("workload.yaml"), yaml)?;
+    fs::write(
+        scripts_dir.join("health.ps1"),
+        r#"# Legacy health check script
+Write-Host "Legacy health check running..."
+exit 0
+"#,
+    )?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Description

Document the backward compatibility contract for legacy `scripts.health_check` alongside the new assertions system, and update example workloads and documentation to demonstrate assertions.

### What's included

- **Backward compatibility contract** — Documented coexistence rules in SPECIFICATION.md: assertions run first, results merged, deprecation timeline (v0.5 warning → v0.6 broader warning → v1.0 removal)
- **Deprecation warning** — `anvil health` now warns when a workload uses both `assertions` and `scripts.health_check` simultaneously
- **Example workloads updated** — `rust-developer` (6 assertions) and `python-developer` (3 assertions) now demonstrate declarative health checks
- **Workload authoring guide** — New assertions section in `WORKLOAD_AUTHORING.md` covering all 9 condition types, composition, and complete examples
- **Init template updated** — `anvil init --template full` now includes an assertion example

## Related Issues

Closes #10, Closes #11

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (293 tests: 212 unit + 81 integration)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)