### PR TITLE
feat: add documentation website, cross-platform CI, and configurable search paths

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ cargo fmt                    # Auto-format
 
 Anvil is a declarative workstation configuration tool. Users define environments in YAML workload files; Anvil installs packages (currently via winget, with cross-platform package managers planned), copies files, runs scripts, and validates system health.
 
-See `docs/ARCHITECTURE.md` for the full internal architecture reference.
+See `docs/src/architecture.md` for the full internal architecture reference.
 
 ### Module layout
 
@@ -91,9 +91,9 @@ Create `examples/<name>/workload.yaml` (plus optional `files/` and `scripts/`). 
 
 ## Key References
 
-- `docs/SPECIFICATION.md` — Project spec, workload schema, and roadmap (v0.4–v1.0)
-- `docs/ARCHITECTURE.md` — Internal code architecture for contributors
-- `docs/USER_GUIDE.md` — End-user CLI usage guide
-- `docs/WORKLOAD_AUTHORING.md` — Workload YAML authoring reference
+- `docs/src/specification.md` — Project spec, workload schema, and roadmap (v0.4–v1.0)
+- `docs/src/architecture.md` — Internal code architecture for contributors
+- `docs/src/user-guide.md` — End-user CLI usage guide
+- `docs/src/workload-authoring.md` — Workload YAML authoring reference
 - `CONTRIBUTING.md` — Contribution workflow and coding standards
 - `CHANGELOG.md` — Release history

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,9 @@ jobs:
       - name: Verify required docs exist
         run: |
           test -f README.md
-          test -f docs/USER_GUIDE.md
-          test -f docs/WORKLOAD_AUTHORING.md
-          test -f docs/TROUBLESHOOTING.md
+          test -f docs/src/user-guide.md
+          test -f docs/src/workload-authoring.md
+          test -f docs/src/troubleshooting.md
 
   ci-pass:
     name: CI Pass

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ workloads/
 # Temporary files
 tmp/
 
+# mdBook build output
+docs/book/
+
 # Cargo lock should be committed for applications
 # but uncomment if this is a library
 # Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search precedence with conflict resolution: explicit path > user-configured > defaults; first match wins
 - `anvil list --all-paths` to show all discovered paths including shadowed duplicates
 - Cross-platform release builds for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64)
+- Documentation website powered by mdBook, served at [anvil.kafkade.com](https://anvil.kafkade.com)
 
 ### Changed
 - Crate renamed to `anvil-cli` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-cli`)
+- Tracing/log output now writes to stderr instead of stdout, preventing pollution of structured output (JSON, YAML)
+
+### Fixed
+- Integration tests no longer fail on Linux and macOS due to winget-dependent tests running on non-Windows platforms
 
 ### Deprecated
 - `scripts.health_check` when used alongside `assertions` (migrate to declarative assertions; removal planned for v1.0)

--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Global Options:
 
 | Document | Description |
 |----------|-------------|
-| [User Guide](docs/USER_GUIDE.md) | Complete usage instructions |
-| [Workload Authoring](docs/WORKLOAD_AUTHORING.md) | Creating custom workloads |
-| [Troubleshooting](docs/TROUBLESHOOTING.md) | Common issues and solutions |
-| [Specification](docs/SPECIFICATION.md) | Technical spec and roadmap |
-| [Architecture](docs/ARCHITECTURE.md) | Internal code architecture |
+| [User Guide](https://anvil.kafkade.com/user-guide.html) | Complete usage instructions |
+| [Workload Authoring](https://anvil.kafkade.com/workload-authoring.html) | Creating custom workloads |
+| [Troubleshooting](https://anvil.kafkade.com/troubleshooting.html) | Common issues and solutions |
+| [Specification](https://anvil.kafkade.com/specification.html) | Technical spec and roadmap |
+| [Architecture](https://anvil.kafkade.com/architecture.html) | Internal code architecture |
 | [Contributing](CONTRIBUTING.md) | Contribution guidelines |
 | [Changelog](CHANGELOG.md) | Version history |
 
@@ -163,7 +163,7 @@ Global Options:
 - [Windows Package Manager (winget)](https://github.com/microsoft/winget-cli)
 - PowerShell 5.1 or later
 
-> Cross-platform support (macOS via Homebrew, Linux via APT) is on the [roadmap](docs/SPECIFICATION.md#8-roadmap).
+> Cross-platform support (macOS via Homebrew, Linux via APT) is on the [roadmap](https://anvil.kafkade.com/specification.html#8-roadmap).
 
 ## 🛠️ Building from Source
 

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,30 @@
+[book]
+authors = ["Kafkade"]
+language = "en"
+src = "docs/src"
+title = "Anvil Documentation"
+description = "Declarative Workstation Configuration Management"
+
+[build]
+build-dir = "docs/book"
+
+[output.html]
+default-theme = "navy"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/kafkade/anvil"
+edit-url-template = "https://github.com/kafkade/anvil/edit/main/{path}"
+site-url = "https://anvil.kafkade.com/"
+cname = "anvil.kafkade.com"
+no-section-label = false
+additional-css = ["docs/theme/custom.css"]
+
+[output.html.search]
+enable = true
+limit-results = 30
+
+[output.html.playground]
+editable = false
+
+[output.html.fold]
+enable = true
+level = 1

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,21 @@
+# Summary
+
+[Introduction](introduction.md)
+
+---
+
+# User Guide
+
+- [Getting Started](user-guide.md)
+- [Workload Authoring](workload-authoring.md)
+- [Troubleshooting](troubleshooting.md)
+
+# Reference
+
+- [Specification](specification.md)
+- [Architecture](architecture.md)
+- [Changelog](changelog.md)
+
+# Development
+
+- [Contributing](contributing.md)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes Anvil's internal architecture for contributors. For user-facing documentation, see the [User Guide](USER_GUIDE.md). For the project vision and roadmap, see the [Specification](SPECIFICATION.md).
+This document describes Anvil's internal architecture for contributors. For user-facing documentation, see the [User Guide](user-guide.md). For the project vision and roadmap, see the [Specification](specification.md).
 
 ## Overview
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,0 +1,141 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Declarative assertions for workload health validation (`assertions:` field in workload YAML)
+- Condition engine with 9 predicate types: `command_exists`, `file_exists`, `dir_exists`, `env_var`, `path_contains`, `registry_value`, `shell`, plus `all_of`/`any_of` composition
+- `--assertions-only` flag for `anvil health` to run only assertion checks
+- `assertion_check` toggle in workload health configuration
+- Assertion examples in `anvil init --template full` scaffold
+- Multi-manager workload schema: `packages.brew` (Homebrew) and `packages.apt` (APT) fields alongside existing `packages.winget`
+- Platform-aware validation warns when workload references an unavailable package manager
+- Inline `commands:` block for workload command execution with `pre_install` and `post_install` phases
+- Conditional command execution via `when:` field using the predicate engine
+- `continue_on_error` option for commands that should not block the install flow
+- Configurable workload search paths via `~/.anvil/config.yaml` (user paths prepended to defaults)
+- Search precedence with conflict resolution: explicit path > user-configured > defaults; first match wins
+- `anvil list --all-paths` to show all discovered paths including shadowed duplicates
+- Cross-platform release builds for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64)
+
+### Changed
+- Crate renamed to `anvil-cli` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-cli`)
+
+### Deprecated
+- `scripts.health_check` when used alongside `assertions` (migrate to declarative assertions; removal planned for v1.0)
+- `scripts.pre_install` and `scripts.post_install` when used alongside `commands` (migrate to inline commands; removal planned for v1.0)
+
+## [0.5.0] - 2026-04-17
+
+This is the first release from the new repository home at [kafkade/anvil](https://github.com/kafkade/anvil). It marks a fresh start with modernized CI/CD, updated documentation, and a clear cross-platform direction. Prior changelog entries (v0.1.0–v0.3.1) are preserved below for historical context.
+
+### Added
+- Architecture reference document for contributors (`docs/ARCHITECTURE.md`)
+- Automated releases from CHANGELOG.md with SHA256 checksums
+- Consolidated CI pipeline with formatting, linting, and testing in a single gate
+
+### Changed
+- Project rebranded to "Declarative Workstation Configuration Management" to reflect cross-platform direction
+- Streamlined CI from 3 separate jobs to a single `Validate` gate plus release build
+- Release workflow aligned with org-wide pattern (changelog-driven notes, semver pre-release detection)
+- Resolved all clippy warnings and formatting issues across the codebase
+
+## [0.3.1] - 2026-01-10
+
+### Added
+- Comprehensive user documentation (USER_GUIDE.md)
+- Workload authoring guide (WORKLOAD_AUTHORING.md)
+- Troubleshooting guide (TROUBLESHOOTING.md)
+- Integration test suite for CLI commands
+- GitHub Actions CI/CD workflows
+- Shell completion generation for PowerShell, Bash, Zsh, and Fish
+- CONTRIBUTING.md with contribution guidelines
+
+### Changed
+- Improved error messages throughout CLI
+- Enhanced validation reporting with detailed messages
+- Updated README with badges and clearer instructions
+
+### Fixed
+- Various documentation typos and inconsistencies
+
+## [0.3.0] - 2026-01-08
+
+### Added
+- Shell completions command for multiple shells
+- Global configuration management (`config` command)
+- Backup management with create, list, show, restore, clean, and verify subcommands
+- Status command to show installation state
+- HTML output format for health reports
+- `--strict` flag for validation command
+- Environment variable configuration in workloads
+- PATH additions support in workloads
+
+### Changed
+- Improved inheritance resolution algorithm
+- Enhanced output formatting for all commands
+- Better progress indicators during installation
+
+## [0.2.0] - 2026-01-05
+
+### Added
+- Script execution support with PowerShell and CMD
+- Pre-install and post-install script hooks
+- Health check script execution
+- Elevated privilege handling for scripts
+- Configurable script timeouts
+- Template processing with Handlebars
+- File integrity verification with SHA-256 checksums
+- Automatic backup creation before file overwrites
+- Variable expansion in paths (`~`, `${HOME}`, etc.)
+
+### Changed
+- Improved file operation error handling
+- Enhanced dry-run output with detailed plan
+
+### Fixed
+- Path expansion on Windows with backslashes
+- File permission handling on Windows
+
+## [0.1.0] - 2026-01-01
+
+### Added
+- Initial release of Anvil
+- Core CLI commands: install, health, list, show, validate, init
+- Package management via winget integration
+  - Install packages with version pinning
+  - Custom winget arguments support
+  - Package health verification
+- File operations
+  - Copy files to target locations
+  - Path variable expansion
+- Workload system
+  - YAML-based workload definitions
+  - Workload inheritance and composition
+  - Circular dependency detection
+- Multiple output formats
+  - Table (default, human-readable)
+  - JSON (machine-readable)
+  - YAML
+- Bundled workloads
+  - essentials: Core development tools (VS Code, Git, Windows Terminal, Oh My Posh) and productivity utilities
+  - rust-developer: Rust toolchain with cargo tools (extends essentials)
+  - python-developer: Python with uv package manager (extends essentials)
+
+### Documentation
+- Initial specification document
+- Phase development prompts
+
+---
+
+[Unreleased]: https://github.com/kafkade/anvil/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/kafkade/anvil/compare/v0.3.1...v0.5.0
+[0.3.1]: https://github.com/kafkade/anvil/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/kafkade/anvil/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/kafkade/anvil/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/kafkade/anvil/releases/tag/v0.1.0

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,24 +1,12 @@
-# Contributing to Anvil
+# Contributing
 
 Thank you for your interest in contributing to Anvil! This document provides guidelines and instructions for contributing to the project.
-
-## Table of Contents
-
-- [Code of Conduct](#code-of-conduct)
-- [How to Contribute](#how-to-contribute)
-- [Development Setup](#development-setup)
-- [Project Structure](#project-structure)
-- [Coding Standards](#coding-standards)
-- [Testing](#testing)
-- [Submitting Changes](#submitting-changes)
-- [Creating Workloads](#creating-workloads)
-- [License](#license)
 
 ---
 
 ## Code of Conduct
 
-This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). Please be respectful and constructive in all interactions.
+This project follows the [Contributor Covenant Code of Conduct](https://github.com/kafkade/anvil/blob/main/CODE_OF_CONDUCT.md). Please be respectful and constructive in all interactions.
 
 ---
 
@@ -203,11 +191,16 @@ anvil/
 │   └── common/
 │       └── mod.rs
 └── docs/                    # Documentation
-    ├── SPECIFICATION.md
-    ├── ARCHITECTURE.md
-    ├── USER_GUIDE.md
-    ├── WORKLOAD_AUTHORING.md
-    └── TROUBLESHOOTING.md
+    └── src/
+        ├── SUMMARY.md
+        ├── introduction.md
+        ├── user-guide.md
+        ├── workload-authoring.md
+        ├── troubleshooting.md
+        ├── specification.md
+        ├── architecture.md
+        ├── changelog.md
+        └── contributing.md
 ```
 
 ### Key Modules
@@ -387,7 +380,7 @@ fn new_command_works() {
 
 ## Creating Workloads
 
-Contributions of new bundled workloads are welcome! See the [Workload Authoring Guide](docs/src/workload-authoring.md) for details.
+Contributions of new bundled workloads are welcome! See the [Workload Authoring](workload-authoring.md) guide for details.
 
 ### Workload Guidelines
 
@@ -432,14 +425,14 @@ scripts:
 
 ## License
 
-By contributing to Anvil, you agree that your contributions will be licensed under the [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE) license, at the user's choice.
+By contributing to Anvil, you agree that your contributions will be licensed under the [MIT](https://github.com/kafkade/anvil/blob/main/LICENSE-MIT) or [Apache-2.0](https://github.com/kafkade/anvil/blob/main/LICENSE-APACHE) license, at the user's choice.
 
 ---
 
 ## Questions?
 
 - Open a [Discussion](https://github.com/kafkade/anvil/discussions)
-- Check the [Documentation](docs/)
+- Check the [Documentation](https://anvil.kafkade.com/)
 - Review existing [Issues](https://github.com/kafkade/anvil/issues)
 
-Thank you for contributing to Anvil! 🎉
+Thank you for contributing to Anvil!

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,55 @@
+# Anvil
+
+**Declarative Workstation Configuration Management**
+
+Anvil is a configuration management tool that lets you define your development
+environment in YAML. Describe the packages, configuration files, scripts, and
+environment variables your workstation needs, and Anvil takes care of the rest —
+installing software, deploying dotfiles, running setup scripts, and validating
+that everything is healthy.
+
+## Key Features
+
+- **Package management** — install software via winget with version pinning (Homebrew and APT planned)
+- **File synchronization** — deploy configuration files with automatic backup and integrity checks
+- **Script execution** — run PowerShell setup and validation scripts with timeout and elevation support
+- **Workload inheritance** — compose configurations with DRY principles using `extends`
+- **Health checks** — validate that the live system matches your workload definition
+- **Multiple output formats** — table, JSON, YAML, and HTML reports
+- **Backup and restore** — snapshot and roll back system state
+- **Shell completions** — tab completion for PowerShell, Bash, Zsh, and Fish
+
+## Quick Install
+
+```sh
+# From crates.io (requires Rust 1.75+)
+cargo install anvil-cli
+```
+
+Or download a pre-built binary from the
+[Releases](https://github.com/kafkade/anvil/releases) page.
+
+## Quick Start
+
+```sh
+# List available workloads
+anvil list
+
+# Preview what an install would do
+anvil install rust-developer --dry-run
+
+# Install a workload
+anvil install rust-developer
+
+# Verify system health
+anvil health rust-developer
+```
+
+## Learn More
+
+- Read the **[User Guide](user-guide.md)** for complete usage instructions.
+- See **[Workload Authoring](workload-authoring.md)** to create your own workloads.
+- Check the **[Troubleshooting](troubleshooting.md)** guide if you run into issues.
+- Review the **[Specification](specification.md)** for the technical design and roadmap.
+- Explore the **[Architecture](architecture.md)** docs to understand the codebase.
+- Want to help? Read the **[Contributing](contributing.md)** guide.

--- a/docs/src/specification.md
+++ b/docs/src/specification.md
@@ -1,26 +1,8 @@
-# Anvil - Declarative Workstation Configuration Management
-
-## Specification Document
+# Specification
 
 **Version:** 2.0.0  
 **Status:** Active  
 **Last Updated:** 2026-04-16
-
----
-
-## Table of Contents
-
-1. [Executive Summary](#1-executive-summary)
-2. [Technology Analysis](#2-technology-analysis)
-3. [Technology Recommendation](#3-technology-recommendation)
-4. [Project Structure](#4-project-structure)
-5. [Workload Definition Schema](#5-workload-definition-schema)
-6. [CLI Interface Design](#6-cli-interface-design)
-7. [Core Components](#7-core-components)
-8. [Implementation Roadmap](#8-implementation-roadmap)
-9. [Appendices](#9-appendices)
-
----
 
 ## 1. Executive Summary
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,19 +1,6 @@
-# Troubleshooting Guide
+# Troubleshooting
 
 A guide to diagnosing and resolving common Anvil issues.
-
-## Table of Contents
-
-1. [Installation Issues](#1-installation-issues)
-2. [Package Installation Issues](#2-package-installation-issues)
-3. [File Operation Issues](#3-file-operation-issues)
-4. [Script Execution Issues](#4-script-execution-issues)
-5. [Health Check Issues](#5-health-check-issues)
-6. [Configuration Issues](#6-configuration-issues)
-7. [Error Reference](#7-error-reference)
-8. [Getting Help](#8-getting-help)
-
----
 
 ## 1. Installation Issues
 

--- a/docs/src/user-guide.md
+++ b/docs/src/user-guide.md
@@ -1,21 +1,6 @@
-# Anvil User Guide
+# User Guide
 
 A comprehensive guide to using Anvil for workstation configuration management.
-
-## Table of Contents
-
-1. [Introduction](#1-introduction)
-2. [Installation](#2-installation)
-3. [Quick Start](#3-quick-start)
-4. [Command Reference](#4-command-reference)
-5. [Configuration](#5-configuration)
-6. [Configuring Workload Search Paths](#6-configuring-workload-search-paths)
-7. [Working with Workloads](#7-working-with-workloads)
-8. [Output Formats](#8-output-formats)
-9. [Environment Variables](#9-environment-variables)
-10. [Best Practices](#10-best-practices)
-
----
 
 ## 1. Introduction
 

--- a/docs/src/workload-authoring.md
+++ b/docs/src/workload-authoring.md
@@ -1,23 +1,6 @@
-# Workload Authoring Guide
+# Workload Authoring
 
 A comprehensive guide to creating custom workloads for Anvil.
-
-## Table of Contents
-
-1. [Workload Structure](#1-workload-structure)
-2. [Schema Reference](#2-schema-reference)
-3. [Package Definitions](#3-package-definitions)
-4. [File Definitions](#4-file-definitions)
-5. [Script Definitions](#5-script-definitions)
-6. [Environment Configuration](#6-environment-configuration)
-7. [Assertions](#7-assertions)
-8. [Inheritance](#8-inheritance)
-9. [Variable Expansion](#9-variable-expansion)
-10. [Best Practices](#10-best-practices)
-11. [Example Workloads](#11-example-workloads)
-12. [Private Workload Repositories](#12-private-workload-repositories)
-
----
 
 ## 1. Workload Structure
 

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,0 +1,42 @@
+/* Anvil documentation theme */
+
+:root {
+    --sidebar-width: 280px;
+}
+
+/* Improve readability */
+.content main {
+    max-width: 48rem;
+}
+
+/* Style the landing page */
+.content main h1:first-child {
+    font-size: 2.2em;
+    margin-bottom: 0.3em;
+}
+
+/* Code block improvements */
+pre {
+    border-radius: 6px;
+}
+
+code {
+    border-radius: 3px;
+    padding: 0.1em 0.3em;
+}
+
+/* Table improvements */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1em 0;
+}
+
+table th {
+    text-align: left;
+    font-weight: 600;
+}
+
+table td, table th {
+    padding: 0.5em 1em;
+}

--- a/src/operations/health.rs
+++ b/src/operations/health.rs
@@ -63,7 +63,7 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
     if has_assertions && has_health_check_scripts {
         print_warning(
             "Deprecation notice: `scripts.health_check` is deprecated when used alongside `assertions`. \
-             Migrate health check scripts to declarative assertions. See docs/SPECIFICATION.md for details.",
+             Migrate health check scripts to declarative assertions. See docs/src/specification.md for details.",
         );
     }
 

--- a/src/operations/install.rs
+++ b/src/operations/install.rs
@@ -177,7 +177,7 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
             print_warning(
                 "Deprecation notice: `scripts.pre_install` is deprecated when used alongside \
                  `commands.pre_install`. Migrate scripts to inline commands. \
-                 See docs/SPECIFICATION.md for details.",
+                 See docs/src/specification.md for details.",
             );
         }
 
@@ -195,7 +195,7 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
             print_warning(
                 "Deprecation notice: `scripts.post_install` is deprecated when used alongside \
                  `commands.post_install`. Migrate scripts to inline commands. \
-                 See docs/SPECIFICATION.md for details.",
+                 See docs/src/specification.md for details.",
             );
         }
     }


### PR DESCRIPTION
## Description

Add cross-platform CI validation, configurable workload search paths, and an mdBook documentation website.

### What's included

- **Cross-platform CI** — Validation matrix now runs on `windows-latest`, `ubuntu-latest`, and `macos-latest`; release workflow builds for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64)
- **Configurable workload search paths** — User-configured paths from `~/.anvil/config.yaml` are prepended to defaults with first-match-wins precedence; `anvil list --all-paths` shows all discovered paths including shadowed duplicates
- **mdBook documentation site** — Full documentation website at [anvil.kafkade.com](https://anvil.kafkade.com) with landing page, search, custom theme, and all existing docs migrated to `docs/src/`
- **Tracing fix** — Log output now writes to stderr instead of stdout, preventing pollution of structured output (JSON/YAML)
- **Cross-platform test fix** — Winget-dependent integration tests are gated with `#[cfg(target_os = "windows")]`

## Related Issues

Closes #25

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] CI / infrastructure
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactoring (no functional changes)
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)