### PR TITLE
docs: add branding, logo, and website redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# Anvil
+<p align="center">
+  <img src="docs/assets/anvil-logo.svg" alt="Anvil" width="120" height="120">
+</p>
 
-[![CI](https://github.com/kafkade/anvil/actions/workflows/ci.yml/badge.svg)](https://github.com/kafkade/anvil/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/kafkade/anvil)](https://github.com/kafkade/anvil/releases)
-[![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
-[![Rust](https://img.shields.io/badge/rust-1.75%2B-orange.svg)](https://www.rust-lang.org/)
+<h1 align="center">Anvil</h1>
 
-**Declarative Workstation Configuration Management**
+<p align="center">
+  <a href="https://github.com/kafkade/anvil/actions/workflows/ci.yml"><img src="https://github.com/kafkade/anvil/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/kafkade/anvil/releases"><img src="https://img.shields.io/github/v/release/kafkade/anvil" alt="Release"></a>
+  <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0"></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.75%2B-orange.svg" alt="Rust"></a>
+  <a href="https://github.com/sponsors/kafkade"><img src="https://img.shields.io/badge/sponsor-♥-ea4aaa.svg" alt="Sponsor"></a>
+</p>
+
+<p align="center"><strong>Declarative Workstation Configuration Management</strong></p>
 
 Anvil is a declarative configuration management tool for developer workstations. Define your development environment in YAML, and Anvil will install packages, copy configuration files, run setup scripts, and verify system health. Currently supports Windows (winget), with cross-platform support planned.
 

--- a/book.toml
+++ b/book.toml
@@ -2,15 +2,16 @@
 authors = ["Kafkade"]
 language = "en"
 src = "docs/src"
-title = "Anvil Documentation"
+title = "Anvil Docs"
 description = "Declarative Workstation Configuration Management"
 
 [build]
 build-dir = "docs/book"
 
 [output.html]
-default-theme = "navy"
-preferred-dark-theme = "navy"
+default-theme = "ayu"
+preferred-dark-theme = "ayu"
+theme = "docs/theme"
 git-repository-url = "https://github.com/kafkade/anvil"
 edit-url-template = "https://github.com/kafkade/anvil/edit/main/{path}"
 site-url = "https://anvil.kafkade.com/"

--- a/docs/assets/anvil-logo.svg
+++ b/docs/assets/anvil-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-labelledby="icon-title icon-desc">
+  <title id="icon-title">Anvil</title>
+  <desc id="icon-desc">Anvil logo — a forged letter A in molten gradient</desc>
+  <defs>
+    <linearGradient id="forge" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#dc2626"/>
+      <stop offset="35%" stop-color="#f97316"/>
+      <stop offset="70%" stop-color="#fbbf24"/>
+      <stop offset="100%" stop-color="#fef3c7"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="30%">
+      <stop offset="0%" stop-color="#fef3c7" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#fef3c7" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <circle cx="100" cy="90" r="75" fill="url(#glow)"/>
+  <g transform="translate(100, 105)">
+    <path d="M-56 65 L-10 -65 Q0 -82 10 -65 L56 65 L34 65 L18 16 L-18 16 L-34 65 Z" fill="url(#forge)"/>
+    <rect x="-24" y="0" width="48" height="16" rx="2" fill="#991b1b"/>
+    <path d="M-12 16 L0 -32 L12 16 Z" fill="#0f172a"/>
+  </g>
+</svg>

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -53,3 +53,7 @@ anvil health rust-developer
 - Review the **[Specification](specification.md)** for the technical design and roadmap.
 - Explore the **[Architecture](architecture.md)** docs to understand the codebase.
 - Want to help? Read the **[Contributing](contributing.md)** guide.
+
+---
+
+*If Anvil saves you time, consider [sponsoring the project](https://github.com/sponsors/kafkade).*

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,42 +1,256 @@
-/* Anvil documentation theme */
+/* Anvil documentation theme — modern, clean design */
+
+/* ===== Fonts ===== */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lilex:wght@400;500&family=Space+Grotesk:wght@600;700&display=swap');
 
 :root {
     --sidebar-width: 280px;
+    font-size: 18px !important;
 }
 
-/* Improve readability */
+/* ===== Base typography ===== */
+html {
+    font-size: 18px !important;
+}
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-size: 18px !important;
+}
+
 .content main {
-    max-width: 48rem;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
+    max-width: 50rem;
+    font-size: 18px !important;
+    letter-spacing: -0.011em;
+    line-height: 1.75;
 }
 
-/* Style the landing page */
+.content main p,
+.content main li,
+.content main td,
+.content main dd {
+    font-size: 18px !important;
+    line-height: 1.75;
+}
+
+/* ===== Headings ===== */
+.content main h1 {
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
+    font-weight: 700;
+    font-size: 36px !important;
+    letter-spacing: -0.03em;
+    margin-top: 1.5em;
+    margin-bottom: 0.4em;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
 .content main h1:first-child {
-    font-size: 2.2em;
-    margin-bottom: 0.3em;
+    font-size: 42px !important;
+    margin-top: 0;
 }
 
-/* Code block improvements */
-pre {
-    border-radius: 6px;
+.content main h2 {
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
+    font-weight: 600;
+    font-size: 28px !important;
+    letter-spacing: -0.02em;
+    margin-top: 2em;
+    margin-bottom: 0.5em;
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid var(--table-border-color);
 }
 
+.content main h3 {
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
+    font-weight: 600;
+    font-size: 22px !important;
+    letter-spacing: -0.01em;
+    margin-top: 1.6em;
+    margin-bottom: 0.4em;
+}
+
+.content main h4 {
+    font-weight: 600;
+    font-size: 19px !important;
+    margin-top: 1.4em;
+}
+
+/* ===== Paragraphs & lists ===== */
+.content main p {
+    margin-bottom: 1em;
+}
+
+.content main ul, .content main ol {
+    margin-bottom: 1em;
+    padding-left: 1.5em;
+}
+
+.content main li {
+    margin-bottom: 0.35em;
+}
+
+.content main li > p {
+    margin-bottom: 0.5em;
+}
+
+.content main strong {
+    font-weight: 600;
+}
+
+/* ===== Code ===== */
 code {
-    border-radius: 3px;
-    padding: 0.1em 0.3em;
+    font-family: 'Lilex', 'Cascadia Code', 'Fira Code', monospace !important;
+    font-size: 16px !important;
+    border-radius: 4px;
+    padding: 0.15em 0.35em;
 }
 
-/* Table improvements */
+pre {
+    border-radius: 8px;
+    padding: 1em 1.2em;
+    font-size: 16px !important;
+    line-height: 1.6;
+    border: 1px solid var(--table-border-color);
+}
+
+pre > code {
+    font-size: 16px !important;
+    padding: 0;
+}
+
+/* ===== Tables ===== */
 table {
     width: 100%;
     border-collapse: collapse;
-    margin: 1em 0;
+    margin: 1.2em 0;
+    font-size: 0.95em;
 }
 
 table th {
     text-align: left;
     font-weight: 600;
+    padding: 0.6em 1em;
+    font-size: 18px !important;
+    border-bottom: 2px solid var(--table-border-color);
 }
 
-table td, table th {
+table td {
+    padding: 0.55em 1em;
+    font-size: 18px !important;
+    border-bottom: 1px solid var(--table-border-color);
+}
+
+table tr:last-child td {
+    border-bottom: none;
+}
+
+/* ===== Sidebar ===== */
+.sidebar .sidebar-scrollbox {
+    padding-top: 1.5em;
+}
+
+.sidebar ol.chapter {
+    padding-left: 0;
+}
+
+.sidebar ol.chapter li a {
+    font-size: 16px !important;
+    font-weight: 500;
+    padding: 0.35em 1.2em;
+    border-radius: 4px;
+    transition: background-color 0.15s ease;
+}
+
+.sidebar ol.chapter li a:hover {
+    text-decoration: none;
+}
+
+.sidebar .chapter-item {
+    line-height: 1.8;
+}
+
+.sidebar-separator {
+    margin: 0.5em 0;
+}
+
+/* ===== Sidebar logo ===== */
+.sidebar .sidebar-scrollbox {
+    padding-top: 0.5em;
+}
+
+.sidebar .sidebar-scrollbox::before {
+    content: 'Anvil';
+    display: block;
+    text-align: center;
+    font-size: 1.15em;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1em;
+    padding-top: 72px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64' width='64' height='64'%3E%3Cdefs%3E%3ClinearGradient id='forge-sm' x1='0%25' y1='100%25' x2='0%25' y2='0%25'%3E%3Cstop offset='0%25' stop-color='%23dc2626'/%3E%3Cstop offset='35%25' stop-color='%23f97316'/%3E%3Cstop offset='70%25' stop-color='%23fbbf24'/%3E%3Cstop offset='100%25' stop-color='%23fef3c7'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cg transform='translate(32, 35)'%3E%3Cpath d='M-22 25 L-4 -25 Q0 -32 4 -25 L22 25 L14 25 L8 6 L-8 6 L-14 25 Z' fill='url(%23forge-sm)'/%3E%3Crect x='-10' y='0' width='20' height='6' rx='1' fill='%23991b1b'/%3E%3Cpath d='M-5 6 L0 -12 L5 6 Z' fill='%230f172a'/%3E%3C/g%3E%3C/svg%3E");
+    background-size: 64px 64px;
+    background-repeat: no-repeat;
+    background-position: center top;
+    opacity: 0.9;
+}
+
+/* ===== Links ===== */
+.content main a {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    transition: opacity 0.15s ease;
+}
+
+.content main a:hover {
+    opacity: 0.8;
+}
+
+/* ===== Blockquotes ===== */
+blockquote {
+    border-left: 3px solid var(--links);
     padding: 0.5em 1em;
+    margin: 1em 0;
+    border-radius: 0 4px 4px 0;
+    font-size: 0.95em;
+}
+
+/* ===== Horizontal rules ===== */
+hr {
+    border: none;
+    border-top: 1px solid var(--table-border-color);
+    margin: 2em 0;
+}
+
+/* ===== Search ===== */
+#searchbar {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    border-radius: 6px;
+    font-size: 16px !important;
+}
+
+/* ===== Navigation buttons ===== */
+.nav-chapters {
+    font-size: 2em;
+    opacity: 0.6;
+    transition: opacity 0.15s ease;
+}
+
+.nav-chapters:hover {
+    opacity: 1;
+}
+
+/* ===== Landing page sponsor note ===== */
+.content main hr + p:last-child em {
+    font-size: 0.9em;
+    opacity: 0.7;
+}
+
+/* ===== Limit themes to Ayu (dark) and Rust (light) ===== */
+#theme-list > button:not([id="ayu"]):not([id="rust"]) {
+    display: none !important;
 }

--- a/docs/theme/favicon.svg
+++ b/docs/theme/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="fav-title">
+  <title id="fav-title">Anvil</title>
+  <defs>
+    <linearGradient id="forge-sm" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#dc2626"/>
+      <stop offset="35%" stop-color="#f97316"/>
+      <stop offset="70%" stop-color="#fbbf24"/>
+      <stop offset="100%" stop-color="#fef3c7"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(32, 35)">
+    <path d="M-22 25 L-4 -25 Q0 -32 4 -25 L22 25 L14 25 L8 6 L-8 6 L-14 25 Z" fill="url(#forge-sm)"/>
+    <rect x="-10" y="0" width="20" height="6" rx="1" fill="#991b1b"/>
+    <path d="M-5 6 L0 -12 L5 6 Z" fill="#0f172a"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Description

Redesign the documentation website with modern branding, improved typography, and a new forge-themed logo.

### What's included

- **Forge lettermark logo** — a bold "A" with a white-hot-to-red gradient evoking forged metal, used as the favicon and sidebar mark (`docs/theme/favicon.svg`, `docs/assets/anvil-logo.svg`)
- **Typography overhaul** — Inter for body text, Space Grotesk for headings, Lilex for code blocks; base font size increased to 18px for readability
- **Theme simplification** — reduced to two themes: Ayu (dark, default) and Rust (light)
- **README branding** — centered logo, heading, and badges layout with sponsor badge
- **Sponsor note** — subtle sponsorship line at the bottom of the docs landing page
- **Title update** — browser tab now reads "Anvil Docs" instead of "Anvil Documentation"

## Related Issues

Relates to #25

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)