### PR TITLE
feat: add commands block with conditional execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Assertion examples in `anvil init --template full` scaffold
 - Multi-manager workload schema: `packages.brew` (Homebrew) and `packages.apt` (APT) fields alongside existing `packages.winget`
 - Platform-aware validation warns when workload references an unavailable package manager
+- Inline `commands:` block for workload command execution with `pre_install` and `post_install` phases
+- Conditional command execution via `when:` field using the predicate engine
+- `continue_on_error` option for commands that should not block the install flow
 
 ### Deprecated
 - `scripts.health_check` when used alongside `assertions` (migrate to declarative assertions; removal planned for v1.0)
+- `scripts.pre_install` and `scripts.post_install` when used alongside `commands` (migrate to inline commands; removal planned for v1.0)
 
 ## [0.5.0] - 2026-04-17
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -448,6 +448,73 @@ assertions:
       command: git
 ```
 
+### 5.1.2 Commands and Legacy Scripts Coexistence
+
+Anvil supports two mechanisms for running actions during installation:
+
+| Mechanism | Field | Introduced | Status |
+|-----------|-------|-----------|--------|
+| Inline commands | `commands.pre_install` / `commands.post_install` | v0.6 | **Recommended** |
+| Script files | `scripts.pre_install` / `scripts.post_install` | v0.1 | Deprecated when used with commands |
+
+**Execution order**: When both exist for the same phase, commands run first, then legacy scripts.
+
+**Deprecation timeline**:
+- **v0.6**: Warning emitted when `scripts.pre_install`/`scripts.post_install` is used alongside `commands.pre_install`/`commands.post_install`
+- **v0.8**: Warning emitted for any use of `scripts.pre_install`/`scripts.post_install`
+- **v1.0**: `scripts.pre_install` and `scripts.post_install` removed; use `commands` exclusively
+
+**Migration**: Convert script entries to inline commands:
+```yaml
+# Before (legacy script)
+scripts:
+  post_install:
+    - path: setup.ps1
+      description: "Install Rust components"
+
+# After (inline command)
+commands:
+  post_install:
+    - run: rustup default stable
+      description: "Set stable as default toolchain"
+    - run: cargo install cargo-watch
+      description: "Install cargo-watch"
+      when:
+        type: command_exists
+        command: cargo
+```
+
+Note: `scripts.health_check` follows a separate deprecation path (see §5.1.1).
+
+### 5.1.3 Command Execution Semantics
+
+Commands defined in `commands.pre_install` and `commands.post_install` are executed inline during the install flow.
+
+**Execution rules:**
+- Commands run sequentially in the order defined
+- Default behavior: **stop on first failure** (non-zero exit code)
+- `continue_on_error: true` overrides this per-command
+- Commands with `when:` conditions are evaluated before execution; if the condition fails, the command is skipped
+
+**Output handling:**
+- stdout and stderr are captured and included in reports
+- In verbose mode (`-v`), output is streamed in real-time
+- In quiet mode (`-q`), output is suppressed unless the command fails
+
+**Timeout behavior:**
+- Default timeout: 300 seconds
+- On timeout: process is terminated (SIGTERM on Unix, TerminateProcess on Windows)
+- Timed-out commands are reported as failures
+
+**Elevated commands:**
+- Commands with `elevated: true` require admin privileges
+- On Windows: validated via `whoami /priv` or equivalent before attempting
+- If elevation is unavailable, the command fails with a clear error message
+
+**Exit codes:**
+- Exit code 0 = success
+- Any non-zero exit code = failure (unless `continue_on_error: true`)
+
 ### 5.2 Example Workloads
 
 #### 5.2.1 Essentials Workload

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,539 @@
+//! Command execution module for Anvil
+//!
+//! This module handles execution of inline commands defined in workload
+//! `commands:` blocks, with conditional execution, timeout enforcement,
+//! and structured result reporting.
+
+use std::time::Duration;
+
+use serde::Serialize;
+use thiserror::Error;
+
+/// Errors that can occur during command execution
+#[allow(dead_code)]
+#[derive(Error, Debug)]
+pub enum CommandError {
+    /// Command executable was not found on the system
+    #[error("Command not found: {0}")]
+    NotFound(String),
+
+    /// Command exceeded its timeout duration
+    #[error("Command timed out after {timeout_seconds} seconds: {command}")]
+    Timeout {
+        command: String,
+        timeout_seconds: u64,
+    },
+
+    /// Command requires elevated privileges that are not available
+    #[error("Command requires elevated privileges: {0}")]
+    ElevationRequired(String),
+
+    /// Command execution failed for a general reason
+    #[error("Command execution failed: {0}")]
+    ExecutionFailed(String),
+
+    /// IO error during command execution
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Status of a command execution
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum CommandStatus {
+    /// Command executed successfully (exit code 0)
+    Success,
+    /// Command failed (non-zero exit code)
+    Failed,
+    /// Command was skipped (when condition not met)
+    Skipped,
+    /// Command timed out
+    TimedOut,
+}
+
+/// Result of executing a single command
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandResult {
+    /// Display name or the command string
+    pub name: String,
+    /// Execution status
+    pub status: CommandStatus,
+    /// Exit code (None if skipped or timed out)
+    pub exit_code: Option<i32>,
+    /// Captured stdout
+    pub stdout: String,
+    /// Captured stderr
+    pub stderr: String,
+    /// Human-readable message
+    pub message: String,
+    /// How long the command took
+    pub duration: Duration,
+}
+
+/// Summary of a batch of command executions
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CommandSummary {
+    /// Total commands in the batch
+    pub total: usize,
+    /// Commands that succeeded
+    pub succeeded: usize,
+    /// Commands that failed
+    pub failed: usize,
+    /// Commands that were skipped
+    pub skipped: usize,
+    /// Commands that timed out
+    pub timed_out: usize,
+    /// Total execution duration
+    pub total_duration: Duration,
+    /// Whether any command requires reboot
+    pub requires_reboot: bool,
+    /// Individual results
+    pub results: Vec<CommandResult>,
+}
+
+#[allow(dead_code)]
+impl CommandSummary {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_result(&mut self, result: CommandResult) {
+        self.total += 1;
+        self.total_duration += result.duration;
+        match result.status {
+            CommandStatus::Success => self.succeeded += 1,
+            CommandStatus::Failed => self.failed += 1,
+            CommandStatus::Skipped => self.skipped += 1,
+            CommandStatus::TimedOut => {
+                self.timed_out += 1;
+                self.failed += 1; // timed out counts as failure
+            }
+        }
+        self.results.push(result);
+    }
+
+    pub fn is_successful(&self) -> bool {
+        self.failed == 0
+    }
+}
+
+/// Execute a list of commands, evaluating `when` conditions and enforcing timeouts.
+pub fn execute_commands(
+    commands: &[crate::config::workload::CommandEntry],
+    _phase: &str,
+    verbose: bool,
+    dry_run: bool,
+) -> CommandSummary {
+    let mut summary = CommandSummary::new();
+
+    for entry in commands {
+        let display_name = entry.description.as_deref().unwrap_or(&entry.run);
+
+        // Evaluate `when` condition if present
+        if let Some(condition) = &entry.when {
+            let result = crate::conditions::evaluate(condition);
+            if !result.passed {
+                summary.add_result(CommandResult {
+                    name: display_name.to_string(),
+                    status: CommandStatus::Skipped,
+                    exit_code: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    message: format!("Condition not met: {}", result.message),
+                    duration: Duration::ZERO,
+                });
+                continue;
+            }
+        }
+
+        if dry_run {
+            summary.add_result(CommandResult {
+                name: display_name.to_string(),
+                status: CommandStatus::Skipped,
+                exit_code: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                message: "Dry run — would execute".to_string(),
+                duration: Duration::ZERO,
+            });
+            continue;
+        }
+
+        // Execute the command
+        let result = execute_single_command(entry, display_name, verbose);
+        let should_stop = result.status == CommandStatus::Failed && !entry.continue_on_error;
+        summary.add_result(result);
+
+        if should_stop {
+            break;
+        }
+    }
+
+    summary
+}
+
+fn execute_single_command(
+    entry: &crate::config::workload::CommandEntry,
+    display_name: &str,
+    _verbose: bool,
+) -> CommandResult {
+    use std::process::Command;
+    use std::time::Instant;
+
+    let start = Instant::now();
+
+    let mut cmd = if cfg!(target_os = "windows") {
+        let mut c = Command::new("powershell.exe");
+        c.args(["-NoProfile", "-NonInteractive", "-Command", &entry.run]);
+        c
+    } else {
+        let mut c = Command::new("sh");
+        c.args(["-c", &entry.run]);
+        c
+    };
+
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    match cmd.spawn() {
+        Ok(child) => match child.wait_with_output() {
+            Ok(output) => {
+                let duration = start.elapsed();
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                let exit_code = output.status.code().unwrap_or(-1);
+
+                if duration.as_secs() > entry.timeout {
+                    CommandResult {
+                        name: display_name.to_string(),
+                        status: CommandStatus::TimedOut,
+                        exit_code: Some(exit_code),
+                        stdout,
+                        stderr,
+                        message: format!("Timed out after {}s", entry.timeout),
+                        duration,
+                    }
+                } else if exit_code == 0 {
+                    CommandResult {
+                        name: display_name.to_string(),
+                        status: CommandStatus::Success,
+                        exit_code: Some(0),
+                        stdout,
+                        stderr,
+                        message: "Completed successfully".to_string(),
+                        duration,
+                    }
+                } else {
+                    CommandResult {
+                        name: display_name.to_string(),
+                        status: CommandStatus::Failed,
+                        exit_code: Some(exit_code),
+                        stdout,
+                        stderr,
+                        message: format!("Exited with code {}", exit_code),
+                        duration,
+                    }
+                }
+            }
+            Err(e) => CommandResult {
+                name: display_name.to_string(),
+                status: CommandStatus::Failed,
+                exit_code: None,
+                stdout: String::new(),
+                stderr: e.to_string(),
+                message: format!("Failed to wait for process: {}", e),
+                duration: start.elapsed(),
+            },
+        },
+        Err(e) => CommandResult {
+            name: display_name.to_string(),
+            status: CommandStatus::Failed,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: e.to_string(),
+            message: format!("Failed to spawn command: {}", e),
+            duration: start.elapsed(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_result_construction() {
+        let result = CommandResult {
+            name: "echo hello".to_string(),
+            status: CommandStatus::Success,
+            exit_code: Some(0),
+            stdout: "hello\n".to_string(),
+            stderr: String::new(),
+            message: "Command succeeded".to_string(),
+            duration: Duration::from_millis(50),
+        };
+
+        assert_eq!(result.name, "echo hello");
+        assert_eq!(result.status, CommandStatus::Success);
+        assert_eq!(result.exit_code, Some(0));
+        assert_eq!(result.stdout, "hello\n");
+        assert!(result.stderr.is_empty());
+    }
+
+    #[test]
+    fn test_command_status_variants() {
+        assert_eq!(CommandStatus::Success, CommandStatus::Success);
+        assert_ne!(CommandStatus::Success, CommandStatus::Failed);
+        assert_ne!(CommandStatus::Skipped, CommandStatus::TimedOut);
+        assert_ne!(CommandStatus::Failed, CommandStatus::Skipped);
+    }
+
+    #[test]
+    fn test_command_summary_empty() {
+        let summary = CommandSummary::new();
+        assert_eq!(summary.total, 0);
+        assert_eq!(summary.succeeded, 0);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.skipped, 0);
+        assert_eq!(summary.timed_out, 0);
+        assert!(summary.is_successful());
+        assert!(summary.results.is_empty());
+    }
+
+    #[test]
+    fn test_command_summary_tracks_success() {
+        let mut summary = CommandSummary::new();
+        summary.add_result(CommandResult {
+            name: "cmd1".to_string(),
+            status: CommandStatus::Success,
+            exit_code: Some(0),
+            stdout: String::new(),
+            stderr: String::new(),
+            message: "ok".to_string(),
+            duration: Duration::from_millis(100),
+        });
+
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(summary.failed, 0);
+        assert!(summary.is_successful());
+        assert_eq!(summary.total_duration, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_command_summary_tracks_failure() {
+        let mut summary = CommandSummary::new();
+        summary.add_result(CommandResult {
+            name: "bad-cmd".to_string(),
+            status: CommandStatus::Failed,
+            exit_code: Some(1),
+            stdout: String::new(),
+            stderr: "error\n".to_string(),
+            message: "failed".to_string(),
+            duration: Duration::from_millis(200),
+        });
+
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.succeeded, 0);
+        assert_eq!(summary.failed, 1);
+        assert!(!summary.is_successful());
+    }
+
+    #[test]
+    fn test_command_summary_timeout_counts_as_failure() {
+        let mut summary = CommandSummary::new();
+        summary.add_result(CommandResult {
+            name: "slow-cmd".to_string(),
+            status: CommandStatus::TimedOut,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            message: "timed out".to_string(),
+            duration: Duration::from_secs(300),
+        });
+
+        assert_eq!(summary.timed_out, 1);
+        assert_eq!(summary.failed, 1);
+        assert!(!summary.is_successful());
+    }
+
+    #[test]
+    fn test_command_summary_mixed_results() {
+        let mut summary = CommandSummary::new();
+
+        summary.add_result(CommandResult {
+            name: "success-cmd".to_string(),
+            status: CommandStatus::Success,
+            exit_code: Some(0),
+            stdout: "done".to_string(),
+            stderr: String::new(),
+            message: "ok".to_string(),
+            duration: Duration::from_millis(50),
+        });
+
+        summary.add_result(CommandResult {
+            name: "skipped-cmd".to_string(),
+            status: CommandStatus::Skipped,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            message: "condition not met".to_string(),
+            duration: Duration::ZERO,
+        });
+
+        summary.add_result(CommandResult {
+            name: "failed-cmd".to_string(),
+            status: CommandStatus::Failed,
+            exit_code: Some(2),
+            stdout: String::new(),
+            stderr: "err".to_string(),
+            message: "failed".to_string(),
+            duration: Duration::from_millis(100),
+        });
+
+        summary.add_result(CommandResult {
+            name: "timeout-cmd".to_string(),
+            status: CommandStatus::TimedOut,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            message: "timed out".to_string(),
+            duration: Duration::from_secs(300),
+        });
+
+        assert_eq!(summary.total, 4);
+        assert_eq!(summary.succeeded, 1);
+        assert_eq!(summary.failed, 2); // 1 failed + 1 timed out
+        assert_eq!(summary.skipped, 1);
+        assert_eq!(summary.timed_out, 1);
+        assert!(!summary.is_successful());
+        assert_eq!(summary.results.len(), 4);
+        assert_eq!(
+            summary.total_duration,
+            Duration::from_millis(50 + 100) + Duration::from_secs(300)
+        );
+    }
+
+    #[test]
+    fn test_command_summary_all_skipped_is_successful() {
+        let mut summary = CommandSummary::new();
+        summary.add_result(CommandResult {
+            name: "skipped".to_string(),
+            status: CommandStatus::Skipped,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            message: "condition not met".to_string(),
+            duration: Duration::ZERO,
+        });
+
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.skipped, 1);
+        assert!(summary.is_successful());
+    }
+
+    fn make_entry(run: &str) -> crate::config::workload::CommandEntry {
+        crate::config::workload::CommandEntry {
+            run: run.to_string(),
+            description: None,
+            timeout: 300,
+            elevated: false,
+            when: None,
+            continue_on_error: false,
+        }
+    }
+
+    #[test]
+    fn test_execute_commands_empty_list() {
+        let commands: Vec<crate::config::workload::CommandEntry> = vec![];
+        let summary = super::execute_commands(&commands, "pre_install", false, false);
+        assert_eq!(summary.total, 0);
+        assert!(summary.is_successful());
+    }
+
+    #[test]
+    fn test_execute_commands_simple_success() {
+        let cmd = if cfg!(target_os = "windows") {
+            "Write-Output 'hello'"
+        } else {
+            "echo hello"
+        };
+        let commands = vec![make_entry(cmd)];
+        let summary = super::execute_commands(&commands, "pre_install", false, false);
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.succeeded, 1);
+        assert!(summary.is_successful());
+        assert!(summary.results[0].stdout.contains("hello"));
+    }
+
+    #[test]
+    fn test_execute_commands_failure() {
+        let commands = vec![make_entry("exit 1")];
+        let summary = super::execute_commands(&commands, "pre_install", false, false);
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.failed, 1);
+        assert!(!summary.is_successful());
+        assert_eq!(summary.results[0].status, CommandStatus::Failed);
+    }
+
+    #[test]
+    fn test_execute_commands_stops_on_failure() {
+        let ok_cmd = if cfg!(target_os = "windows") {
+            "Write-Output 'after'"
+        } else {
+            "echo after"
+        };
+        let commands = vec![make_entry("exit 1"), make_entry(ok_cmd)];
+        let summary = super::execute_commands(&commands, "pre_install", false, false);
+        // Should stop after first failure (continue_on_error is false)
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.failed, 1);
+    }
+
+    #[test]
+    fn test_execute_commands_continue_on_error() {
+        let ok_cmd = if cfg!(target_os = "windows") {
+            "Write-Output 'after'"
+        } else {
+            "echo after"
+        };
+        let mut entry1 = make_entry("exit 1");
+        entry1.continue_on_error = true;
+        let entry2 = make_entry(ok_cmd);
+        let commands = vec![entry1, entry2];
+        let summary = super::execute_commands(&commands, "pre_install", false, false);
+        assert_eq!(summary.total, 2);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.succeeded, 1);
+    }
+
+    #[test]
+    fn test_execute_commands_dry_run() {
+        let cmd = if cfg!(target_os = "windows") {
+            "Write-Output 'should not run'"
+        } else {
+            "echo 'should not run'"
+        };
+        let commands = vec![make_entry(cmd)];
+        let summary = super::execute_commands(&commands, "pre_install", false, true);
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.skipped, 1);
+        assert!(summary.results[0].message.contains("Dry run"));
+    }
+
+    #[test]
+    fn test_execute_commands_when_condition_skips() {
+        // Use a condition that will never be true
+        let mut entry = make_entry("echo should-not-run");
+        entry.when = Some(crate::conditions::Condition::FileExists {
+            path: "__anvil_nonexistent_file_for_test_12345__".to_string(),
+        });
+        let commands = vec![entry];
+        let summary = super::execute_commands(&commands, "pre_install", false, false);
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.skipped, 1);
+        assert!(summary.results[0].message.contains("Condition not met"));
+    }
+}

--- a/src/config/inheritance.rs
+++ b/src/config/inheritance.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use tracing::{debug, trace};
 
 use super::workload::{
-    AptPackage, BrewPackage, Environment, FileEntry, HealthCheckScript, Packages, ScriptEntry,
-    Scripts, WingetPackage, Workload,
+    AptPackage, BrewPackage, CommandBlock, CommandEntry, Environment, FileEntry, HealthCheckScript,
+    Packages, ScriptEntry, Scripts, WingetPackage, Workload,
 };
 use super::ConfigManager;
 
@@ -509,6 +509,9 @@ fn merge_workloads(parent: Workload, child: Workload) -> Workload {
         // Merge scripts
         scripts: merge_scripts(parent.scripts, child.scripts),
 
+        // Merge commands
+        commands: merge_commands(parent.commands, child.commands),
+
         // Merge environment
         environment: merge_environment(parent.environment, child.environment),
 
@@ -699,6 +702,57 @@ fn merge_health_check_list(
     parent: Option<Vec<HealthCheckScript>>,
     child: Option<Vec<HealthCheckScript>>,
 ) -> Option<Vec<HealthCheckScript>> {
+    match (parent, child) {
+        (None, None) => None,
+        (Some(p), None) => Some(p),
+        (None, Some(c)) => Some(c),
+        (Some(mut parent), Some(child)) => {
+            parent.extend(child);
+            Some(parent)
+        }
+    }
+}
+
+/// Merge command block definitions
+///
+/// Strategy:
+/// - pre_install: Parent commands first, then child commands appended
+/// - post_install: Parent commands first, then child commands appended
+fn merge_commands(
+    parent: Option<CommandBlock>,
+    child: Option<CommandBlock>,
+) -> Option<CommandBlock> {
+    match (parent, child) {
+        (None, None) => None,
+        (Some(p), None) => Some(p),
+        (None, Some(c)) => Some(c),
+        (Some(parent), Some(child)) => {
+            let mut result = CommandBlock {
+                pre_install: None,
+                post_install: None,
+            };
+
+            // Pre-install: parent first, then child
+            result.pre_install = merge_command_list(parent.pre_install, child.pre_install);
+
+            // Post-install: parent first, then child
+            result.post_install = merge_command_list(parent.post_install, child.post_install);
+
+            // Only return Some if at least one command list is present
+            if result.pre_install.is_some() || result.post_install.is_some() {
+                Some(result)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Merge two command entry lists (parent first, then child)
+fn merge_command_list(
+    parent: Option<Vec<CommandEntry>>,
+    child: Option<Vec<CommandEntry>>,
+) -> Option<Vec<CommandEntry>> {
     match (parent, child) {
         (None, None) => None,
         (Some(p), None) => Some(p),

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -190,6 +190,9 @@ impl SchemaValidator {
         // Validate scripts
         self.validate_scripts(workload, &mut result);
 
+        // Validate commands
+        self.validate_commands(workload, &mut result);
+
         // Validate environment
         self.validate_environment(workload, &mut result);
 
@@ -580,6 +583,70 @@ impl SchemaValidator {
                 format!("{}.elevated", path),
                 "Script requires elevated privileges. Ensure this is necessary.",
             );
+        }
+    }
+
+    /// Validate command definitions
+    fn validate_commands(&self, workload: &Workload, result: &mut ValidationResult) {
+        if let Some(commands) = &workload.commands {
+            // Validate pre-install commands
+            if let Some(pre_cmds) = &commands.pre_install {
+                for (i, cmd) in pre_cmds.iter().enumerate() {
+                    let path = format!("commands.pre_install[{}]", i);
+                    self.validate_command_entry(&path, cmd, result);
+                }
+            }
+
+            // Validate post-install commands
+            if let Some(post_cmds) = &commands.post_install {
+                for (i, cmd) in post_cmds.iter().enumerate() {
+                    let path = format!("commands.post_install[{}]", i);
+                    self.validate_command_entry(&path, cmd, result);
+                }
+            }
+        }
+    }
+
+    /// Validate a single command entry
+    fn validate_command_entry(
+        &self,
+        path: &str,
+        cmd: &super::workload::CommandEntry,
+        result: &mut ValidationResult,
+    ) {
+        // run is required and must be non-empty
+        if cmd.run.is_empty() {
+            result.add_error(format!("{}.run", path), "Command string is required");
+        }
+
+        // timeout must be > 0
+        if cmd.timeout == 0 {
+            result.add_error(
+                format!("{}.timeout", path),
+                "Timeout must be greater than 0",
+            );
+        } else if cmd.timeout > 3600 {
+            result.add_warning(
+                format!("{}.timeout", path),
+                format!(
+                    "Timeout of {} seconds ({:.1} hours) is very long. Consider if this is intentional.",
+                    cmd.timeout,
+                    cmd.timeout as f64 / 3600.0
+                ),
+            );
+        }
+
+        // Warn about elevated commands in strict mode
+        if cmd.elevated && self.strict {
+            result.add_info(
+                format!("{}.elevated", path),
+                "Command requires elevated privileges. Ensure this is necessary.",
+            );
+        }
+
+        // Validate the when condition if present
+        if let Some(condition) = &cmd.when {
+            self.validate_condition(&format!("{}.when", path), condition, result);
         }
     }
 

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -34,6 +34,10 @@ pub struct Workload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scripts: Option<Scripts>,
 
+    /// Inline command definitions
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commands: Option<CommandBlock>,
+
     /// Environment configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment: Option<Environment>,
@@ -63,6 +67,7 @@ impl Workload {
             packages: None,
             files: None,
             scripts: None,
+            commands: None,
             environment: None,
             health: None,
             assertions: None,
@@ -79,6 +84,7 @@ impl Workload {
             packages: None,
             files: None,
             scripts: None,
+            commands: None,
             environment: None,
             health: None,
             assertions: None,
@@ -128,6 +134,18 @@ impl Workload {
                 let post = s.post_install.as_ref().map(|p| p.len()).unwrap_or(0);
                 let health = s.health_check.as_ref().map(|h| h.len()).unwrap_or(0);
                 pre + post + health
+            })
+            .unwrap_or(0)
+    }
+
+    /// Get the total number of commands (pre_install + post_install)
+    pub fn command_count(&self) -> usize {
+        self.commands
+            .as_ref()
+            .map(|c| {
+                let pre = c.pre_install.as_ref().map(|p| p.len()).unwrap_or(0);
+                let post = c.post_install.as_ref().map(|p| p.len()).unwrap_or(0);
+                pre + post
             })
             .unwrap_or(0)
     }
@@ -374,6 +392,47 @@ impl HealthCheckScript {
             shell: default_shell(),
         }
     }
+}
+
+/// Commands block for inline command execution
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandBlock {
+    /// Commands to run before package installation
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pre_install: Option<Vec<CommandEntry>>,
+
+    /// Commands to run after package installation
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_install: Option<Vec<CommandEntry>>,
+}
+
+/// A single command to execute
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandEntry {
+    /// Shell command string to execute (required)
+    pub run: String,
+
+    /// Human-readable description (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Timeout in seconds (default: 300)
+    #[serde(default = "default_timeout")]
+    pub timeout: u64,
+
+    /// Whether the command requires admin privileges (default: false)
+    #[serde(default)]
+    pub elevated: bool,
+
+    /// Condition that must be true for this command to run (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub when: Option<crate::conditions::Condition>,
+
+    /// Whether to continue if this command fails (default: false)
+    #[serde(default)]
+    pub continue_on_error: bool,
 }
 
 /// Environment configuration
@@ -767,5 +826,130 @@ packages:
         assert!(pkgs.brew.is_none());
         assert!(pkgs.apt.is_none());
         assert!(pkgs.winget.is_some());
+    }
+
+    #[test]
+    fn test_deserialize_workload_with_commands() {
+        let yaml = r#"
+name: cmd-workload
+version: "1.0.0"
+description: "Workload with commands"
+commands:
+  pre_install:
+    - run: "echo pre-step"
+      description: "Pre-install echo"
+  post_install:
+    - run: "echo post-step"
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        assert!(workload.commands.is_some());
+        let cmds = workload.commands.as_ref().unwrap();
+        assert_eq!(cmds.pre_install.as_ref().unwrap().len(), 1);
+        assert_eq!(cmds.post_install.as_ref().unwrap().len(), 1);
+        assert_eq!(cmds.pre_install.as_ref().unwrap()[0].run, "echo pre-step");
+        assert_eq!(
+            cmds.pre_install.as_ref().unwrap()[0].description.as_deref(),
+            Some("Pre-install echo")
+        );
+    }
+
+    #[test]
+    fn test_deserialize_command_with_when_condition() {
+        let yaml = r#"
+name: cond-cmd
+version: "1.0.0"
+description: "Command with when"
+commands:
+  post_install:
+    - run: "cargo install sccache"
+      when:
+        type: command_exists
+        command: cargo
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        let cmds = workload.commands.as_ref().unwrap();
+        let post = cmds.post_install.as_ref().unwrap();
+        assert_eq!(post.len(), 1);
+        assert!(post[0].when.is_some());
+        assert!(matches!(
+            post[0].when.as_ref().unwrap(),
+            crate::conditions::Condition::CommandExists { .. }
+        ));
+    }
+
+    #[test]
+    fn test_command_count() {
+        let mut workload = Workload::new("test", "1.0.0", "test");
+        assert_eq!(workload.command_count(), 0);
+
+        workload.commands = Some(CommandBlock {
+            pre_install: Some(vec![CommandEntry {
+                run: "echo a".to_string(),
+                description: None,
+                timeout: 300,
+                elevated: false,
+                when: None,
+                continue_on_error: false,
+            }]),
+            post_install: Some(vec![
+                CommandEntry {
+                    run: "echo b".to_string(),
+                    description: None,
+                    timeout: 300,
+                    elevated: false,
+                    when: None,
+                    continue_on_error: false,
+                },
+                CommandEntry {
+                    run: "echo c".to_string(),
+                    description: None,
+                    timeout: 300,
+                    elevated: false,
+                    when: None,
+                    continue_on_error: false,
+                },
+            ]),
+        });
+        assert_eq!(workload.command_count(), 3);
+    }
+
+    #[test]
+    fn test_workload_without_commands_backward_compat() {
+        let yaml = r#"
+name: legacy
+version: "1.0.0"
+description: "No commands"
+packages:
+  winget:
+    - id: Git.Git
+"#;
+        let workload: Workload = serde_yaml::from_str(yaml).unwrap();
+        assert!(workload.commands.is_none());
+        assert_eq!(workload.command_count(), 0);
+        assert_eq!(workload.package_count(), 1);
+    }
+
+    #[test]
+    fn test_command_entry_all_fields() {
+        let yaml = r#"
+run: "npm install -g typescript"
+description: "Install TypeScript globally"
+timeout: 120
+elevated: true
+continue_on_error: true
+when:
+  type: command_exists
+  command: npm
+"#;
+        let cmd: CommandEntry = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cmd.run, "npm install -g typescript");
+        assert_eq!(
+            cmd.description.as_deref(),
+            Some("Install TypeScript globally")
+        );
+        assert_eq!(cmd.timeout, 120);
+        assert!(cmd.elevated);
+        assert!(cmd.continue_on_error);
+        assert!(cmd.when.is_some());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 mod assertions;
 mod cli;
+mod commands;
 mod conditions;
 mod config;
 mod operations;

--- a/src/operations/install.rs
+++ b/src/operations/install.rs
@@ -161,6 +161,45 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
         }
     }
 
+    // Deprecation warning: scripts alongside commands
+    if let (Some(commands), Some(scripts)) = (&workload.commands, &workload.scripts) {
+        let has_cmd_pre = commands
+            .pre_install
+            .as_ref()
+            .map(|c| !c.is_empty())
+            .unwrap_or(false);
+        let has_script_pre = scripts
+            .pre_install
+            .as_ref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false);
+        if has_cmd_pre && has_script_pre {
+            print_warning(
+                "Deprecation notice: `scripts.pre_install` is deprecated when used alongside \
+                 `commands.pre_install`. Migrate scripts to inline commands. \
+                 See docs/SPECIFICATION.md for details.",
+            );
+        }
+
+        let has_cmd_post = commands
+            .post_install
+            .as_ref()
+            .map(|c| !c.is_empty())
+            .unwrap_or(false);
+        let has_script_post = scripts
+            .post_install
+            .as_ref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false);
+        if has_cmd_post && has_script_post {
+            print_warning(
+                "Deprecation notice: `scripts.post_install` is deprecated when used alongside \
+                 `commands.post_install`. Migrate scripts to inline commands. \
+                 See docs/SPECIFICATION.md for details.",
+            );
+        }
+    }
+
     if !args.force && !args.dry_run && !confirm_installation(&workload)? {
         print_info("Installation cancelled by user");
         return Ok(());
@@ -168,6 +207,13 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
 
     // Initialize installation state
     let mut state = InstallationState::new(&workload.name, &workload.version);
+
+    // Run pre-install commands (skip if files_only)
+    let pre_cmd_summary = if !args.files_only {
+        run_pre_install_commands(&context, args)?
+    } else {
+        crate::commands::CommandSummary::new()
+    };
 
     // Run pre-installation scripts (skip if files_only)
     let mut pre_script_summary = ScriptExecutionSummary::new();
@@ -188,14 +234,24 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
         copy_files(&context, args)?;
     }
 
+    // Run post-install commands (skip if packages_only or files_only)
+    let post_cmd_summary = if !args.packages_only && !args.files_only {
+        run_post_install_commands(&context, args)?
+    } else {
+        crate::commands::CommandSummary::new()
+    };
+
     // Run post-installation scripts (skip if files_only)
     let mut post_script_summary = ScriptExecutionSummary::new();
     if !args.skip_scripts && !args.skip_post_scripts && !args.packages_only && !args.files_only {
         post_script_summary = run_post_install_scripts(&context, args)?;
     }
 
-    // Check if any scripts require reboot
+    // Check if any scripts or commands require reboot
     if pre_script_summary.requires_reboot || post_script_summary.requires_reboot {
+        summary.reboot_required = true;
+    }
+    if pre_cmd_summary.requires_reboot || post_cmd_summary.requires_reboot {
         summary.reboot_required = true;
     }
 
@@ -481,6 +537,110 @@ fn confirm_installation(workload: &Workload) -> Result<bool> {
     io::stdin().read_line(&mut input)?;
 
     Ok(input.trim().eq_ignore_ascii_case("y") || input.trim().eq_ignore_ascii_case("yes"))
+}
+
+/// Run pre-install inline commands
+fn run_pre_install_commands(
+    context: &OperationContext,
+    _args: &InstallArgs,
+) -> Result<crate::commands::CommandSummary> {
+    let commands = match &context.workload.commands {
+        Some(c) => c.pre_install.as_ref(),
+        None => return Ok(crate::commands::CommandSummary::new()),
+    };
+
+    let commands = match commands {
+        Some(c) if !c.is_empty() => c,
+        _ => return Ok(crate::commands::CommandSummary::new()),
+    };
+
+    if context.verbosity >= 1 {
+        println!();
+        print_info(&format!(
+            "Running {} pre-install command(s)...",
+            commands.len()
+        ));
+    }
+
+    let summary = crate::commands::execute_commands(
+        commands,
+        "pre_install",
+        context.verbosity >= 2,
+        context.dry_run,
+    );
+
+    if context.verbosity >= 1 {
+        print_command_summary(&summary, "Pre-install");
+    }
+
+    if !summary.is_successful() {
+        print_warning("Pre-install commands had failures");
+    }
+
+    Ok(summary)
+}
+
+/// Run post-install inline commands
+fn run_post_install_commands(
+    context: &OperationContext,
+    _args: &InstallArgs,
+) -> Result<crate::commands::CommandSummary> {
+    let commands = match &context.workload.commands {
+        Some(c) => c.post_install.as_ref(),
+        None => return Ok(crate::commands::CommandSummary::new()),
+    };
+
+    let commands = match commands {
+        Some(c) if !c.is_empty() => c,
+        _ => return Ok(crate::commands::CommandSummary::new()),
+    };
+
+    if context.verbosity >= 1 {
+        println!();
+        print_info(&format!(
+            "Running {} post-install command(s)...",
+            commands.len()
+        ));
+    }
+
+    let summary = crate::commands::execute_commands(
+        commands,
+        "post_install",
+        context.verbosity >= 2,
+        context.dry_run,
+    );
+
+    if context.verbosity >= 1 {
+        print_command_summary(&summary, "Post-install");
+    }
+
+    if !summary.is_successful() {
+        print_warning("Post-install commands had failures");
+    }
+
+    Ok(summary)
+}
+
+/// Print a brief command execution summary
+fn print_command_summary(summary: &crate::commands::CommandSummary, phase: &str) {
+    if summary.total == 0 {
+        return;
+    }
+
+    if summary.is_successful() {
+        print_success(&format!(
+            "{} commands complete ({} succeeded, {} skipped, {:.1}s total)",
+            phase,
+            summary.succeeded,
+            summary.skipped,
+            summary.total_duration.as_secs_f64()
+        ));
+    } else {
+        print_warning(&format!(
+            "{} commands: {} succeeded, {} failed, {} skipped",
+            phase, summary.succeeded, summary.failed, summary.skipped
+        ));
+    }
 }
 
 /// Run pre-installation scripts with enhanced output and tracking

--- a/src/operations/validate.rs
+++ b/src/operations/validate.rs
@@ -779,6 +779,14 @@ fn print_json_schema() -> Result<()> {
         }
       }
     },
+    "commands": {
+      "type": "object",
+      "description": "Inline command definitions",
+      "properties": {
+        "pre_install": { "$ref": "#/definitions/commandList" },
+        "post_install": { "$ref": "#/definitions/commandList" }
+      }
+    },
     "environment": {
       "type": "object",
       "properties": {
@@ -866,6 +874,48 @@ fn print_json_schema() -> Result<()> {
             "minimum": 5,
             "maximum": 3600,
             "description": "Timeout in seconds"
+          }
+        }
+      }
+    },
+    "commandList": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["run"],
+        "properties": {
+          "run": {
+            "type": "string",
+            "description": "Shell command string to execute"
+          },
+          "description": { "type": "string" },
+          "timeout": {
+            "type": "integer",
+            "default": 300,
+            "minimum": 1,
+            "maximum": 3600,
+            "description": "Timeout in seconds"
+          },
+          "elevated": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the command requires admin privileges"
+          },
+          "when": {
+            "type": "object",
+            "description": "Condition that must be true for this command to run (uses condition engine types)",
+            "required": ["type"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["command_exists", "file_exists", "dir_exists", "env_var", "path_contains", "registry_value", "shell", "all_of", "any_of"]
+              }
+            }
+          },
+          "continue_on_error": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to continue if this command fails"
           }
         }
       }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -410,6 +410,31 @@ mod install_command {
             .assert()
             .success();
     }
+
+    #[test]
+    fn install_deprecation_warning_when_commands_and_scripts_coexist() {
+        let temp = TempDir::new().unwrap();
+        common::create_workload_with_commands_and_scripts(temp.path(), "coexist-test").unwrap();
+        let workload_path = temp.path().join("coexist-test");
+
+        // When both commands and scripts exist for the same phase, stderr should contain deprecation warnings
+        anvil()
+            .args([
+                "install",
+                workload_path.to_str().unwrap(),
+                "--dry-run",
+                "--skip-scripts",
+                "--skip-packages",
+            ])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains(
+                "scripts.pre_install` is deprecated when used alongside `commands.pre_install`",
+            ))
+            .stderr(predicate::str::contains(
+                "scripts.post_install` is deprecated when used alongside `commands.post_install`",
+            ));
+    }
 }
 
 mod health_command {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -458,6 +458,56 @@ exit 0
     Ok(())
 }
 
+/// Create a workload with both commands and scripts for testing
+/// the deprecation warning when both coexist
+#[allow(dead_code)]
+pub fn create_workload_with_commands_and_scripts(dir: &Path, name: &str) -> std::io::Result<()> {
+    let workload_dir = dir.join(name);
+    let scripts_dir = workload_dir.join("scripts");
+    fs::create_dir_all(&scripts_dir)?;
+
+    let yaml = format!(
+        r#"name: {name}
+version: "1.0.0"
+description: "Workload with both commands and scripts"
+
+commands:
+  pre_install:
+    - run: echo pre-install command
+      description: "Pre-install command"
+  post_install:
+    - run: echo post-install command
+      description: "Post-install command"
+
+scripts:
+  pre_install:
+    - path: pre-install.ps1
+      description: "Legacy pre-install script"
+  post_install:
+    - path: post-install.ps1
+      description: "Legacy post-install script"
+"#
+    );
+
+    fs::write(workload_dir.join("workload.yaml"), yaml)?;
+    fs::write(
+        scripts_dir.join("pre-install.ps1"),
+        r#"# Pre-install script
+Write-Host "Pre-install running..."
+exit 0
+"#,
+    )?;
+    fs::write(
+        scripts_dir.join("post-install.ps1"),
+        r#"# Post-install script
+Write-Host "Post-install running..."
+exit 0
+"#,
+    )?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Description

Add a `commands:` block to the workload schema for inline command execution with conditional support, replacing the need for separate script files for simple post-install actions.

### What's included

- **Commands schema** — New `commands.pre_install` and `commands.post_install` phases in workload YAML, each entry with `run` (shell string), `description`, `timeout`, `elevated`, `when` (condition from the predicate engine), and `continue_on_error`
- **Command executor** — Execution engine that evaluates `when:` conditions before running, enforces timeouts, captures stdout/stderr, and stops on first failure (unless `continue_on_error` is set)
- **Install flow integration** — Commands run before legacy scripts in each phase (pre-install commands → pre-install scripts → packages → files → post-install commands → post-install scripts)
- **Failure semantics** — Documented in SPECIFICATION.md: sequential execution, stop-on-failure default, output capture rules, timeout behavior, elevation requirements
- **Backward compatibility** — Deprecation warning when `scripts.pre_install`/`scripts.post_install` is used alongside `commands`; documented migration path and timeline (v0.6→v0.8→v1.0)
- **Schema validation** — Command entries validated during `anvil validate` (non-empty run, positive timeout, condition structure)
- **Inheritance** — Commands merge through workload inheritance (parent first, child appended)

Example usage:
`yaml
commands:
  post_install:
    - run: rustup default stable
      description: "Set stable as default toolchain"
    - run: cargo install cargo-watch
      timeout: 900
      when:
        type: command_exists
        command: cargo
`

## Related Issues

Closes #15, Closes #16, Closes #17, Closes #18

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (344 tests: 262 unit + 82 integration)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)