### PR TITLE
feat: add PackageManager trait and multi-manager schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--assertions-only` flag for `anvil health` to run only assertion checks
 - `assertion_check` toggle in workload health configuration
 - Assertion examples in `anvil init --template full` scaffold
+- Multi-manager workload schema: `packages.brew` (Homebrew) and `packages.apt` (APT) fields alongside existing `packages.winget`
+- Platform-aware validation warns when workload references an unavailable package manager
 
 ### Deprecated
 - `scripts.health_check` when used alongside `assertions` (migrate to declarative assertions; removal planned for v1.0)

--- a/src/config/inheritance.rs
+++ b/src/config/inheritance.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use tracing::{debug, trace};
 
 use super::workload::{
-    Environment, FileEntry, HealthCheckScript, Packages, ScriptEntry, Scripts, WingetPackage,
-    Workload,
+    AptPackage, BrewPackage, Environment, FileEntry, HealthCheckScript, Packages, ScriptEntry,
+    Scripts, WingetPackage, Workload,
 };
 use super::ConfigManager;
 
@@ -538,7 +538,11 @@ fn merge_packages(parent: Option<Packages>, child: Option<Packages>) -> Option<P
         (Some(p), None) => Some(p),
         (None, Some(c)) => Some(c),
         (Some(parent), Some(child)) => {
-            let mut result = Packages { winget: None };
+            let mut result = Packages {
+                winget: None,
+                brew: None,
+                apt: None,
+            };
 
             // Merge winget packages
             let parent_winget = parent.winget.unwrap_or_default();
@@ -560,6 +564,42 @@ fn merge_packages(parent: Option<Packages>, child: Option<Packages>) -> Option<P
                 }
 
                 result.winget = Some(merged);
+            }
+
+            // Merge brew packages
+            let parent_brew = parent.brew.unwrap_or_default();
+            let child_brew = child.brew.unwrap_or_default();
+
+            if !parent_brew.is_empty() || !child_brew.is_empty() {
+                let mut merged: Vec<BrewPackage> = parent_brew;
+
+                for child_pkg in child_brew {
+                    if let Some(existing) = merged.iter_mut().find(|p| p.name == child_pkg.name) {
+                        *existing = child_pkg;
+                    } else {
+                        merged.push(child_pkg);
+                    }
+                }
+
+                result.brew = Some(merged);
+            }
+
+            // Merge apt packages
+            let parent_apt = parent.apt.unwrap_or_default();
+            let child_apt = child.apt.unwrap_or_default();
+
+            if !parent_apt.is_empty() || !child_apt.is_empty() {
+                let mut merged: Vec<AptPackage> = parent_apt;
+
+                for child_pkg in child_apt {
+                    if let Some(existing) = merged.iter_mut().find(|p| p.name == child_pkg.name) {
+                        *existing = child_pkg;
+                    } else {
+                        merged.push(child_pkg);
+                    }
+                }
+
+                result.apt = Some(merged);
             }
 
             Some(result)
@@ -834,12 +874,14 @@ mod tests {
                 WingetPackage::new("Parent.Package1"),
                 WingetPackage::new("Parent.Package2"),
             ]),
+            ..Default::default()
         });
         let child = Some(Packages {
             winget: Some(vec![
                 WingetPackage::new("Child.Package1"),
                 WingetPackage::with_version("Parent.Package2", "2.0.0"), // Override
             ]),
+            ..Default::default()
         });
 
         let merged = merge_packages(parent, child).unwrap();
@@ -850,6 +892,105 @@ mod tests {
         assert_eq!(winget[1].id, "Parent.Package2");
         assert_eq!(winget[1].version, Some("2.0.0".to_string())); // Overwritten by child
         assert_eq!(winget[2].id, "Child.Package1");
+    }
+
+    #[test]
+    fn test_merge_brew_packages() {
+        let parent = Some(Packages {
+            brew: Some(vec![
+                BrewPackage {
+                    name: "git".to_string(),
+                    cask: false,
+                    tap: None,
+                },
+                BrewPackage {
+                    name: "node".to_string(),
+                    cask: false,
+                    tap: None,
+                },
+            ]),
+            ..Default::default()
+        });
+        let child = Some(Packages {
+            brew: Some(vec![
+                BrewPackage {
+                    name: "wget".to_string(),
+                    cask: false,
+                    tap: None,
+                },
+                BrewPackage {
+                    name: "node".to_string(),
+                    cask: false,
+                    tap: Some("custom/tap".to_string()),
+                },
+            ]),
+            ..Default::default()
+        });
+
+        let merged = merge_packages(parent, child).unwrap();
+        let brew = merged.brew.unwrap();
+        assert_eq!(brew.len(), 3);
+        assert_eq!(brew[0].name, "git");
+        assert_eq!(brew[1].name, "node");
+        assert_eq!(brew[1].tap.as_deref(), Some("custom/tap")); // Overwritten by child
+        assert_eq!(brew[2].name, "wget");
+    }
+
+    #[test]
+    fn test_merge_apt_packages() {
+        let parent = Some(Packages {
+            apt: Some(vec![AptPackage {
+                name: "git".to_string(),
+                version: None,
+            }]),
+            ..Default::default()
+        });
+        let child = Some(Packages {
+            apt: Some(vec![
+                AptPackage {
+                    name: "git".to_string(),
+                    version: Some("2.40".to_string()),
+                },
+                AptPackage {
+                    name: "curl".to_string(),
+                    version: None,
+                },
+            ]),
+            ..Default::default()
+        });
+
+        let merged = merge_packages(parent, child).unwrap();
+        let apt = merged.apt.unwrap();
+        assert_eq!(apt.len(), 2);
+        assert_eq!(apt[0].name, "git");
+        assert_eq!(apt[0].version.as_deref(), Some("2.40")); // Overwritten by child
+        assert_eq!(apt[1].name, "curl");
+    }
+
+    #[test]
+    fn test_merge_mixed_managers() {
+        let parent = Some(Packages {
+            winget: Some(vec![WingetPackage::new("Git.Git")]),
+            brew: Some(vec![BrewPackage {
+                name: "git".to_string(),
+                cask: false,
+                tap: None,
+            }]),
+            apt: None,
+        });
+        let child = Some(Packages {
+            winget: None,
+            brew: None,
+            apt: Some(vec![AptPackage {
+                name: "git".to_string(),
+                version: None,
+            }]),
+        });
+
+        let merged = merge_packages(parent, child).unwrap();
+        assert!(merged.winget.is_some());
+        assert!(merged.brew.is_some());
+        assert!(merged.apt.is_some());
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
-use super::workload::Workload;
+use super::workload::{Packages, Workload};
 
 /// Validation severity levels
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -345,6 +345,94 @@ impl SchemaValidator {
                     }
                 }
             }
+
+            // Validate brew packages
+            if let Some(brew_packages) = &packages.brew {
+                for (i, package) in brew_packages.iter().enumerate() {
+                    let path = format!("packages.brew[{}]", i);
+
+                    if package.name.is_empty() {
+                        result.add_error(format!("{}.name", path), "Package name is required");
+                    }
+
+                    // Validate tap format if provided (must be "owner/repo")
+                    if let Some(ref tap) = package.tap {
+                        if !is_valid_brew_tap(tap) {
+                            result.add_warning(
+                                format!("{}.tap", path),
+                                format!(
+                                    "Tap '{}' may not be valid. Expected format: 'owner/repo'",
+                                    tap
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Validate apt packages
+            if let Some(apt_packages) = &packages.apt {
+                for (i, package) in apt_packages.iter().enumerate() {
+                    let path = format!("packages.apt[{}]", i);
+
+                    if package.name.is_empty() {
+                        result.add_error(format!("{}.name", path), "Package name is required");
+                    }
+
+                    // Validate version string if provided
+                    if let Some(ref version) = package.version {
+                        if version.is_empty() {
+                            result.add_warning(
+                                format!("{}.version", path),
+                                "Version string is empty, will install latest",
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Check platform availability
+            self.validate_manager_availability(packages, result);
+        }
+    }
+
+    /// Warn if workload references package managers not available on the current platform
+    fn validate_manager_availability(&self, packages: &Packages, result: &mut ValidationResult) {
+        if cfg!(target_os = "windows") {
+            if packages
+                .brew
+                .as_ref()
+                .map(|b| !b.is_empty())
+                .unwrap_or(false)
+            {
+                result.add_warning(
+                    "packages.brew",
+                    "Homebrew packages defined but Homebrew is not available on Windows",
+                );
+            }
+            if packages
+                .apt
+                .as_ref()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false)
+            {
+                result.add_warning(
+                    "packages.apt",
+                    "APT packages defined but APT is not available on Windows",
+                );
+            }
+        }
+        if !cfg!(target_os = "windows")
+            && packages
+                .winget
+                .as_ref()
+                .map(|w| !w.is_empty())
+                .unwrap_or(false)
+        {
+            result.add_warning(
+                "packages.winget",
+                "Winget packages defined but winget is only available on Windows",
+            );
         }
     }
 
@@ -832,9 +920,19 @@ fn is_valid_env_var_name(name: &str) -> bool {
     name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// Check if a Homebrew tap identifier is valid (format: "owner/repo")
+fn is_valid_brew_tap(tap: &str) -> bool {
+    if tap.is_empty() {
+        return false;
+    }
+    let parts: Vec<&str> = tap.split('/').collect();
+    parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::workload::{AptPackage, BrewPackage};
 
     // Workload name tests
     #[test]
@@ -1020,5 +1118,156 @@ mod tests {
         let result = validator.validate(&workload);
         assert!(result.is_valid()); // Invalid format is just a warning
         assert!(result.warning_count() > 0);
+    }
+
+    #[test]
+    fn test_validate_brew_packages_valid() {
+        let mut workload = Workload::new("test-workload", "1.0.0", "A test workload");
+        workload.packages = Some(Packages {
+            winget: None,
+            brew: Some(vec![
+                BrewPackage {
+                    name: "git".to_string(),
+                    cask: false,
+                    tap: None,
+                },
+                BrewPackage {
+                    name: "visual-studio-code".to_string(),
+                    cask: true,
+                    tap: Some("homebrew/cask".to_string()),
+                },
+            ]),
+            apt: None,
+        });
+
+        let validator = SchemaValidator::new();
+        let result = validator.validate(&workload);
+        // No errors expected (warnings about platform availability are ok)
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn test_validate_brew_empty_name() {
+        let mut workload = Workload::new("test-workload", "1.0.0", "A test workload");
+        workload.packages = Some(Packages {
+            winget: None,
+            brew: Some(vec![BrewPackage {
+                name: "".to_string(),
+                cask: false,
+                tap: None,
+            }]),
+            apt: None,
+        });
+
+        let validator = SchemaValidator::new();
+        let result = validator.validate(&workload);
+        assert!(!result.is_valid());
+        assert!(result
+            .errors()
+            .any(|e| e.path.contains("brew") && e.message.contains("name")));
+    }
+
+    #[test]
+    fn test_validate_brew_invalid_tap() {
+        let mut workload = Workload::new("test-workload", "1.0.0", "A test workload");
+        workload.packages = Some(Packages {
+            winget: None,
+            brew: Some(vec![BrewPackage {
+                name: "font-fira-code".to_string(),
+                cask: true,
+                tap: Some("invalid-tap".to_string()),
+            }]),
+            apt: None,
+        });
+
+        let validator = SchemaValidator::new();
+        let result = validator.validate(&workload);
+        assert!(result.is_valid()); // Invalid tap is a warning, not error
+        assert!(result
+            .warnings()
+            .any(|w| w.path.contains("tap") && w.message.contains("owner/repo")));
+    }
+
+    #[test]
+    fn test_validate_apt_packages_valid() {
+        let mut workload = Workload::new("test-workload", "1.0.0", "A test workload");
+        workload.packages = Some(Packages {
+            winget: None,
+            brew: None,
+            apt: Some(vec![
+                AptPackage {
+                    name: "git".to_string(),
+                    version: None,
+                },
+                AptPackage {
+                    name: "build-essential".to_string(),
+                    version: Some("12.9".to_string()),
+                },
+            ]),
+        });
+
+        let validator = SchemaValidator::new();
+        let result = validator.validate(&workload);
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn test_validate_apt_empty_name() {
+        let mut workload = Workload::new("test-workload", "1.0.0", "A test workload");
+        workload.packages = Some(Packages {
+            winget: None,
+            brew: None,
+            apt: Some(vec![AptPackage {
+                name: "".to_string(),
+                version: None,
+            }]),
+        });
+
+        let validator = SchemaValidator::new();
+        let result = validator.validate(&workload);
+        assert!(!result.is_valid());
+        assert!(result
+            .errors()
+            .any(|e| e.path.contains("apt") && e.message.contains("name")));
+    }
+
+    #[test]
+    fn test_validate_manager_availability_on_windows() {
+        let mut workload = Workload::new("test-workload", "1.0.0", "A test workload");
+        workload.packages = Some(Packages {
+            winget: None,
+            brew: Some(vec![BrewPackage {
+                name: "git".to_string(),
+                cask: false,
+                tap: None,
+            }]),
+            apt: Some(vec![AptPackage {
+                name: "git".to_string(),
+                version: None,
+            }]),
+        });
+
+        let validator = SchemaValidator::new();
+        let result = validator.validate(&workload);
+
+        if cfg!(target_os = "windows") {
+            assert!(result.warnings().any(
+                |w| w.path == "packages.brew" && w.message.contains("not available on Windows")
+            ));
+            assert!(result.warnings().any(
+                |w| w.path == "packages.apt" && w.message.contains("not available on Windows")
+            ));
+        }
+    }
+
+    #[test]
+    fn test_validate_brew_tap_format() {
+        assert!(is_valid_brew_tap("homebrew/cask"));
+        assert!(is_valid_brew_tap("homebrew/cask-fonts"));
+        assert!(is_valid_brew_tap("user/repo"));
+        assert!(!is_valid_brew_tap(""));
+        assert!(!is_valid_brew_tap("invalid"));
+        assert!(!is_valid_brew_tap("/empty-owner"));
+        assert!(!is_valid_brew_tap("empty-repo/"));
     }
 }

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -101,12 +101,16 @@ impl Workload {
             .unwrap_or_default()
     }
 
-    /// Get the total number of packages
+    /// Get the total number of packages across all managers
     pub fn package_count(&self) -> usize {
         self.packages
             .as_ref()
-            .and_then(|p| p.winget.as_ref())
-            .map(|w| w.len())
+            .map(|p| {
+                let winget = p.winget.as_ref().map(|w| w.len()).unwrap_or(0);
+                let brew = p.brew.as_ref().map(|b| b.len()).unwrap_or(0);
+                let apt = p.apt.as_ref().map(|a| a.len()).unwrap_or(0);
+                winget + brew + apt
+            })
             .unwrap_or(0)
     }
 
@@ -149,9 +153,17 @@ pub struct Assertion {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Packages {
-    /// Winget package definitions
+    /// Winget package definitions (Windows)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub winget: Option<Vec<WingetPackage>>,
+
+    /// Homebrew package definitions (macOS/Linux)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub brew: Option<Vec<BrewPackage>>,
+
+    /// APT package definitions (Debian/Ubuntu)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub apt: Option<Vec<AptPackage>>,
 }
 
 /// A single winget package definition
@@ -201,6 +213,31 @@ impl WingetPackage {
             override_str: None,
         }
     }
+}
+
+/// A Homebrew package definition (schema-only, not yet implemented)
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrewPackage {
+    /// Package name (e.g., "git", "node")
+    pub name: String,
+    /// Whether this is a cask (GUI app) vs formula (CLI tool)
+    #[serde(default)]
+    pub cask: bool,
+    /// Tap source (e.g., "homebrew/cask-fonts")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tap: Option<String>,
+}
+
+/// An APT package definition (schema-only, not yet implemented)
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AptPackage {
+    /// Package name (e.g., "git", "build-essential")
+    pub name: String,
+    /// Specific version constraint
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
 }
 
 /// A file to be copied to the target system
@@ -619,5 +656,116 @@ packages:
         assert!(workload.assertions.is_none());
         assert_eq!(workload.assertion_count(), 0);
         assert_eq!(workload.package_count(), 1);
+    }
+
+    #[test]
+    fn test_deserialize_brew_packages() {
+        let yaml = r#"
+name: brew-workload
+version: "1.0.0"
+description: "Workload with brew packages"
+packages:
+  brew:
+    - name: git
+    - name: visual-studio-code
+      cask: true
+    - name: font-cascadia-code
+      cask: true
+      tap: "homebrew/cask-fonts"
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        let brew = workload.packages.as_ref().unwrap().brew.as_ref().unwrap();
+        assert_eq!(brew.len(), 3);
+        assert_eq!(brew[0].name, "git");
+        assert!(!brew[0].cask);
+        assert!(brew[1].cask);
+        assert_eq!(brew[2].tap.as_deref(), Some("homebrew/cask-fonts"));
+        assert_eq!(workload.package_count(), 3);
+    }
+
+    #[test]
+    fn test_deserialize_apt_packages() {
+        let yaml = r#"
+name: apt-workload
+version: "1.0.0"
+description: "Workload with apt packages"
+packages:
+  apt:
+    - name: git
+    - name: build-essential
+      version: "12.9"
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        let apt = workload.packages.as_ref().unwrap().apt.as_ref().unwrap();
+        assert_eq!(apt.len(), 2);
+        assert_eq!(apt[0].name, "git");
+        assert!(apt[0].version.is_none());
+        assert_eq!(apt[1].name, "build-essential");
+        assert_eq!(apt[1].version.as_deref(), Some("12.9"));
+        assert_eq!(workload.package_count(), 2);
+    }
+
+    #[test]
+    fn test_deserialize_all_three_managers() {
+        let yaml = r#"
+name: multi-manager
+version: "1.0.0"
+description: "Workload with all managers"
+packages:
+  winget:
+    - id: Git.Git
+  brew:
+    - name: git
+  apt:
+    - name: git
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        let pkgs = workload.packages.as_ref().unwrap();
+        assert_eq!(pkgs.winget.as_ref().unwrap().len(), 1);
+        assert_eq!(pkgs.brew.as_ref().unwrap().len(), 1);
+        assert_eq!(pkgs.apt.as_ref().unwrap().len(), 1);
+        assert_eq!(workload.package_count(), 3);
+    }
+
+    #[test]
+    fn test_package_count_all_managers() {
+        let yaml = r#"
+name: count-test
+version: "1.0.0"
+description: "Count test"
+packages:
+  winget:
+    - id: Git.Git
+    - id: Microsoft.VisualStudioCode
+  brew:
+    - name: git
+    - name: node
+    - name: visual-studio-code
+      cask: true
+  apt:
+    - name: git
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(workload.package_count(), 6); // 2 + 3 + 1
+    }
+
+    #[test]
+    fn test_backward_compat_winget_only() {
+        let yaml = r#"
+name: winget-only
+version: "1.0.0"
+description: "Only winget"
+packages:
+  winget:
+    - id: Git.Git
+    - id: Microsoft.VisualStudioCode
+      version: "1.85.0"
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(workload.package_count(), 2);
+        let pkgs = workload.packages.as_ref().unwrap();
+        assert!(pkgs.brew.is_none());
+        assert!(pkgs.apt.is_none());
+        assert!(pkgs.winget.is_some());
     }
 }

--- a/src/operations/show.rs
+++ b/src/operations/show.rs
@@ -480,6 +480,7 @@ mod tests {
                 WingetPackage::new("Package.One"),
                 WingetPackage::new("Package.Two"),
             ]),
+            ..Default::default()
         });
         assert_eq!(workload.package_count(), 2);
     }

--- a/src/operations/validate.rs
+++ b/src/operations/validate.rs
@@ -678,6 +678,47 @@ fn print_json_schema() -> Result<()> {
               }
             }
           }
+        },
+        "brew": {
+          "type": "array",
+          "description": "Homebrew packages (macOS/Linux)",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Homebrew formula or cask name (e.g., 'git', 'visual-studio-code')"
+              },
+              "cask": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether this is a cask (GUI app) vs formula (CLI tool)"
+              },
+              "tap": {
+                "type": "string",
+                "description": "Tap source (e.g., 'homebrew/cask-fonts')"
+              }
+            }
+          }
+        },
+        "apt": {
+          "type": "array",
+          "description": "APT packages (Debian/Ubuntu)",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "APT package name (e.g., 'git', 'build-essential')"
+              },
+              "version": {
+                "type": "string",
+                "description": "Specific version constraint"
+              }
+            }
+          }
         }
       }
     },

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -15,6 +15,7 @@ pub mod winget;
 pub use filesystem::FilesystemProvider;
 pub use winget::WingetProvider;
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors that can occur in providers
@@ -127,5 +128,316 @@ impl ProviderConfig {
     pub fn with_retries(mut self, count: u32) -> Self {
         self.retry_count = count;
         self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Package-manager abstraction layer
+// ---------------------------------------------------------------------------
+
+/// A package specification that is manager-agnostic.
+/// Each package manager can interpret these fields as needed.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageSpec {
+    /// Package identifier (e.g. "Git.Git" for winget, "git" for brew)
+    pub id: String,
+    /// Specific version to install (None = latest)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Package source or tap
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// Result of installing a package
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct PackageInstallResult {
+    /// Package that was installed
+    pub package_id: String,
+    /// Whether the installation succeeded
+    pub success: bool,
+    /// Whether the package was already installed (no-op)
+    pub already_installed: bool,
+    /// Version that was installed
+    pub installed_version: Option<String>,
+    /// Whether a reboot is required
+    pub needs_reboot: bool,
+    /// Human-readable message
+    pub message: String,
+}
+
+/// Information about an installed package
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+pub struct InstalledPackage {
+    /// Package identifier
+    pub id: String,
+    /// Installed version
+    pub version: Option<String>,
+    /// Available version (if upgrade available)
+    pub available_version: Option<String>,
+    /// Package source
+    pub source: Option<String>,
+}
+
+/// Trait abstracting a system package manager (winget, brew, apt, etc.)
+///
+/// Implementations provide package installation, querying, and listing
+/// capabilities. Only `winget` is implemented today; `brew` and `apt`
+/// are planned for future cross-platform support.
+#[allow(dead_code)]
+pub trait PackageManager: Send + Sync {
+    /// Return the manager's human-readable name (e.g., "winget", "brew", "apt")
+    fn name(&self) -> &str;
+
+    /// Check whether the manager binary is available on this system
+    fn is_available(&self) -> bool;
+
+    /// Install a package from a specification
+    fn install(&self, package: &PackageSpec) -> Result<PackageInstallResult, ProviderError>;
+
+    /// Check whether a package is installed, returning its version if so
+    fn is_installed(&self, package_id: &str) -> Result<Option<String>, ProviderError>;
+
+    /// List all packages managed by this provider
+    fn list_installed(&self) -> Result<Vec<InstalledPackage>, ProviderError>;
+}
+
+/// Registry of available package managers.
+/// At runtime, managers are detected and only available ones are used.
+#[allow(dead_code)]
+pub struct PackageManagerRegistry {
+    managers: Vec<Box<dyn PackageManager>>,
+}
+
+#[allow(dead_code)]
+impl PackageManagerRegistry {
+    /// Create a new registry with no managers
+    pub fn new() -> Self {
+        Self {
+            managers: Vec::new(),
+        }
+    }
+
+    /// Register a package manager
+    pub fn register(&mut self, manager: Box<dyn PackageManager>) {
+        self.managers.push(manager);
+    }
+
+    /// Get a manager by name
+    pub fn get(&self, name: &str) -> Option<&dyn PackageManager> {
+        self.managers
+            .iter()
+            .find(|m| m.name() == name)
+            .map(|m| m.as_ref())
+    }
+
+    /// Get all available managers (those whose is_available() returns true)
+    pub fn available(&self) -> Vec<&dyn PackageManager> {
+        self.managers
+            .iter()
+            .filter(|m| m.is_available())
+            .map(|m| m.as_ref())
+            .collect()
+    }
+
+    /// Get all registered manager names
+    pub fn registered_names(&self) -> Vec<&str> {
+        self.managers.iter().map(|m| m.name()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock package manager for testing the trait and registry.
+    struct MockManager {
+        manager_name: String,
+        available: bool,
+        packages: Vec<InstalledPackage>,
+    }
+
+    impl MockManager {
+        fn new(name: &str, available: bool) -> Self {
+            Self {
+                manager_name: name.to_string(),
+                available,
+                packages: Vec::new(),
+            }
+        }
+
+        fn with_package(mut self, id: &str, version: &str) -> Self {
+            self.packages.push(InstalledPackage {
+                id: id.to_string(),
+                version: Some(version.to_string()),
+                available_version: None,
+                source: None,
+            });
+            self
+        }
+    }
+
+    impl PackageManager for MockManager {
+        fn name(&self) -> &str {
+            &self.manager_name
+        }
+
+        fn is_available(&self) -> bool {
+            self.available
+        }
+
+        fn install(&self, package: &PackageSpec) -> Result<PackageInstallResult, ProviderError> {
+            Ok(PackageInstallResult {
+                package_id: package.id.clone(),
+                success: true,
+                already_installed: false,
+                installed_version: package.version.clone(),
+                needs_reboot: false,
+                message: format!("Installed {}", package.id),
+            })
+        }
+
+        fn is_installed(&self, package_id: &str) -> Result<Option<String>, ProviderError> {
+            Ok(self
+                .packages
+                .iter()
+                .find(|p| p.id == package_id)
+                .and_then(|p| p.version.clone()))
+        }
+
+        fn list_installed(&self) -> Result<Vec<InstalledPackage>, ProviderError> {
+            Ok(self.packages.clone())
+        }
+    }
+
+    // -- PackageSpec tests --
+
+    #[test]
+    fn test_package_spec_creation() {
+        let spec = PackageSpec {
+            id: "Git.Git".to_string(),
+            version: Some("2.42.0".to_string()),
+            source: None,
+        };
+        assert_eq!(spec.id, "Git.Git");
+        assert_eq!(spec.version.as_deref(), Some("2.42.0"));
+        assert!(spec.source.is_none());
+    }
+
+    #[test]
+    fn test_package_spec_serde_roundtrip_full() {
+        let spec = PackageSpec {
+            id: "Git.Git".to_string(),
+            version: Some("2.42.0".to_string()),
+            source: Some("winget".to_string()),
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let deserialized: PackageSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, "Git.Git");
+        assert_eq!(deserialized.version.as_deref(), Some("2.42.0"));
+        assert_eq!(deserialized.source.as_deref(), Some("winget"));
+    }
+
+    #[test]
+    fn test_package_spec_serde_roundtrip_minimal() {
+        let json = r#"{"id":"ripgrep"}"#;
+        let spec: PackageSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.id, "ripgrep");
+        assert!(spec.version.is_none());
+        assert!(spec.source.is_none());
+
+        // Re-serialize should omit None fields
+        let reserialized = serde_json::to_string(&spec).unwrap();
+        assert!(!reserialized.contains("version"));
+        assert!(!reserialized.contains("source"));
+    }
+
+    // -- PackageManagerRegistry tests --
+
+    #[test]
+    fn test_registry_empty() {
+        let registry = PackageManagerRegistry::new();
+        assert!(registry.get("winget").is_none());
+        assert!(registry.available().is_empty());
+        assert!(registry.registered_names().is_empty());
+    }
+
+    #[test]
+    fn test_registry_register_and_get() {
+        let mut registry = PackageManagerRegistry::new();
+        registry.register(Box::new(MockManager::new("winget", true)));
+        registry.register(Box::new(MockManager::new("brew", false)));
+
+        assert!(registry.get("winget").is_some());
+        assert_eq!(registry.get("winget").unwrap().name(), "winget");
+        assert!(registry.get("brew").is_some());
+        assert!(registry.get("apt").is_none());
+    }
+
+    #[test]
+    fn test_registry_available_filters_unavailable() {
+        let mut registry = PackageManagerRegistry::new();
+        registry.register(Box::new(MockManager::new("winget", true)));
+        registry.register(Box::new(MockManager::new("brew", false)));
+        registry.register(Box::new(MockManager::new("apt", true)));
+
+        let available = registry.available();
+        assert_eq!(available.len(), 2);
+        let names: Vec<&str> = available.iter().map(|m| m.name()).collect();
+        assert!(names.contains(&"winget"));
+        assert!(names.contains(&"apt"));
+        assert!(!names.contains(&"brew"));
+    }
+
+    #[test]
+    fn test_registry_registered_names() {
+        let mut registry = PackageManagerRegistry::new();
+        registry.register(Box::new(MockManager::new("winget", true)));
+        registry.register(Box::new(MockManager::new("brew", false)));
+
+        let names = registry.registered_names();
+        assert_eq!(names, vec!["winget", "brew"]);
+    }
+
+    // -- Mock PackageManager behaviour --
+
+    #[test]
+    fn test_mock_install() {
+        let manager = MockManager::new("test", true);
+        let spec = PackageSpec {
+            id: "Pkg.Test".to_string(),
+            version: Some("1.0.0".to_string()),
+            source: None,
+        };
+        let result = manager.install(&spec).unwrap();
+        assert!(result.success);
+        assert!(!result.already_installed);
+        assert_eq!(result.package_id, "Pkg.Test");
+        assert_eq!(result.installed_version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn test_mock_is_installed() {
+        let manager = MockManager::new("test", true).with_package("Git.Git", "2.42.0");
+        assert_eq!(
+            manager.is_installed("Git.Git").unwrap().as_deref(),
+            Some("2.42.0")
+        );
+        assert!(manager.is_installed("Unknown.Pkg").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_mock_list_installed() {
+        let manager = MockManager::new("test", true)
+            .with_package("Git.Git", "2.42.0")
+            .with_package("Rustlang.Rust", "1.75.0");
+
+        let packages = manager.list_installed().unwrap();
+        assert_eq!(packages.len(), 2);
+        assert_eq!(packages[0].id, "Git.Git");
+        assert_eq!(packages[1].id, "Rustlang.Rust");
     }
 }

--- a/src/providers/winget.rs
+++ b/src/providers/winget.rs
@@ -9,7 +9,10 @@ use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
-use super::{ProviderConfig, ProviderStatus};
+use super::{
+    InstalledPackage as SharedInstalledPackage, PackageInstallResult, PackageManager, PackageSpec,
+    ProviderConfig, ProviderError, ProviderStatus,
+};
 use crate::config::workload::WingetPackage;
 
 /// Winget exit codes
@@ -1023,6 +1026,71 @@ impl ProviderStatus for WingetProvider {
     }
 }
 
+impl PackageManager for WingetProvider {
+    fn name(&self) -> &str {
+        "winget"
+    }
+
+    fn is_available(&self) -> bool {
+        <Self as ProviderStatus>::is_available(self)
+    }
+
+    fn install(&self, package: &PackageSpec) -> Result<PackageInstallResult, ProviderError> {
+        let winget_package = WingetPackage {
+            id: package.id.clone(),
+            version: package.version.clone(),
+            source: package.source.clone(),
+            override_args: None,
+            override_str: None,
+        };
+
+        // Delegate to the inherent install method (takes &WingetPackage)
+        match self.install(&winget_package) {
+            Ok(result) => {
+                let already_installed = matches!(
+                    result.exit_code,
+                    exit_codes::ALREADY_INSTALLED
+                        | exit_codes::ALREADY_INSTALLED_FRIENDLY
+                        | exit_codes::NO_APPLICABLE_INSTALLER
+                        | exit_codes::NO_APPLICABLE_INSTALLER_FRIENDLY
+                ) || result
+                    .message
+                    .as_deref()
+                    .is_some_and(|m| m.contains("already installed"));
+
+                Ok(PackageInstallResult {
+                    package_id: package.id.clone(),
+                    success: result.success,
+                    already_installed,
+                    installed_version: result.installed_version.clone(),
+                    needs_reboot: result.reboot_required,
+                    message: result.message.unwrap_or_default(),
+                })
+            }
+            Err(e) => Err(ProviderError::Winget(e)),
+        }
+    }
+
+    fn is_installed(&self, package_id: &str) -> Result<Option<String>, ProviderError> {
+        self.get_installed_version(package_id)
+            .map_err(ProviderError::Winget)
+    }
+
+    fn list_installed(&self) -> Result<Vec<SharedInstalledPackage>, ProviderError> {
+        // Delegate to the inherent list_installed (returns winget::InstalledPackage)
+        let packages = WingetProvider::list_installed(self).map_err(ProviderError::Winget)?;
+        Ok(packages
+            .into_iter()
+            .map(|p| SharedInstalledPackage {
+                id: p.id,
+                version: Some(p.version),
+                available_version: p.available_version,
+                source: p.source,
+            })
+            .collect())
+    }
+}
+
 /// Information about the winget installation
 #[derive(Debug, Clone)]
 pub struct WingetInfo {
@@ -1502,7 +1570,7 @@ mod tests {
     #[test]
     fn test_provider_name() {
         let provider = WingetProvider::new();
-        assert_eq!(provider.name(), "winget");
+        assert_eq!(ProviderStatus::name(&provider), "winget");
     }
 
     #[test]
@@ -1530,5 +1598,63 @@ mod tests {
     fn test_exit_codes() {
         assert_eq!(exit_codes::SUCCESS, 0);
         assert_eq!(exit_codes::ALREADY_INSTALLED, -1978335215);
+    }
+
+    // -- PackageManager trait tests --
+
+    #[test]
+    fn test_package_manager_name() {
+        let provider = WingetProvider::new();
+        assert_eq!(PackageManager::name(&provider), "winget");
+    }
+
+    #[test]
+    fn test_winget_provider_implements_package_manager() {
+        // Compile-time check: WingetProvider can be used as a dyn PackageManager
+        fn _assert_package_manager(_pm: &dyn PackageManager) {}
+        let provider = WingetProvider::new();
+        _assert_package_manager(&provider);
+    }
+
+    #[test]
+    fn test_package_spec_to_winget_package_conversion() {
+        // Verify that a PackageSpec can be used with the PackageManager::install interface
+        // by checking that the conversion logic in the trait impl is coherent
+        let spec = PackageSpec {
+            id: "Git.Git".to_string(),
+            version: Some("2.42.0".to_string()),
+            source: Some("winget".to_string()),
+        };
+
+        // Simulate the conversion done inside PackageManager::install
+        let winget_package = WingetPackage {
+            id: spec.id.clone(),
+            version: spec.version.clone(),
+            source: spec.source.clone(),
+            override_args: None,
+            override_str: None,
+        };
+
+        assert_eq!(winget_package.id, "Git.Git");
+        assert_eq!(winget_package.version, Some("2.42.0".to_string()));
+        assert_eq!(winget_package.source, Some("winget".to_string()));
+        assert!(winget_package.override_args.is_none());
+        assert!(winget_package.override_str.is_none());
+    }
+
+    #[test]
+    fn test_package_manager_is_available_delegates_to_provider_status() {
+        let provider = WingetProvider::new();
+        // Both traits should return the same result
+        let pm_result = PackageManager::is_available(&provider);
+        let ps_result = ProviderStatus::is_available(&provider);
+        assert_eq!(pm_result, ps_result);
+    }
+
+    #[test]
+    fn test_winget_provider_is_send_and_sync() {
+        // PackageManager requires Send + Sync; verify WingetProvider satisfies this
+        fn _assert_send_sync<T: Send + Sync>() {}
+        _assert_send_sync::<WingetProvider>();
     }
 }


### PR DESCRIPTION
## Description

Introduce a `PackageManager` trait that abstracts package installation and querying, refactor `WingetProvider` to implement it, and extend the workload schema to support multiple package managers.

### What's included

- **PackageManager trait** — Manager-agnostic interface with `install()`, `is_installed()`, `list_installed()`, plus shared types (`PackageSpec`, `PackageInstallResult`, `InstalledPackage`) and a runtime `PackageManagerRegistry`
- **WingetProvider refactored** — Implements `PackageManager` trait by delegating to existing methods with type conversion; all existing behavior preserved
- **Multi-manager workload schema** — New `packages.brew` and `packages.apt` fields in workload YAML (schema-only, not yet implemented); platform-aware validation warns when referencing unavailable managers
- **Inheritance support** — Brew and apt package lists merge correctly through workload inheritance
- **Schema validation** — Brew tap format validation, empty-name checks, and platform availability warnings

## Related Issues

Closes #12, Closes #13, Closes #14

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (323 tests: 242 unit + 81 integration)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)