### PR TITLE
feat: documentation website, branding, CLI reference, and animated version banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `anvil list --all-paths` to show all discovered paths including shadowed duplicates
 - Cross-platform release builds for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64)
 - Documentation website powered by mdBook, served at [anvil.kafkade.com](https://anvil.kafkade.com)
+- Animated forge lettermark banner on `anvil --version` with molten gradient
 
 ### Changed
 - Crate renamed to `anvil-cli` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-cli`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,19 +89,21 @@ dependencies = [
  "colored",
  "comfy-table",
  "console",
+ "crossterm 0.28.1",
  "dirs",
  "glob",
  "handlebars",
  "indicatif",
  "predicates",
  "pretty_assertions",
+ "ratatui",
  "regex-lite",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "tracing",
@@ -126,6 +134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +158,33 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -175,10 +219,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -195,6 +254,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -251,7 +316,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -282,9 +347,23 @@ version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -298,6 +377,15 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -342,15 +430,35 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
+ "derive_more",
  "document-features",
+ "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.3",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -371,6 +479,87 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -454,16 +643,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "float-cmp"
@@ -473,6 +704,18 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -524,7 +767,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -532,6 +775,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -547,6 +795,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -573,6 +827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,10 +857,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -617,6 +908,23 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -636,9 +944,24 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
 ]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -668,6 +991,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,14 +1025,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -709,12 +1096,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -740,6 +1153,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -794,7 +1216,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -808,6 +1230,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +1292,12 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -884,6 +1364,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.10.0",
+ "compact_str",
+ "hashbrown",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +1489,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -920,7 +1500,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -959,15 +1539,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -999,6 +1601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,7 +1633,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1090,6 +1698,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1727,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -1116,10 +1751,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1141,7 +1814,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1151,8 +1824,29 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1162,12 +1856,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.10.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1178,7 +1923,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1189,6 +1945,27 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"
@@ -1215,7 +1992,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1278,7 +2055,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1345,6 +2122,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +2156,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "atomic",
  "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
@@ -1384,6 +2173,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -1451,7 +2249,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1472,6 +2270,78 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -1526,7 +2396,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1537,7 +2407,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ indicatif = { version = "0.17", features = ["rayon"] }
 console = "0.15"
 colored = "2"
 atty = "0.2"
+ratatui = "0.30"
+crossterm = "0.28"
 
 # File operations
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Anvil is a declarative configuration management tool for developer workstations.
 - 🔧 **Script Execution** - Run PowerShell setup and validation scripts
 - 🧬 **Workload Inheritance** - Compose configurations using DRY principles
 - ✅ **Health Checks** - Validate system state matches workload definition
+- 🔍 **Assertions & Conditions** - Declarative system state predicates for health validation
 - 📊 **Multiple Formats** - Output as table, JSON, YAML, or HTML reports
 - 🔄 **Backup & Restore** - Save and restore system state
 - 🐚 **Shell Completions** - Tab completion for PowerShell, Bash, Zsh, Fish
+- 🌐 **Multi-Platform Design** - Windows support now; macOS and Linux on the roadmap
 
 ## 🚀 Quick Start
 
@@ -138,14 +140,15 @@ Commands:
   validate     Validate workload syntax
   init         Create new workload template
   status       Show installation status
-  backup       Manage system backups
+  backup       Manage file backups
   config       Manage global configuration
   completions  Generate shell completions
 
 Global Options:
   -v, --verbose    Increase verbosity (-v, -vv, -vvv)
   -q, --quiet      Suppress output
-  --no-color       Disable colored output
+  -c, --config     Use custom configuration file
+      --no-color   Disable colored output
   -h, --help       Show help
   -V, --version    Show version
 ```

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 
 - [Getting Started](user-guide.md)
 - [Workload Authoring](workload-authoring.md)
+- [Cookbook](cookbook.md)
 - [Troubleshooting](troubleshooting.md)
 
 # Reference

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,8 @@
 
 # Reference
 
+- [CLI Reference](cli-reference.md)
+- [Schema Reference](schema-reference.md)
 - [Specification](specification.md)
 - [Architecture](architecture.md)
 - [Changelog](changelog.md)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -10,6 +10,10 @@ Anvil is a single-binary Rust CLI. The binary parses commands, loads YAML worklo
 main.rs → cli/ → operations/ → providers/
                       ↓              ↓
                    config/        state/
+                      ↓
+              conditions/ → assertions/
+                      ↓
+                  commands/
 ```
 
 | Layer | Role |
@@ -19,6 +23,9 @@ main.rs → cli/ → operations/ → providers/
 | **operations/** | One module per CLI command — each exposes `execute(args, cli) → Result<()>` |
 | **providers/** | External system integrations: winget, filesystem, scripts, templates, backups |
 | **state/** | Tracks installation records, file hashes, and package cache at `~/.anvil/` |
+| **conditions/** | Composable predicate engine: command existence, file/dir checks, env vars, registry, shell commands |
+| **assertions/** | Evaluates named assertions (backed by conditions) for health reporting |
+| **commands/** | Inline command execution with conditional execution, timeouts, and structured results |
 
 ## Data Flow: `anvil install <workload>`
 
@@ -48,12 +55,14 @@ pub struct Workload {
     pub packages: Option<Packages>,
     pub files: Option<Vec<FileEntry>>,
     pub scripts: Option<Scripts>,
+    pub commands: Option<CommandBlock>,
     pub environment: Option<Environment>,
     pub health: Option<HealthConfig>,
+    pub assertions: Option<Vec<Assertion>>,
 }
 ```
 
-The `Workload` struct is the central data type — deserialized from YAML via serde. All fields except `name`, `version`, and `description` are optional.
+The `Workload` struct is the central data type — deserialized from YAML via serde. All fields except `name`, `version`, and `description` are optional. The `commands` and `assertions` fields were added in v0.5–v0.6 alongside the `conditions/`, `assertions/`, and `commands/` modules.
 
 ### CLI (`cli/mod.rs`, `cli/commands.rs`)
 
@@ -143,6 +152,7 @@ Two-tier approach:
   - `InheritanceError` (includes `suggestion()` for user-friendly hints)
   - `FileStateError`
   - `ProviderError` (wraps all provider errors)
+  - `CommandError`, `ConditionError`
 - **`anyhow`** for error propagation in operations and CLI code
 
 Pattern: domain errors are created with `thiserror` and converted to `anyhow::Error` at operation boundaries using `.with_context(|| ...)`.
@@ -151,11 +161,11 @@ Pattern: domain errors are created with `thiserror` and converted to `anyhow::Er
 
 ### Unit Tests
 
-Inline `#[cfg(test)] mod tests` in the same file as the code under test. 168 unit tests covering providers, config parsing, inheritance, state management, and formatting.
+Inline `#[cfg(test)] mod tests` in the same file as the code under test. 270 unit tests covering providers, config parsing, inheritance, state management, conditions, commands, and formatting.
 
 ### Integration Tests
 
-`tests/cli_tests.rs` uses `assert_cmd` + `predicates` for end-to-end CLI testing. 75 integration tests covering all commands with fixture workloads.
+`tests/cli_tests.rs` uses `assert_cmd` + `predicates` for end-to-end CLI testing. 85 integration tests covering all commands with fixture workloads.
 
 `tests/common/mod.rs` provides test fixture helpers:
 - `create_test_workload()` — minimal valid workload
@@ -168,9 +178,9 @@ Inline `#[cfg(test)] mod tests` in the same file as the code under test. 168 uni
 ### Running Tests
 
 ```sh
-cargo test                   # All tests (243 total)
-cargo test --bin anvil       # Unit tests only (168)
-cargo test --test cli_tests  # Integration tests only (75)
+cargo test                   # All tests (355 total)
+cargo test --bin anvil       # Unit tests only (270)
+cargo test --test cli_tests  # Integration tests only (85)
 cargo test test_name         # Single test by name
 ```
 
@@ -187,12 +197,10 @@ All commands that produce output support `--format`:
 
 ## CI Pipeline
 
-`.github/workflows/ci.yml` runs on every push/PR:
+`.github/workflows/ci.yml` runs on every push/PR across **Windows, Linux, and macOS** (matrix build):
 
 1. `cargo fmt --all -- --check`
 2. `cargo clippy --all-targets --all-features -- -D warnings`
-3. `cargo check`
-4. `cargo test --bin anvil` (unit tests)
-5. `cargo test --test cli_tests` (integration tests)
-6. `cargo build --release`
-7. Verify binary runs (`./anvil --version`)
+3. `cargo test --bin anvil` (unit tests)
+4. `cargo test --test cli_tests` (integration tests)
+5. `cargo build --release` (Windows only)

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1,0 +1,688 @@
+# CLI Reference
+
+Complete reference for every Anvil command, flag, and option.
+
+## Global Options
+
+These options are available on **all** commands:
+
+| Flag | Description |
+|------|-------------|
+| `-v, --verbose...` | Increase output verbosity (repeat for more: `-v`, `-vv`, `-vvv`) |
+| `-q, --quiet` | Suppress non-essential output |
+| `-c, --config <PATH>` | Use a custom configuration file |
+| `--no-color` | Disable colored output |
+| `-h, --help` | Print help |
+| `-V, --version` | Print version |
+
+---
+
+## Commands
+
+### anvil install
+
+**Synopsis:** `anvil install [OPTIONS] <WORKLOAD>`
+
+**Description:** Apply a workload configuration to the system. Installs packages, deploys files, and runs scripts as defined in the workload.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<WORKLOAD>` | Yes | Name of the workload to install (or path to `workload.yaml`) |
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-d, --dry-run` | — | Show what would be done without making changes |
+| `-f, --force` | — | Skip confirmation prompts |
+| `-p, --packages-only` | — | Only install packages, skip files and scripts |
+| `--skip-packages` | — | Skip package installation |
+| `--skip-files` | — | Skip file operations |
+| `--skip-scripts` | — | Skip all script execution |
+| `--skip-pre-scripts` | — | Skip pre-installation scripts |
+| `--skip-post-scripts` | — | Skip post-installation scripts |
+| `--no-backup` | — | Don't backup existing files before overwriting |
+| `--upgrade` | — | Upgrade existing packages to specified versions |
+| `--retry-failed` | — | Retry only failed packages from previous run |
+| `--parallel` | — | Run installations in parallel where safe |
+| `-j, --jobs <N>` | `4` | Number of parallel package installations |
+| `--timeout <SECONDS>` | `3600` | Global timeout for operations in seconds |
+| `--files-only` | — | Only process files, skip packages and scripts |
+| `--force-files` | — | Force overwrite files without checking hash |
+
+**Examples:**
+
+```sh
+# Install a workload
+anvil install essentials
+
+# Dry run to preview changes
+anvil install dev-tools --dry-run
+
+# Install only packages, skip everything else
+anvil install essentials --packages-only
+
+# Force install with parallel jobs
+anvil install dev-tools --force --parallel -j 8
+
+# Retry previously failed packages
+anvil install essentials --retry-failed
+
+# Install from a specific path
+anvil install ./my-workload/workload.yaml
+
+# Deploy only files, no packages or scripts
+anvil install essentials --files-only --force-files
+```
+
+**Exit Codes:** `0` = success, `1` = failure
+
+---
+
+### anvil health
+
+**Synopsis:** `anvil health [OPTIONS] <WORKLOAD>`
+
+**Description:** Check system health against a workload definition. Verifies packages are installed, files are deployed, and health check scripts pass.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<WORKLOAD>` | Yes | Name of the workload to check against |
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o, --output <OUTPUT>` | `table` | Output format (`table`, `json`, `yaml`, `html`) |
+| `-f, --file <PATH>` | — | Write report to file instead of stdout |
+| `--fail-fast` | — | Stop on first failure |
+| `--packages-only` | — | Only check packages |
+| `--files-only` | — | Only check files |
+| `--scripts-only` | — | Only run health check scripts |
+| `--assertions-only` | — | Only evaluate declarative assertions |
+| `-s, --strict` | — | Treat warnings as errors |
+| `--fix` | — | Attempt to install missing packages |
+| `--update` | — | Update packages with available updates |
+| `--no-cache` | — | Skip cache and query winget directly |
+| `--show-diff` | — | Show file differences for modified files |
+| `--script <NAME>` | — | Run only a specific health check script by name |
+
+**Examples:**
+
+```sh
+# Check health of a workload
+anvil health essentials
+
+# JSON report saved to file
+anvil health dev-tools -o json -f report.json
+
+# Check only packages, stop on first failure
+anvil health essentials --packages-only --fail-fast
+
+# Auto-fix missing packages
+anvil health essentials --fix
+
+# Run a single health check script
+anvil health essentials --script "Git Configuration"
+
+# Strict mode — warnings become errors
+anvil health essentials --strict
+```
+
+**Exit Codes:** `0` = all checks passed, `1` = one or more checks failed
+
+---
+
+### anvil list
+
+**Synopsis:** `anvil list [OPTIONS]`
+
+**Description:** List available workloads discovered from all configured search paths.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-a, --all` | — | Include built-in and custom workloads |
+| `-l, --long` | — | Show detailed information |
+| `--path <PATH>` | — | Search for workloads in additional path |
+| `--all-paths` | — | Show all discovered paths including shadowed duplicates |
+| `-o, --output <OUTPUT>` | — | Output format (`table`, `json`, `yaml`, `html`) |
+
+**Examples:**
+
+```sh
+# List all workloads
+anvil list
+
+# Detailed listing with extra info
+anvil list --long
+
+# Include all sources
+anvil list --all
+
+# Search an additional directory
+anvil list --path ~/my-workloads
+
+# Machine-readable output
+anvil list -o json
+```
+
+**Exit Codes:** `0` = success, `1` = failure
+
+---
+
+### anvil show
+
+**Synopsis:** `anvil show [OPTIONS] <WORKLOAD>`
+
+**Description:** Display detailed workload information including packages, files, scripts, and configuration.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<WORKLOAD>` | Yes | Name of the workload to display |
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-r, --resolved` | — | Show resolved configuration (with inheritance applied) |
+| `--show-inheritance` | — | Show inheritance tree visualization |
+| `-o, --output <OUTPUT>` | `yaml` | Output format (`yaml`, `json`) |
+
+**Examples:**
+
+```sh
+# Show workload definition
+anvil show essentials
+
+# Show with inheritance resolved
+anvil show dev-tools --resolved
+
+# View inheritance tree
+anvil show dev-tools --show-inheritance
+
+# Output as JSON
+anvil show essentials -o json
+```
+
+**Exit Codes:** `0` = success, `1` = failure
+
+---
+
+### anvil validate
+
+**Synopsis:** `anvil validate [OPTIONS] [PATH]`
+
+**Description:** Validate workload definition syntax. Checks YAML structure, schema conformance, and optionally script syntax.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[PATH]` | No | Path to `workload.yaml` file or workload directory |
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--strict` | — | Enable strict validation mode |
+| `--schema` | — | Output JSON schema for workload definitions |
+| `--check-scripts` | — | Validate script syntax using PowerShell parser |
+| `--scripts-only` | — | Only validate scripts (skip other validation) |
+
+**Examples:**
+
+```sh
+# Validate a workload directory
+anvil validate workloads/essentials
+
+# Strict mode validation
+anvil validate workloads/dev-tools --strict
+
+# Validate with script syntax checking
+anvil validate workloads/essentials --check-scripts
+
+# Dump the JSON schema
+anvil validate --schema
+
+# Validate only scripts
+anvil validate workloads/essentials --scripts-only
+```
+
+**Exit Codes:** `0` = valid, `1` = validation errors found
+
+---
+
+### anvil init
+
+**Synopsis:** `anvil init [OPTIONS] <NAME>`
+
+**Description:** Initialize a new workload template with scaffolded directory structure and `workload.yaml`.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<NAME>` | Yes | Name for the new workload |
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-t, --template <TEMPLATE>` | `standard` | Base template (`minimal`, `standard`, `full`) |
+| `-e, --extends <PARENT>` | — | Parent workload to extend |
+| `-o, --output <PATH>` | — | Output directory |
+
+**Template values:**
+
+| Template | Description |
+|----------|-------------|
+| `minimal` | Minimal workload with just metadata |
+| `standard` | Standard workload with common sections |
+| `full` | Full workload with all sections and examples |
+
+**Examples:**
+
+```sh
+# Create a standard workload
+anvil init my-workload
+
+# Create a minimal workload
+anvil init my-workload --template minimal
+
+# Create a workload extending essentials
+anvil init my-workload --extends essentials
+
+# Full template in a custom directory
+anvil init my-workload --template full --output ~/workloads
+```
+
+**Exit Codes:** `0` = success, `1` = failure
+
+---
+
+### anvil status
+
+**Synopsis:** `anvil status [OPTIONS] [WORKLOAD]`
+
+**Description:** Show installation status and state for one or all workloads.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[WORKLOAD]` | No | Name of the workload (shows all if omitted) |
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o, --output <OUTPUT>` | `table` | Output format (`table`, `json`, `yaml`, `html`) |
+| `-l, --long` | — | Show detailed status including timestamps |
+| `--clear` | — | Clear stored state for the specified workload |
+
+**Examples:**
+
+```sh
+# Show status for all workloads
+anvil status
+
+# Status for a specific workload
+anvil status essentials
+
+# Detailed status with timestamps
+anvil status essentials --long
+
+# Clear stored state
+anvil status essentials --clear
+
+# Machine-readable output
+anvil status -o json
+```
+
+**Exit Codes:** `0` = success, `1` = failure
+
+---
+
+### anvil completions
+
+**Synopsis:** `anvil completions [OPTIONS] <SHELL>`
+
+**Description:** Generate shell completion scripts for the specified shell.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<SHELL>` | Yes | Target shell (`bash`, `zsh`, `fish`, `powershell`, `elvish`) |
+
+**Examples:**
+
+```sh
+# PowerShell — add to $PROFILE
+anvil completions powershell >> $PROFILE
+
+# Bash
+anvil completions bash > ~/.local/share/bash-completion/completions/anvil
+
+# Zsh
+anvil completions zsh > ~/.zfunc/_anvil
+
+# Fish
+anvil completions fish > ~/.config/fish/completions/anvil.fish
+```
+
+**Exit Codes:** `0` = success, `1` = failure
+
+---
+
+### anvil backup
+
+**Synopsis:** `anvil backup <COMMAND>`
+
+**Description:** Manage file backups created during workload installation. Anvil backs up existing files before overwriting them; this command lets you list, restore, verify, and clean those backups.
+
+#### anvil backup create
+
+**Synopsis:** `anvil backup create [OPTIONS]`
+
+**Description:** Create a new backup.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-n, --name <NAME>` | — | Name for the backup |
+| `-w, --workload <WORKLOAD>` | — | Only backup files related to workload |
+| `--include-packages` | — | Include winget package list export |
+| `--compress` | — | Create compressed archive |
+
+**Examples:**
+
+```sh
+# Create a named backup
+anvil backup create --name "before-upgrade"
+
+# Backup files for a specific workload
+anvil backup create --workload essentials
+
+# Compressed backup with package list
+anvil backup create --compress --include-packages
+```
+
+#### anvil backup list
+
+**Synopsis:** `anvil backup list [OPTIONS]`
+
+**Description:** List all backups.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-w, --workload <WORKLOAD>` | — | Filter by workload name |
+| `-o, --output <OUTPUT>` | `table` | Output format (`table`, `json`, `yaml`, `html`) |
+| `-l, --long` | — | Show detailed information |
+
+**Examples:**
+
+```sh
+# List all backups
+anvil backup list
+
+# Filter by workload
+anvil backup list --workload essentials
+
+# Detailed listing
+anvil backup list --long
+```
+
+#### anvil backup show
+
+**Synopsis:** `anvil backup show [OPTIONS] <ID>`
+
+**Description:** Show details for a specific backup.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<ID>` | Yes | Backup ID |
+
+**Examples:**
+
+```sh
+anvil backup show abc123
+```
+
+#### anvil backup restore
+
+**Synopsis:** `anvil backup restore [OPTIONS] [ID]`
+
+**Description:** Restore files from a backup.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[ID]` | No | Backup ID to restore (or use `--workload`) |
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-w, --workload <WORKLOAD>` | — | Restore all backups for a workload |
+| `-d, --dry-run` | — | Show what would be done without making changes |
+| `-f, --force` | — | Skip confirmation prompts |
+
+**Examples:**
+
+```sh
+# Restore a specific backup
+anvil backup restore abc123
+
+# Dry run restore
+anvil backup restore abc123 --dry-run
+
+# Restore all backups for a workload
+anvil backup restore --workload essentials --force
+```
+
+#### anvil backup clean
+
+**Synopsis:** `anvil backup clean [OPTIONS]`
+
+**Description:** Remove old backups.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--older-than <DAYS>` | `30` | Remove backups older than N days |
+| `-d, --dry-run` | — | Show what would be done without making changes |
+| `-f, --force` | — | Skip confirmation prompts |
+
+**Examples:**
+
+```sh
+# Clean backups older than 30 days (default)
+anvil backup clean
+
+# Clean backups older than 7 days
+anvil backup clean --older-than 7
+
+# Preview what would be removed
+anvil backup clean --dry-run
+```
+
+#### anvil backup verify
+
+**Synopsis:** `anvil backup verify [OPTIONS]`
+
+**Description:** Verify backup integrity by checking that backup files exist and are uncorrupted.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-w, --workload <WORKLOAD>` | — | Only verify backups for a specific workload |
+| `--fix` | — | Fix issues by removing corrupted/missing entries |
+
+**Examples:**
+
+```sh
+# Verify all backups
+anvil backup verify
+
+# Verify and auto-fix issues
+anvil backup verify --fix
+
+# Verify backups for one workload
+anvil backup verify --workload essentials
+```
+
+---
+
+### anvil config
+
+**Synopsis:** `anvil config <COMMAND>`
+
+**Description:** Manage global Anvil configuration. Settings are persisted in a YAML file at `~/.anvil/config.yaml`.
+
+#### anvil config get
+
+**Synopsis:** `anvil config get [OPTIONS] <KEY>`
+
+**Description:** Get a configuration value.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<KEY>` | Yes | Configuration key (e.g., `defaults.shell`) |
+
+**Examples:**
+
+```sh
+anvil config get defaults.shell
+anvil config get workload_paths
+```
+
+#### anvil config set
+
+**Synopsis:** `anvil config set [OPTIONS] <KEY> <VALUE>`
+
+**Description:** Set a configuration value.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<KEY>` | Yes | Configuration key (e.g., `defaults.shell`) |
+| `<VALUE>` | Yes | Value to set |
+
+**Examples:**
+
+```sh
+anvil config set defaults.shell powershell
+anvil config set defaults.timeout 600
+```
+
+#### anvil config list
+
+**Synopsis:** `anvil config list [OPTIONS]`
+
+**Description:** List all configuration values.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o, --output <OUTPUT>` | `table` | Output format (`table`, `json`, `yaml`, `html`) |
+
+**Examples:**
+
+```sh
+# Show all config
+anvil config list
+
+# JSON output
+anvil config list -o json
+```
+
+#### anvil config reset
+
+**Synopsis:** `anvil config reset [OPTIONS]`
+
+**Description:** Reset configuration to defaults.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-f, --force` | — | Skip confirmation prompt |
+
+**Examples:**
+
+```sh
+# Reset with confirmation
+anvil config reset
+
+# Force reset without prompt
+anvil config reset --force
+```
+
+#### anvil config edit
+
+**Synopsis:** `anvil config edit [OPTIONS]`
+
+**Description:** Open configuration file in the default editor.
+
+**Examples:**
+
+```sh
+anvil config edit
+```
+
+#### anvil config path
+
+**Synopsis:** `anvil config path [OPTIONS]`
+
+**Description:** Show configuration file path.
+
+**Examples:**
+
+```sh
+anvil config path
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description | Used by |
+|----------|-------------|---------|
+| `NO_COLOR` | Disables colored output when set (any value). Standard convention ([no-color.org](https://no-color.org)). | All commands |
+| `ANVIL_WORKLOAD` | Name of the current workload being processed. | Scripts, templates |
+| `ANVIL_WORKLOAD_PATH` | Absolute path to the workload directory. | Scripts |
+| `ANVIL_DRY_RUN` | Set to `"true"` or `"false"` during script execution. | Scripts |
+| `ANVIL_VERBOSE` | Verbosity level (`0`–`3`) during script execution. | Scripts |
+| `ANVIL_PHASE` | Current execution phase: `pre_install`, `post_install`, or `health_check`. | Scripts |
+| `ANVIL_VERSION` | Anvil version string. Available in scripts and Handlebars templates. | Scripts, templates |
+| `RUST_LOG` | Controls Rust log output (e.g., `RUST_LOG=debug`). Standard `env_logger` / `tracing` variable. | Debugging |
+| `RUST_BACKTRACE` | Enables Rust backtraces on panic (`1` = short, `full` = complete). | Debugging |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success — command completed, all checks passed |
+| `1` | General failure — operation failed or health checks did not pass |
+| `2` | Usage error — invalid arguments or missing required parameters |

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -121,10 +121,10 @@ cargo run -- -vvv list
 cargo test
 
 # Run unit tests only
-cargo test --lib
+cargo test --bin anvil
 
 # Run integration tests only
-cargo test --test '*'
+cargo test --test cli_tests
 
 # Run a specific test
 cargo test test_name
@@ -159,6 +159,12 @@ anvil/
 │   │   ├── workload.rs      # Workload parsing
 │   │   ├── inheritance.rs   # Inheritance resolution
 │   │   └── global.rs        # Global configuration
+│   ├── assertions/          # Assertion evaluation engine
+│   │   └── mod.rs
+│   ├── commands/            # Inline command execution
+│   │   └── mod.rs
+│   ├── conditions/          # Condition/predicate engine
+│   │   └── mod.rs
 │   ├── operations/          # Command implementations
 │   │   ├── mod.rs
 │   │   ├── install.rs       # Install command
@@ -207,6 +213,9 @@ anvil/
 
 - **cli**: Handles command-line parsing with clap and output formatting
 - **config**: Parses workload YAML files and handles inheritance
+- **assertions**: Evaluates named assertions for health reporting
+- **commands**: Executes inline commands with timeout and elevation support
+- **conditions**: Composable predicate engine for system state checks
 - **operations**: Implements each CLI command's business logic
 - **providers**: Interfaces with external systems (winget, filesystem, PowerShell)
 - **state**: Tracks installation state and manages caching

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -1,0 +1,518 @@
+# Cookbook
+
+Practical recipes for common Anvil tasks. Each recipe is self-contained with copy-pasteable examples. See the [User Guide](user-guide.md) and [Workload Authoring](workload-authoring.md) for full reference.
+
+## Creating Your First Workload
+
+Start with `anvil init` to scaffold a new workload:
+
+```sh
+# Create a minimal workload
+anvil init my-setup
+
+# Create a full-featured template with all sections
+anvil init my-setup --template full
+
+# Create a workload that extends another
+anvil init my-setup --extends essentials
+```
+
+This creates a directory with a `workload.yaml` and optional `files/` and `scripts/` subdirectories. Edit the YAML to define your environment:
+
+```yaml
+name: my-setup
+version: "1.0.0"
+description: "My development environment"
+
+packages:
+  winget:
+    - id: Git.Git
+    - id: Microsoft.VisualStudioCode
+```
+
+Preview what would happen, then apply:
+
+```sh
+anvil install my-setup --dry-run   # preview
+anvil install my-setup             # apply
+anvil health my-setup              # verify
+```
+
+## Adding Packages
+
+### Basic winget packages
+
+```yaml
+packages:
+  winget:
+    - id: Git.Git
+    - id: BurntSushi.ripgrep.MSVC
+    - id: sharkdp.fd
+```
+
+### Pinning a version
+
+```yaml
+packages:
+  winget:
+    - id: Python.Python.3.12
+      version: "3.12.4"
+```
+
+### Installing from the Microsoft Store
+
+```yaml
+packages:
+  winget:
+    - id: 9NBLGGH4NNS1        # Windows Terminal
+      source: msstore
+```
+
+### Custom install arguments
+
+```yaml
+packages:
+  winget:
+    - id: Microsoft.VisualStudio.2022.BuildTools
+      override:
+        - --override
+        - "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools"
+```
+
+### Multi-platform packages
+
+Define packages for multiple platforms — Anvil picks the right manager for the current OS:
+
+```yaml
+packages:
+  winget:
+    - id: Git.Git
+  brew:
+    - name: git
+  apt:
+    - name: git
+```
+
+## Deploying Configuration Files
+
+### Basic file deployment
+
+Place source files in the `files/` subdirectory of your workload, then reference them in `workload.yaml`:
+
+```yaml
+files:
+  - source: config.toml
+    destination: "~/.cargo/config.toml"
+    backup: true
+```
+
+The `~` expands to the user's home directory. With `backup: true`, Anvil saves the existing file before overwriting.
+
+### Directory structure mirroring
+
+Organize source files to mirror the target directory structure:
+
+```
+my-workload/
+├── workload.yaml
+└── files/
+    └── .config/
+        ├── starship.toml
+        └── alacritty/
+            └── alacritty.toml
+```
+
+```yaml
+files:
+  - source: .config/starship.toml
+    destination: "~/.config/starship.toml"
+    backup: true
+  - source: .config/alacritty/alacritty.toml
+    destination: "~/.config/alacritty/alacritty.toml"
+    backup: true
+```
+
+### Deploying files without touching packages
+
+```sh
+anvil install my-setup --files-only --dry-run
+```
+
+## Writing Health Check Scripts
+
+Health check scripts validate that your environment is correctly configured. They return exit code 0 for success, 1 for failure.
+
+### Basic health check
+
+Create `scripts/health-check.ps1`:
+
+```powershell
+# health-check.ps1 - Verify development tools
+$ErrorActionPreference = "Continue"
+$exitCode = 0
+
+function Test-Tool($name) {
+    if (Get-Command $name -ErrorAction SilentlyContinue) {
+        Write-Host "  [PASS] $name found" -ForegroundColor Green
+    } else {
+        Write-Host "  [FAIL] $name not found" -ForegroundColor Red
+        $script:exitCode = 1
+    }
+}
+
+Write-Host "Checking tools..." -ForegroundColor Cyan
+Test-Tool "git"
+Test-Tool "code"
+Test-Tool "cargo"
+
+exit $exitCode
+```
+
+Reference it in `workload.yaml`:
+
+```yaml
+scripts:
+  health_check:
+    - path: health-check.ps1
+      name: "Development Tools"
+      description: "Verifies core development tools are installed"
+```
+
+Run the check:
+
+```sh
+anvil health my-setup                     # all checks
+anvil health my-setup --scripts-only      # scripts only
+anvil health my-setup --script "Development Tools"  # one script
+```
+
+## Using Assertions for Declarative Health Checks
+
+Assertions are a declarative alternative to health check scripts — no scripting needed.
+
+### Check that commands exist
+
+```yaml
+assertions:
+  - name: Git is installed
+    check:
+      type: command_exists
+      command: git
+
+  - name: Cargo is installed
+    check:
+      type: command_exists
+      command: cargo
+```
+
+### Check files and directories
+
+```yaml
+assertions:
+  - name: SSH key exists
+    check:
+      type: file_exists
+      path: "~/.ssh/id_ed25519"
+
+  - name: Cargo directory exists
+    check:
+      type: dir_exists
+      path: "~/.cargo"
+```
+
+### Check environment variables
+
+```yaml
+assertions:
+  - name: RUST_BACKTRACE is set
+    check:
+      type: env_var
+      name: RUST_BACKTRACE
+      value: "1"
+
+  - name: Cargo bin is on PATH
+    check:
+      type: path_contains
+      substring: ".cargo/bin"
+```
+
+### Check Windows registry values
+
+```yaml
+assertions:
+  - name: Developer mode enabled
+    check:
+      type: registry_value
+      key: "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock"
+      value_name: "AllowDevelopmentWithoutDevLicense"
+      expected: "1"
+```
+
+### Run a shell command as a check
+
+```yaml
+assertions:
+  - name: Rust stable is default toolchain
+    check:
+      type: shell
+      command: "rustup default"
+      contains: "stable"
+```
+
+### Compose checks with all_of / any_of
+
+```yaml
+assertions:
+  - name: Rust toolchain is fully configured
+    check:
+      type: all_of
+      conditions:
+        - type: command_exists
+          command: rustc
+        - type: command_exists
+          command: cargo
+        - type: dir_exists
+          path: "~/.cargo"
+        - type: path_contains
+          substring: ".cargo/bin"
+```
+
+Run assertion checks:
+
+```sh
+anvil health my-setup --assertions-only
+```
+
+Enable assertions in the health config:
+
+```yaml
+health:
+  assertion_check: true
+```
+
+## Running Post-Install Commands
+
+Use the `commands` block for inline shell commands that run during installation — no separate script files needed.
+
+### Basic commands
+
+```yaml
+commands:
+  post_install:
+    - run: "rustup component add clippy rustfmt"
+      description: "Install Rust components"
+
+    - run: "cargo install cargo-watch cargo-nextest"
+      description: "Install cargo tools"
+```
+
+### Pre-install setup
+
+```yaml
+commands:
+  pre_install:
+    - run: "mkdir -p ~/.config"
+      description: "Ensure config directory exists"
+```
+
+### Conditional execution
+
+Only run a command when a condition is met:
+
+```yaml
+commands:
+  post_install:
+    - run: "rustup component add rust-analyzer"
+      description: "Install rust-analyzer"
+      when:
+        command_exists: rustup
+
+    - run: "npm install -g typescript"
+      description: "Install TypeScript globally"
+      when:
+        command_exists: npm
+```
+
+### Continue on error
+
+Allow a command to fail without stopping the install:
+
+```yaml
+commands:
+  post_install:
+    - run: "cargo install sccache"
+      description: "Install sccache (optional)"
+      continue_on_error: true
+```
+
+## Using Workload Inheritance
+
+Inheritance lets you build on top of existing workloads. Child workloads inherit packages, files, scripts, and environment from their parents.
+
+### Extending a base workload
+
+```yaml
+name: rust-developer
+version: "1.0.0"
+description: "Rust dev environment"
+
+extends:
+  - essentials        # inherits Git, VS Code, Terminal, etc.
+
+packages:
+  winget:
+    - id: Rustlang.Rustup   # added on top of essentials packages
+```
+
+### Building a team workload chain
+
+```
+essentials          → shared dev tools
+  └── backend       → adds Docker, Postgres, Redis
+       └── rust-be  → adds Rust toolchain
+       └── go-be    → adds Go toolchain
+```
+
+```yaml
+# backend/workload.yaml
+name: backend
+version: "1.0.0"
+description: "Backend development base"
+extends:
+  - essentials
+
+packages:
+  winget:
+    - id: Docker.DockerDesktop
+    - id: PostgreSQL.PostgreSQL
+```
+
+```yaml
+# rust-be/workload.yaml
+name: rust-be
+version: "1.0.0"
+description: "Rust backend developer"
+extends:
+  - backend
+
+packages:
+  winget:
+    - id: Rustlang.Rustup
+```
+
+### How inheritance merges
+
+- **Packages**: child packages are appended after parent packages
+- **Files**: child files are appended; same destination = child overrides parent
+- **Scripts**: concatenated (parent scripts run first)
+- **Environment**: child variables override same-named parent variables
+- **Assertions**: child assertions are appended after parent assertions
+
+## Setting Up Environment Variables
+
+### User-scoped variables
+
+```yaml
+environment:
+  variables:
+    - name: EDITOR
+      value: "code --wait"
+      scope: user
+
+    - name: RUST_BACKTRACE
+      value: "1"
+      scope: user
+```
+
+### PATH additions
+
+```yaml
+environment:
+  path_additions:
+    - "~/.cargo/bin"
+    - "~/go/bin"
+    - "~/.local/bin"
+```
+
+## Managing Private Workload Repositories
+
+Keep team-specific workloads in a private Git repo and configure Anvil to find them.
+
+### Set up the search path
+
+```sh
+# Clone your team's workloads
+git clone git@github.com:myteam/workloads.git ~/team-workloads
+
+# Tell Anvil where to find them
+anvil config set workloads.paths '["~/team-workloads"]'
+```
+
+Or edit `~/.anvil/config.yaml` directly:
+
+```yaml
+workloads:
+  paths:
+    - "~/team-workloads"
+    - "~/personal-workloads"
+```
+
+### Search precedence
+
+When multiple paths contain a workload with the same name, the first match wins:
+
+1. Explicit `--path` argument (highest priority)
+2. User-configured paths from `config.yaml`
+3. Default search paths (bundled workloads)
+
+See all discovered paths and any shadowed duplicates:
+
+```sh
+anvil list --all-paths --long
+```
+
+### Private repo structure
+
+```
+team-workloads/
+├── base-dev/
+│   └── workload.yaml
+├── frontend/
+│   └── workload.yaml
+├── backend/
+│   ├── workload.yaml
+│   ├── files/
+│   │   └── .pgpass
+│   └── scripts/
+│       └── post-install.ps1
+└── data-science/
+    └── workload.yaml
+```
+
+Team members clone the repo and configure the path once. Updates are pulled with `git pull`.
+
+## Generating Reports
+
+### JSON output for scripting
+
+```sh
+anvil health my-setup --output json | jq '.summary'
+```
+
+### HTML health report
+
+```sh
+anvil health my-setup --output html --file report.html
+```
+
+### YAML export
+
+```sh
+anvil show my-setup --output yaml
+```
+
+### List workloads as JSON
+
+```sh
+anvil list --output json | jq '.[].name'
+```

--- a/docs/src/schema-reference.md
+++ b/docs/src/schema-reference.md
@@ -1,0 +1,569 @@
+# Schema Reference
+
+This document is the authoritative reference for both the global configuration file (`~/.anvil/config.yaml`) and the workload definition file (`workload.yaml`). All field names, types, and defaults are derived from the Rust source structs.
+
+---
+
+## Configuration File (`~/.anvil/config.yaml`)
+
+The global configuration file stores user preferences and default settings. If the file does not exist, Anvil uses the built-in defaults shown below.
+
+### defaults
+
+Default settings applied to CLI commands.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `defaults.shell` | string | `"powershell"` | Default shell for script execution (`powershell`, `pwsh`). |
+| `defaults.script_timeout` | integer | `300` | Default script timeout in seconds. |
+| `defaults.output_format` | string | `"table"` | Output format for commands. Valid values: `table`, `json`, `yaml`, `html`. |
+| `defaults.color` | string | `"auto"` | Color output mode. Valid values: `auto`, `always`, `never`. |
+
+### backup
+
+Controls automatic backup behavior during installs.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `backup.auto_backup` | boolean | `true` | Create a backup before install operations. |
+| `backup.retention_days` | integer | `30` | Delete backups older than this many days. |
+| `backup.max_backups` | integer | `10` | Maximum number of backups to keep per workload. |
+| `backup.compress` | boolean | `false` | Compress backups by default. |
+
+### install
+
+Settings that govern package installation behavior.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `install.parallel_packages` | boolean | `false` | Install packages in parallel. |
+| `install.skip_installed` | boolean | `true` | Skip packages that are already installed. |
+| `install.confirm` | boolean | `true` | Prompt for confirmation before installing. |
+
+### workloads
+
+Workload discovery configuration.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `workloads.paths` | list of strings | `[]` | Additional directories to search for workloads. |
+
+### logging
+
+Logging configuration.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `logging.level` | string | `"info"` | Log verbosity level. Valid values: `error`, `warn`, `info`, `debug`, `trace`. |
+| `logging.file` | string or null | `null` | Path to a log file. `null` disables file logging. |
+
+### Full Example
+
+```yaml
+defaults:
+  shell: powershell
+  script_timeout: 300
+  output_format: table
+  color: auto
+
+backup:
+  auto_backup: true
+  retention_days: 30
+  max_backups: 10
+  compress: false
+
+install:
+  parallel_packages: false
+  skip_installed: true
+  confirm: true
+
+workloads:
+  paths:
+    - ~/my-workloads
+    - /shared/team-workloads
+
+logging:
+  level: info
+  file: ~/.anvil/anvil.log
+```
+
+---
+
+## Workload Schema (`workload.yaml`)
+
+A workload is defined by a `workload.yaml` file inside a workload directory. The directory may also contain `files/` and `scripts/` subdirectories.
+
+### Top-Level Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | yes | — | Unique workload identifier (kebab-case). |
+| `version` | string | yes | — | Semantic version (e.g., `"1.0.0"`). |
+| `description` | string | yes | — | Human-readable description of the workload. |
+| `extends` | list of strings | no | `null` | Parent workload names to inherit from. |
+| `packages` | object | no | `null` | Package definitions, grouped by manager. |
+| `files` | list of [FileEntry](#files) | no | `null` | Configuration files to deploy. |
+| `scripts` | object | no | `null` | Scripts to execute at various phases. |
+| `commands` | object | no | `null` | Inline commands to execute at various phases. |
+| `environment` | object | no | `null` | Environment variables and PATH additions. |
+| `health` | object | no | `null` | Health check configuration flags. |
+| `assertions` | list of [Assertion](#assertions) | no | `null` | Declarative assertions for health validation. |
+
+### packages
+
+The `packages` object groups package definitions by package manager. Each manager key is optional.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `packages.winget` | list of [WingetPackage](#winget-package) | no | Windows packages managed by winget. |
+| `packages.brew` | list of [BrewPackage](#brew-package) | no | macOS/Linux packages managed by Homebrew. |
+| `packages.apt` | list of [AptPackage](#apt-package) | no | Debian/Ubuntu packages managed by APT. |
+
+#### Winget Package
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | string | yes | — | Winget package identifier (e.g., `Git.Git`). |
+| `version` | string | no | latest | Specific version to install. |
+| `source` | string | no | `null` | Package source (e.g., `msstore` for Microsoft Store apps). |
+| `override` | list of strings | no | `null` | Override arguments passed to the installer. |
+| `override_args` | list of strings | no | `null` | Additional winget arguments. |
+
+```yaml
+packages:
+  winget:
+    - id: Git.Git
+    - id: Microsoft.VisualStudioCode
+      version: "1.95.0"
+    - id: Notepad++.Notepad++
+      override:
+        - --override
+        - "/VERYSILENT /NORESTART"
+    - id: 9NBLGGH4NNS1
+      source: msstore
+```
+
+#### Brew Package
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | yes | — | Package name (e.g., `git`, `node`). |
+| `cask` | boolean | no | `false` | Whether this is a cask (GUI app) vs formula (CLI tool). |
+| `tap` | string | no | `null` | Tap source (e.g., `homebrew/cask-fonts`). |
+
+```yaml
+packages:
+  brew:
+    - name: git
+    - name: visual-studio-code
+      cask: true
+    - name: font-cascadia-code
+      cask: true
+      tap: homebrew/cask-fonts
+```
+
+#### APT Package
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | yes | — | Package name (e.g., `git`, `build-essential`). |
+| `version` | string | no | `null` | Specific version constraint. |
+
+```yaml
+packages:
+  apt:
+    - name: git
+    - name: build-essential
+      version: "12.9"
+```
+
+### files
+
+Each entry in the `files` list describes a configuration file to deploy.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `source` | string | yes | — | Path relative to the workload's `files/` directory. |
+| `destination` | string | yes | — | Target path. `~` expands to the user's home directory. |
+| `backup` | boolean | no | `true` | Back up the existing file before overwriting. |
+| `permissions` | string | no | `null` | File permissions (reserved for future use). |
+| `template` | boolean | no | `false` | Process the file as a Handlebars template before deploying. |
+
+```yaml
+files:
+  - source: user/.config/starship.toml
+    destination: "~/.config/starship.toml"
+  - source: user/.gitconfig
+    destination: "~/.gitconfig"
+    backup: true
+    template: true
+```
+
+### scripts
+
+The `scripts` object organizes script entries by execution phase. All phase keys are optional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scripts.pre_install` | list of [ScriptEntry](#scriptentry) | Scripts to run **before** package installation. |
+| `scripts.post_install` | list of [ScriptEntry](#scriptentry) | Scripts to run **after** package installation. |
+| `scripts.health_check` | list of [HealthCheckScript](#healthcheckscript) | Scripts for health validation. |
+
+#### ScriptEntry
+
+Used in `pre_install` and `post_install` phases.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `path` | string | yes | — | Path relative to the workload's `scripts/` directory. |
+| `shell` | string | no | `"powershell"` | Execution shell. |
+| `description` | string | no | `null` | Human-readable description of what the script does. |
+| `elevated` | boolean | no | `false` | Whether the script requires administrator privileges. |
+| `timeout` | integer | no | `300` | Timeout in seconds. |
+
+#### HealthCheckScript
+
+Used in the `health_check` phase. Requires a `name` field (unlike other script types).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `path` | string | yes | — | Path relative to the workload's `scripts/` directory. |
+| `name` | string | yes | — | Display name for the health check. |
+| `description` | string | no | `null` | Description of what this check validates. |
+| `shell` | string | no | `"powershell"` | Execution shell. |
+
+```yaml
+scripts:
+  pre_install:
+    - path: pre-install.ps1
+      description: "Prepare system for installation"
+      timeout: 60
+
+  post_install:
+    - path: configure-terminal.ps1
+      description: "Configure Windows Terminal settings"
+      timeout: 300
+      elevated: true
+
+  health_check:
+    - path: health-check/check-tools.ps1
+      name: "Developer Tools"
+      description: "Verify developer tools are installed"
+    - path: health-check/check-config.ps1
+      name: "Configuration Files"
+      description: "Verify configuration files are deployed"
+```
+
+### commands
+
+The `commands` object defines inline shell commands to execute at install phases. This is a lightweight alternative to scripts for simple one-liners.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `commands.pre_install` | list of [CommandEntry](#commandentry) | Commands to run **before** package installation. |
+| `commands.post_install` | list of [CommandEntry](#commandentry) | Commands to run **after** package installation. |
+
+#### CommandEntry
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `run` | string | yes | — | Shell command string to execute. |
+| `description` | string | no | `null` | Human-readable description. |
+| `timeout` | integer | no | `300` | Timeout in seconds. |
+| `elevated` | boolean | no | `false` | Whether the command requires administrator privileges. |
+| `when` | [Condition](#condition-types) | no | `null` | Condition that must be true for this command to run. |
+| `continue_on_error` | boolean | no | `false` | Whether to continue if this command fails. |
+
+```yaml
+commands:
+  post_install:
+    - run: "rustup default stable"
+      description: "Set Rust stable as default toolchain"
+      timeout: 120
+    - run: "cargo install cargo-watch"
+      description: "Install cargo-watch"
+      when:
+        type: command_exists
+        command: cargo
+      continue_on_error: true
+```
+
+### environment
+
+Environment variable and PATH configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `environment.variables` | list of [EnvVariable](#envvariable) | Environment variables to set. |
+| `environment.path_additions` | list of strings | Directory paths to add to the system PATH. `~` expands to the user's home. |
+
+#### EnvVariable
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | yes | — | Variable name. |
+| `value` | string | yes | — | Variable value. |
+| `scope` | string | no | `"user"` | Scope: `user` or `machine`. |
+
+```yaml
+environment:
+  variables:
+    - name: EDITOR
+      value: code
+      scope: user
+    - name: DOTNET_CLI_TELEMETRY_OPTOUT
+      value: "1"
+
+  path_additions:
+    - "~/.cargo/bin"
+    - "~/.local/bin"
+```
+
+### health
+
+Flags that control which categories of health checks are evaluated during `anvil health`.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `package_check` | boolean | no | `true` | Verify that declared packages are installed. |
+| `file_check` | boolean | no | `true` | Verify that declared files are deployed. |
+| `script_check` | boolean | no | `true` | Run `scripts.health_check` scripts. |
+| `assertion_check` | boolean | no | `true` | Evaluate declarative assertions. |
+
+```yaml
+health:
+  package_check: true
+  file_check: true
+  script_check: true
+  assertion_check: true
+```
+
+### assertions
+
+Declarative health assertions using the condition engine. Each assertion pairs a display name with a condition to evaluate.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Display name for the assertion. |
+| `check` | [Condition](#condition-types) | yes | The condition to evaluate. |
+
+#### Condition Types
+
+Conditions are serialized as tagged objects with a `type` discriminator field. The following condition types are available:
+
+##### `command_exists`
+
+Check whether a command is available on PATH.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"command_exists"` |
+| `command` | string | yes | Command name to look for. |
+
+##### `file_exists`
+
+Check whether a file exists at the given path (`~` is expanded).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"file_exists"` |
+| `path` | string | yes | File path to check. |
+
+##### `dir_exists`
+
+Check whether a directory exists at the given path (`~` is expanded).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"dir_exists"` |
+| `path` | string | yes | Directory path to check. |
+
+##### `env_var`
+
+Check whether an environment variable is set, optionally matching an expected value.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"env_var"` |
+| `name` | string | yes | Environment variable name. |
+| `value` | string | no | Expected value. If omitted, only checks that the variable is set. |
+
+##### `path_contains`
+
+Check whether the system PATH contains a given substring.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"path_contains"` |
+| `substring` | string | yes | Substring to search for in PATH entries. |
+
+##### `registry_value`
+
+Query a Windows registry value under HKCU or HKLM.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"registry_value"` |
+| `hive` | string | yes | Registry hive: `"HKCU"` or `"HKLM"`. |
+| `key` | string | yes | Full key path (e.g., `"SOFTWARE\\Microsoft\\Windows\\CurrentVersion"`). |
+| `name` | string | yes | Value name inside the key. |
+| `expected` | string | no | Expected data. If omitted, only asserts the value exists. |
+
+##### `shell`
+
+Run a shell command; the condition passes when the exit code is 0.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"shell"` |
+| `command` | string | yes | Shell command to execute. |
+| `description` | string | no | Human-readable description of the check. |
+
+##### `all_of`
+
+Logical AND — all child conditions must pass.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"all_of"` |
+| `conditions` | list of Condition | yes | Child conditions to evaluate. |
+
+##### `any_of`
+
+Logical OR — at least one child condition must pass.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | yes | `"any_of"` |
+| `conditions` | list of Condition | yes | Child conditions to evaluate. |
+
+#### Assertions Example
+
+```yaml
+assertions:
+  - name: "Git is installed"
+    check:
+      type: command_exists
+      command: git
+
+  - name: "Config directory exists"
+    check:
+      type: dir_exists
+      path: "~/.config/app"
+
+  - name: "EDITOR is set to VS Code"
+    check:
+      type: env_var
+      name: EDITOR
+      value: code
+
+  - name: "Cargo bin is in PATH"
+    check:
+      type: path_contains
+      substring: ".cargo/bin"
+
+  - name: "Dark mode enabled"
+    check:
+      type: registry_value
+      hive: HKCU
+      key: "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"
+      name: AppsUseLightTheme
+      expected: "0x0"
+
+  - name: "Rust toolchain ready"
+    check:
+      type: all_of
+      conditions:
+        - type: command_exists
+          command: rustc
+        - type: command_exists
+          command: cargo
+        - type: path_contains
+          substring: ".cargo/bin"
+```
+
+### Full Example
+
+A complete `workload.yaml` demonstrating all sections:
+
+```yaml
+name: developer-tools
+version: "1.0.0"
+description: "Full developer workstation setup"
+extends:
+  - essentials
+
+packages:
+  winget:
+    - id: Git.Git
+    - id: Microsoft.VisualStudioCode
+    - id: Rustlang.Rustup
+    - id: Starship.Starship
+
+files:
+  - source: user/.config/starship.toml
+    destination: "~/.config/starship.toml"
+    backup: true
+  - source: user/.gitconfig
+    destination: "~/.gitconfig"
+    template: true
+
+scripts:
+  pre_install:
+    - path: pre-install.ps1
+      description: "System preparation"
+      timeout: 60
+
+  post_install:
+    - path: configure-terminal.ps1
+      description: "Configure Windows Terminal"
+      timeout: 300
+      elevated: true
+
+  health_check:
+    - path: health-check/check-tools.ps1
+      name: "Developer Tools"
+      description: "Verify all developer tools are installed"
+
+commands:
+  post_install:
+    - run: "rustup default stable"
+      description: "Set default Rust toolchain"
+      timeout: 120
+    - run: "cargo install cargo-watch"
+      description: "Install cargo-watch"
+      when:
+        type: command_exists
+        command: cargo
+      continue_on_error: true
+
+environment:
+  variables:
+    - name: EDITOR
+      value: code
+    - name: DOTNET_CLI_TELEMETRY_OPTOUT
+      value: "1"
+      scope: user
+  path_additions:
+    - "~/.cargo/bin"
+
+health:
+  package_check: true
+  file_check: true
+  script_check: true
+  assertion_check: true
+
+assertions:
+  - name: "Git is installed"
+    check:
+      type: command_exists
+      command: git
+  - name: "VS Code is installed"
+    check:
+      type: command_exists
+      command: code
+  - name: "Starship config deployed"
+    check:
+      type: file_exists
+      path: "~/.config/starship.toml"
+```

--- a/docs/src/specification.md
+++ b/docs/src/specification.md
@@ -1064,27 +1064,27 @@ Phases 1–6 of the original implementation are complete. This section describes
 ### 8.1 Overview
 
 ```
-v0.4 — Declarative Assertions
+v0.4 — Declarative Assertions               ✅ Implemented
     │
     ├── Reusable condition/predicate engine
     ├── assertions: YAML schema
     ├── Integration with health command
     └── Backward compatibility with scripts.health_check
 
-v0.5 — Package Manager Abstraction
+v0.5 — Package Manager Abstraction          ✅ Schema implemented
     │
-    ├── PackageManager trait
-    ├── WingetProvider adapter
-    └── Schema design for multi-manager support
+    ├── PackageManager trait                 ⬚ Pending
+    ├── WingetProvider adapter               ⬚ Pending
+    └── Schema design for multi-manager      ✅ Implemented (winget/brew/apt)
 
-v0.6 — Commands Block
+v0.6 — Commands Block                       ✅ Implemented
     │
     ├── commands: YAML schema
     ├── Conditional execution (when:)
     ├── Failure semantics
     └── Backward compatibility with scripts.post_install
 
-v0.7 — Workload Discovery & Separation
+v0.7 — Workload Discovery & Separation      ✅ Implemented
     │
     ├── Wire search_paths through ConfigManager
     ├── Search precedence and conflict resolution
@@ -1092,13 +1092,16 @@ v0.7 — Workload Discovery & Separation
 
 v1.0 — Polish & Distribution
     │
-    ├── crates.io publishing
-    ├── Cross-platform CI
+    ├── crates.io publishing                 ⬚ Pending
+    ├── Cross-platform CI                    ✅ Implemented (Windows/Linux/macOS matrix)
+    ├── Shell completions                    ✅ Implemented (bash/zsh/fish/powershell/elvish)
     ├── Remove scripts.health_check (use assertions exclusively)
     └── Documentation review
 ```
 
-### 8.2 v0.4 — Declarative Assertions
+### 8.2 v0.4 — Declarative Assertions ✅
+
+> **Status:** Implemented. Modules: `src/conditions/`, `src/assertions/`. Workload struct includes `assertions: Option<Vec<Assertion>>`. Health command evaluates assertions alongside legacy `scripts.health_check`.
 
 **Goal:** Replace ~70% of PowerShell health-check scripts with declarative YAML assertions, evaluated natively in Rust.
 
@@ -1152,7 +1155,9 @@ assertions:
 - Update `src/operations/health.rs` — evaluate assertions alongside legacy `scripts.health_check`
 - **Backward compatible** — existing `scripts.health_check` continues to work
 
-### 8.3 v0.5 — Package Manager Abstraction
+### 8.3 v0.5 — Package Manager Abstraction (Partial)
+
+> **Status:** Multi-manager schema implemented (`Packages` struct with `winget`, `brew`, `apt` fields; `BrewPackage` and `AptPackage` types defined). The `PackageManager` trait and non-winget provider implementations are still pending.
 
 **Goal:** Introduce a `PackageManager` trait so the install flow is decoupled from winget, enabling future cross-platform support.
 
@@ -1180,7 +1185,9 @@ packages:
 
 Anvil selects the available manager for the current platform. The v0.5 milestone implements the trait and refactors `WingetProvider` — other manager implementations are deferred.
 
-### 8.4 v0.6 — Commands Block
+### 8.4 v0.6 — Commands Block ✅
+
+> **Status:** Implemented. Module: `src/commands/`. Workload struct includes `commands: Option<CommandBlock>` with `pre_install` and `post_install` phases. `CommandEntry` supports `run`, `description`, `timeout`, `elevated`, `when` (condition), and `continue_on_error`. Execution engine in `commands::execute_commands()`.
 
 **Goal:** Replace post-install PowerShell scripts with inline commands that support conditional execution.
 
@@ -1205,11 +1212,11 @@ commands:
 
 The `when:` condition reuses the predicate engine from v0.4.
 
-### 8.5 v0.7 — Workload Discovery & Separation
+### 8.5 v0.7 — Workload Discovery & Separation ✅
+
+> **Status:** Implemented. `ConfigManager` loads user-configured search paths from `GlobalConfig.workloads.paths` and merges them with default paths. `add_search_path()` deduplicates entries. Search precedence matches the design below.
 
 **Goal:** Support multiple workload directories so private workloads live outside the main repo.
-
-**Current state:** `GlobalConfig` already has a `workloads.paths` field, but `ConfigManager` uses only `default_workload_paths()`. This milestone wires configured paths through all commands and defines precedence.
 
 **Search precedence:**
 1. Explicit path argument (highest priority)
@@ -1223,7 +1230,8 @@ Duplicate workload names produce a warning with the resolved path shown.
 **Goal:** Stable release with cross-platform CI and crates.io publishing.
 
 - Decide crate name (`anvil` is taken on crates.io — candidates: `anvil-cli`, `devsmith`, `forgekit`)
-- Cross-compilation CI for Windows, Linux, macOS
+- ~~Cross-compilation CI for Windows, Linux, macOS~~ ✅ Implemented (matrix build in `ci.yml`)
+- ~~Shell completions~~ ✅ Implemented (bash, zsh, fish, powershell, elvish via `cli/completions.rs`)
 - Comprehensive documentation review
 - First stable release
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -394,7 +394,145 @@ A guide to diagnosing and resolving common Anvil issues.
 
 ---
 
-## 7. Error Reference
+## 7. Workload Inheritance Issues
+
+### Circular dependency detected
+
+**Symptoms:**
+- Error: "Circular dependency detected: A → B → A"
+
+**Solutions:**
+
+1. **Inspect the `extends` chain** in each workload
+   ```yaml
+   # workload-a/workload.yaml
+   extends:
+     - workload-b     # workload-b also extends workload-a → cycle!
+   ```
+
+2. **Break the cycle** by removing one of the `extends` references
+3. **Run `anvil validate`** to see the detected chain
+
+---
+
+### Maximum inheritance depth exceeded
+
+**Symptoms:**
+- Error: "Maximum inheritance depth (10) exceeded for workload 'X'"
+
+**Solutions:**
+
+1. **Flatten the hierarchy** — the maximum allowed depth is 10
+2. **Merge intermediate workloads** to reduce nesting
+3. **Check for unintended long chains**
+   ```powershell
+   anvil show my-workload    # Review resolved inheritance
+   ```
+
+---
+
+### Parent workload not found
+
+**Symptoms:**
+- Error: "Parent workload 'X' not found"
+
+**Solutions:**
+
+1. **Verify the parent name** matches an available workload
+   ```powershell
+   anvil list    # See all available workloads
+   ```
+
+2. **Check search paths** — ensure the parent workload directory is discoverable
+   ```powershell
+   anvil config list    # Review configured workload search paths
+   ```
+
+3. **Use `--path`** if the parent is in a custom location
+   ```powershell
+   anvil install my-workload --path /path/to/workloads
+   ```
+
+---
+
+## 8. Platform-Specific Warnings
+
+### Workload references unavailable package manager
+
+**Symptoms:**
+- Warning: "Homebrew packages defined but Homebrew is not available on Windows"
+- Warning: "APT packages defined but APT is not available on Windows"
+- Warning: "Winget packages defined but winget is only available on Windows"
+
+**Solutions:**
+
+1. **Run `anvil validate --strict`** to surface these warnings
+2. **Use platform-appropriate package managers** in your workload
+   ```yaml
+   packages:
+     winget:           # Windows only
+       - id: Package.Name
+     brew:             # macOS only (planned)
+       - name: package
+     apt:              # Linux only (planned)
+       - name: package
+   ```
+
+3. **Split into platform-specific workloads** if targeting multiple OSes
+
+---
+
+## 9. Assertion and Command Failures
+
+### Assertion failure
+
+**Symptoms:**
+- Health check assertion fails with `[FAIL]`
+- Error: condition evaluation returned false
+
+**Solutions:**
+
+1. **Run the health check with verbose output** to see which assertion failed
+   ```powershell
+   anvil health my-workload -vvv
+   ```
+
+2. **Review the condition** — assertions check system state (command existence, file presence, environment variables, registry values)
+
+3. **Common assertion types and fixes:**
+   - **Command not found** — install the missing tool or add it to PATH
+   - **File missing** — re-run `anvil install` to deploy files
+   - **Environment variable not set** — check your shell profile or restart the terminal
+
+---
+
+### Command execution failure
+
+**Symptoms:**
+- Error: "Command not found: X"
+- Error: "Command timed out after N seconds"
+- Error: "Command requires elevated privileges"
+
+**Solutions:**
+
+1. **Command not found** — ensure the executable is installed and on PATH
+   ```powershell
+   Get-Command <command-name>
+   ```
+
+2. **Timeout** — increase the timeout in your workload definition
+   ```yaml
+   scripts:
+     post_install:
+       - path: slow-script.ps1
+         timeout: 1800    # 30 minutes
+   ```
+
+3. **Elevation required** — run anvil as administrator, or set `elevated: true`
+
+---
+
+## 10. Error Reference
 
 ### Common Error Codes
 
@@ -413,7 +551,7 @@ A guide to diagnosing and resolving common Anvil issues.
 
 ---
 
-## 8. Getting Help
+## 11. Getting Help
 
 ### Verbose Output
 
@@ -464,9 +602,9 @@ When [reporting issues](https://github.com/kafkade/anvil/issues), include:
 ### Resources
 
 - [GitHub Issues](https://github.com/kafkade/anvil/issues)
-- [User Guide](USER_GUIDE.md)
-- [Workload Authoring Guide](WORKLOAD_AUTHORING.md)
-- [Architecture](ARCHITECTURE.md)
+- [User Guide](user-guide.md)
+- [Workload Authoring Guide](workload-authoring.md)
+- [Architecture](architecture.md)
 
 ---
 

--- a/docs/src/user-guide.md
+++ b/docs/src/user-guide.md
@@ -192,12 +192,21 @@ anvil install <WORKLOAD> [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--dry-run` | Preview actions without making changes |
-| `--force` | Force reinstallation of packages |
+| `--force` | Skip confirmation prompts |
+| `-p, --packages-only` | Only install packages, skip files and scripts |
+| `--files-only` | Only process files, skip packages and scripts |
 | `--skip-packages` | Skip package installation |
 | `--skip-files` | Skip file operations |
-| `--skip-scripts` | Skip script execution |
-| `--output <FORMAT>` | Output format: table, json, yaml |
-| `--path <DIR>` | Custom workload search path |
+| `--skip-scripts` | Skip all script execution |
+| `--skip-pre-scripts` | Skip pre-installation scripts only |
+| `--skip-post-scripts` | Skip post-installation scripts only |
+| `--no-backup` | Don't backup existing files before overwriting |
+| `--upgrade` | Upgrade existing packages to specified versions |
+| `--retry-failed` | Retry only failed packages from previous run |
+| `--parallel` | Run installations in parallel where safe |
+| `-j, --jobs <N>` | Number of parallel installations (default: 4) |
+| `--timeout <SECONDS>` | Global timeout for operations (default: 3600) |
+| `--force-files` | Force overwrite files without checking hash |
 
 **Examples:**
 ```powershell
@@ -210,11 +219,17 @@ anvil install rust-developer --dry-run
 # Skip packages (only copy files and run scripts)
 anvil install rust-developer --skip-packages
 
-# Use JSON output for scripting
-anvil install rust-developer --dry-run --output json
+# Only deploy files
+anvil install rust-developer --files-only
 
-# Install from custom directory
-anvil install my-workload --path C:\Workloads
+# Upgrade existing packages
+anvil install rust-developer --upgrade
+
+# Retry previously failed packages
+anvil install rust-developer --retry-failed
+
+# Parallel installation with 8 workers
+anvil install rust-developer --parallel -j 8
 ```
 
 **Exit Codes:**
@@ -242,10 +257,19 @@ anvil health <WORKLOAD> [OPTIONS]
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--output <FORMAT>` | Output format: table, json, yaml, html |
-| `--file <PATH>` | Write output to file |
-| `--verbose` | Show detailed check results |
-| `--path <DIR>` | Custom workload search path |
+| `-o, --output <FORMAT>` | Output format: table, json, yaml, html |
+| `-f, --file <PATH>` | Write output to file |
+| `--fail-fast` | Stop on first failure |
+| `--packages-only` | Only check packages |
+| `--files-only` | Only check files |
+| `--scripts-only` | Only run health check scripts |
+| `--assertions-only` | Only evaluate declarative assertions |
+| `-s, --strict` | Treat warnings as errors |
+| `--fix` | Attempt to install missing packages |
+| `--update` | Update packages with available updates |
+| `--no-cache` | Skip cache and query winget directly |
+| `--show-diff` | Show file differences for modified files |
+| `--script <NAME>` | Run only a specific health check script by name |
 
 **Examples:**
 ```powershell
@@ -253,13 +277,28 @@ anvil health <WORKLOAD> [OPTIONS]
 anvil health rust-developer
 
 # Detailed output
-anvil health rust-developer --verbose
+anvil -v health rust-developer
 
 # Generate JSON report
 anvil health rust-developer --output json --file health-report.json
 
 # Generate HTML report
 anvil health rust-developer --output html --file report.html
+
+# Only check packages
+anvil health rust-developer --packages-only
+
+# Only run assertions
+anvil health rust-developer --assertions-only
+
+# Auto-fix missing packages
+anvil health rust-developer --fix
+
+# Run a specific health check script
+anvil health rust-developer --script "Git Health"
+
+# Show file diffs for modified config files
+anvil health rust-developer --show-diff
 ```
 
 **Understanding Health Reports:**
@@ -268,6 +307,7 @@ Health checks verify:
 - **Packages**: Are required packages installed? Correct versions?
 - **Files**: Do configuration files exist with expected content?
 - **Scripts**: Do health check scripts pass?
+- **Assertions**: Do declarative condition checks pass? (see [Assertion-Based Health Checks](#assertion-based-health-checks))
 
 Status indicators:
 - ✓ (Green) - Check passed
@@ -288,10 +328,11 @@ anvil list [OPTIONS]
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--all` | Include hidden/system workloads |
-| `--long` | Show detailed information |
-| `--path <DIR>` | Custom workload search path |
-| `--output <FORMAT>` | Output format: table, json, yaml |
+| `-a, --all` | Include built-in and custom workloads |
+| `-l, --long` | Show detailed information |
+| `--path <DIR>` | Search for workloads in additional path |
+| `--all-paths` | Show all discovered paths including shadowed duplicates |
+| `-o, --output <FORMAT>` | Output format: table, json, yaml, html |
 
 **Examples:**
 ```powershell
@@ -306,6 +347,9 @@ anvil list --output json
 
 # List from custom directory
 anvil list --path C:\MyWorkloads
+
+# Show all paths including shadowed duplicates
+anvil list --all-paths
 ```
 
 ---
@@ -325,10 +369,9 @@ anvil show <WORKLOAD> [OPTIONS]
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--inheritance-tree` | Show inheritance hierarchy |
-| `--resolved` | Show fully resolved workload (after inheritance) |
-| `--output <FORMAT>` | Output format: table, json, yaml |
-| `--path <DIR>` | Custom workload search path |
+| `--show-inheritance` | Show inheritance hierarchy |
+| `-r, --resolved` | Show fully resolved workload (after inheritance) |
+| `-o, --output <FORMAT>` | Output format: yaml (default), json |
 
 **Examples:**
 ```powershell
@@ -336,10 +379,10 @@ anvil show <WORKLOAD> [OPTIONS]
 anvil show rust-developer
 
 # Show inheritance tree
-anvil show rust-developer --inheritance-tree
+anvil show rust-developer --show-inheritance
 
-# Export as YAML
-anvil show rust-developer --output yaml
+# Export as JSON
+anvil show rust-developer --output json
 
 # Show resolved (merged) workload
 anvil show rust-developer --resolved
@@ -353,18 +396,19 @@ Validate workload syntax and structure.
 
 **Synopsis:**
 ```
-anvil validate <WORKLOAD> [OPTIONS]
+anvil validate <PATH> [OPTIONS]
 ```
 
 **Arguments:**
-- `<WORKLOAD>` - Name of the workload to validate
+- `<PATH>` - Path to workload.yaml file or workload directory
 
 **Options:**
 | Option | Description |
 |--------|-------------|
 | `--strict` | Enable strict validation mode |
-| `--output <FORMAT>` | Output format: table, json, yaml |
-| `--path <DIR>` | Custom workload search path |
+| `--schema` | Output JSON schema for workload definitions |
+| `--check-scripts` | Validate script syntax using PowerShell parser |
+| `--scripts-only` | Only validate scripts (skip other validation) |
 
 **Examples:**
 ```powershell
@@ -394,36 +438,38 @@ Create a new workload from a template.
 
 **Synopsis:**
 ```
-anvil init <PATH> [OPTIONS]
+anvil init <NAME> [OPTIONS]
 ```
 
 **Arguments:**
-- `<PATH>` - Directory path for the new workload
+- `<NAME>` - Name for the new workload
 
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--template <NAME>` | Template to use: minimal, full, rust, python |
-| `--force` | Overwrite existing files |
-| `--name <NAME>` | Workload name (defaults to directory name) |
+| `-t, --template <NAME>` | Template to use: minimal, standard (default), full |
+| `-e, --extends <PARENT>` | Parent workload to extend |
+| `-o, --output <PATH>` | Output directory |
 
 **Examples:**
 ```powershell
+# Create a standard workload
+anvil init my-workload
+
 # Create minimal workload
-anvil init C:\Workloads\my-workload
+anvil init my-workload --template minimal
 
-# Create from template
-anvil init C:\Workloads\my-rust-env --template rust
+# Create workload that extends essentials
+anvil init my-rust-env --extends essentials
 
-# Overwrite existing
-anvil init C:\Workloads\existing --force
+# Create in custom directory
+anvil init my-workload --output C:\Workloads
 ```
 
 **Available Templates:**
 - `minimal` - Basic structure with required fields only
+- `standard` - Common sections with sensible defaults (default)
 - `full` - Complete example with all features
-- `rust` - Rust development environment template
-- `python` - Python development environment template
 
 ---
 
@@ -442,7 +488,9 @@ anvil status [WORKLOAD] [OPTIONS]
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--output <FORMAT>` | Output format: table, json, yaml |
+| `-o, --output <FORMAT>` | Output format: table, json, yaml, html |
+| `-l, --long` | Show detailed status including timestamps |
+| `--clear` | Clear stored state for the specified workload |
 
 **Examples:**
 ```powershell
@@ -504,14 +552,37 @@ anvil backup restore <BACKUP_ID>
 
 # Preview restore
 anvil backup restore <BACKUP_ID> --dry-run
+
+# Restore all backups for a workload
+anvil backup restore --workload rust-developer
 ```
 
-#### `backup delete`
-Delete a backup.
+#### `backup clean`
+Remove old backups.
 
 ```powershell
-anvil backup delete <BACKUP_ID>
-anvil backup delete <BACKUP_ID> --force
+# Remove backups older than 30 days (default)
+anvil backup clean
+
+# Remove backups older than 7 days
+anvil backup clean --older-than 7
+
+# Preview what would be removed
+anvil backup clean --dry-run
+```
+
+#### `backup verify`
+Verify backup integrity.
+
+```powershell
+# Verify all backups
+anvil backup verify
+
+# Verify backups for a specific workload
+anvil backup verify --workload rust-developer
+
+# Fix issues by removing corrupted entries
+anvil backup verify --fix
 ```
 
 ---
@@ -527,21 +598,29 @@ anvil config <SUBCOMMAND>
 
 **Subcommands:**
 
-#### `config show`
-Display current configuration.
+#### `config get`
+Get a specific configuration value.
 
 ```powershell
-anvil config show
-anvil config show --output json
+anvil config get defaults.shell
+anvil config get workloads.paths
 ```
 
 #### `config set`
 Set a configuration value.
 
 ```powershell
-anvil config set workload_paths "C:\Workloads;D:\MoreWorkloads"
-anvil config set default_output json
-anvil config set backup.enabled true
+anvil config set defaults.shell powershell
+anvil config set defaults.output_format json
+anvil config set backup.auto_backup true
+```
+
+#### `config list`
+Display all configuration values.
+
+```powershell
+anvil config list
+anvil config list --output json
 ```
 
 #### `config reset`
@@ -549,14 +628,21 @@ Reset configuration to defaults.
 
 ```powershell
 anvil config reset
-anvil config reset --key workload_paths
+anvil config reset --force  # Skip confirmation prompt
 ```
 
 #### `config edit`
-Open configuration file in editor.
+Open configuration file in default editor.
 
 ```powershell
 anvil config edit
+```
+
+#### `config path`
+Show the configuration file path.
+
+```powershell
+anvil config path
 ```
 
 ---
@@ -571,7 +657,7 @@ anvil completions <SHELL>
 ```
 
 **Arguments:**
-- `<SHELL>` - Target shell: powershell, bash, zsh, fish
+- `<SHELL>` - Target shell: powershell, bash, zsh, fish, elvish
 
 **Examples:**
 ```powershell
@@ -592,6 +678,7 @@ These options work with all commands:
 |--------|-------|-------------|
 | `--verbose` | `-v` | Increase verbosity (use multiple times: -v, -vv, -vvv) |
 | `--quiet` | `-q` | Suppress non-essential output |
+| `--config <PATH>` | `-c` | Use custom configuration file |
 | `--no-color` | | Disable colored output |
 | `--help` | `-h` | Show help information |
 | `--version` | `-V` | Show version information |
@@ -619,67 +706,58 @@ anvil --no-color list > workloads.txt
 
 Anvil stores its configuration at:
 ```
-%APPDATA%\anvil\config.toml
+~/.anvil/config.yaml
 ```
 
-Or if `ANVIL_CONFIG` is set:
-```
-$env:ANVIL_CONFIG
+On Windows this is typically `%USERPROFILE%\.anvil\config.yaml`.
+
+You can also specify a custom config file with the `-c`/`--config` global flag:
+```powershell
+anvil -c C:\config\anvil.yaml list
 ```
 
 ### Configuration Options
 
-```toml
-# Global Anvil Configuration
+```yaml
+# Global Anvil Configuration (~/.anvil/config.yaml)
 
-# Default output format (table, json, yaml)
-default_output = "table"
+defaults:
+  shell: powershell           # Default script shell
+  script_timeout: 300         # Default script timeout in seconds
+  output_format: table        # Default output format (table, json, yaml)
+  color: auto                 # Color mode (auto, always, never)
 
-# Workload search paths (semicolon-separated)
-workload_paths = "C:\\Workloads;D:\\MyWorkloads"
+backup:
+  auto_backup: true           # Enable automatic backups before changes
+  retention_days: 30          # Days to keep backups
 
-# Enable colored output
-color = true
+install:
+  parallel: false             # Run installations in parallel by default
+  max_parallel: 4             # Max concurrent package installations
 
-# Default verbosity level (0-3)
-verbosity = 0
+workloads:
+  paths:                      # Additional workload search paths
+    - "~/my-workloads"
+    - "~/work/team-workloads"
 
-[backup]
-# Enable automatic backups before changes
-enabled = true
-
-# Backup directory
-path = "%APPDATA%\\anvil\\backups"
-
-# Maximum number of backups to keep
-max_count = 10
-
-[packages]
-# Default package source
-default_source = "winget"
-
-# Allow prerelease versions
-allow_prerelease = false
-
-[scripts]
-# Default script timeout (seconds)
-default_timeout = 300
-
-# Shell for script execution
-default_shell = "powershell"
+logging:
+  level: info                 # Log level: error, warn, info, debug, trace
 ```
 
 ### View Current Configuration
 
 ```powershell
-anvil config show
+anvil config list
 ```
 
 ### Modify Configuration
 
 ```powershell
 # Set a value
-anvil config set default_output json
+anvil config set defaults.output_format json
+
+# Get a value
+anvil config get defaults.shell
 
 # Reset to default
 anvil config reset
@@ -768,7 +846,7 @@ extends:
 
 View the inheritance tree:
 ```powershell
-anvil show my-rust-env --inheritance-tree
+anvil show my-rust-env --show-inheritance
 ```
 
 Output:
@@ -787,7 +865,7 @@ anvil list --path C:\MyWorkloads
 anvil install my-workload --path C:\MyWorkloads
 
 # Configure permanently
-anvil config set workload_paths "C:\MyWorkloads"
+anvil config set workloads.paths '["C:\\MyWorkloads"]'
 ```
 
 ### Validating Before Install
@@ -887,17 +965,17 @@ Generates a styled HTML document with:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ANVIL_CONFIG` | Configuration file path | `%APPDATA%\anvil\config.toml` |
+| `ANVIL_CONFIG` | Configuration file path | `~/.anvil/config.yaml` |
 | `ANVIL_WORKLOADS` | Additional workload search paths | (none) |
 | `ANVIL_LOG` | Log level: error, warn, info, debug, trace | `warn` |
 | `NO_COLOR` | Disable colored output (any value) | (unset) |
-| `ANVIL_BACKUP_DIR` | Backup storage directory | `%APPDATA%\anvil\backups` |
+| `ANVIL_BACKUP_DIR` | Backup storage directory | `~/.anvil/backups` |
 
 **Examples:**
 
 ```powershell
 # Use custom config file
-$env:ANVIL_CONFIG = "C:\config\anvil.toml"
+$env:ANVIL_CONFIG = "C:\config\anvil.yaml"
 anvil list
 
 # Add workload search paths
@@ -936,7 +1014,7 @@ Verify your system state periodically:
 anvil health rust-developer
 
 # Detailed report
-anvil health rust-developer --verbose --output html --file health.html
+anvil -v health rust-developer --output html --file health.html
 ```
 
 ### Keep Backups
@@ -944,7 +1022,7 @@ anvil health rust-developer --verbose --output html --file health.html
 Enable automatic backups in configuration:
 
 ```powershell
-anvil config set backup.enabled true
+anvil config set backup.auto_backup true
 ```
 
 Or create manual backups before major changes:
@@ -1037,6 +1115,94 @@ catch {
     Write-Error "Health check failed: $_"
     exit 1
 }
+```
+
+---
+
+## 11. Assertion-Based Health Checks
+
+In addition to package, file, and script checks, workloads can define **declarative assertions** using a built-in condition engine. Assertions let you express health checks directly in YAML without writing PowerShell scripts.
+
+### Defining Assertions
+
+Add an `assertions` section to your `workload.yaml`:
+
+```yaml
+name: my-workload
+version: "1.0.0"
+assertions:
+  - name: "Git is installed"
+    check:
+      type: command_exists
+      command: git
+
+  - name: "Config directory exists"
+    check:
+      type: dir_exists
+      path: "~/.config/my-app"
+
+  - name: "GOPATH is set"
+    check:
+      type: env_var
+      name: GOPATH
+
+  - name: "Cargo in PATH"
+    check:
+      type: path_contains
+      substring: ".cargo\\bin"
+```
+
+### Available Condition Types
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `command_exists` | `command` | Check if a command is available on PATH |
+| `file_exists` | `path` | Check if a file exists (`~` expanded) |
+| `dir_exists` | `path` | Check if a directory exists (`~` expanded) |
+| `env_var` | `name`, `value` (optional) | Check if env var is set, optionally matching a value |
+| `path_contains` | `substring` | Check if PATH contains a substring |
+| `registry_value` | `hive`, `key`, `name`, `expected` (optional) | Query a Windows registry value |
+| `shell` | `command`, `description` (optional) | Run a shell command; passes if exit code is 0 |
+| `all_of` | `conditions` | All child conditions must pass (logical AND) |
+| `any_of` | `conditions` | At least one child must pass (logical OR) |
+
+### Composing Conditions
+
+Use `all_of` and `any_of` to build complex checks:
+
+```yaml
+assertions:
+  - name: "Rust toolchain ready"
+    check:
+      type: all_of
+      conditions:
+        - type: command_exists
+          command: rustc
+        - type: command_exists
+          command: cargo
+        - type: path_contains
+          substring: ".cargo\\bin"
+```
+
+### Running Assertions
+
+Assertions are evaluated as part of `anvil health`:
+
+```powershell
+# Run all health checks including assertions
+anvil health my-workload
+
+# Run only assertions
+anvil health my-workload --assertions-only
+```
+
+### Controlling Assertions in Health Config
+
+You can disable assertion evaluation per-workload:
+
+```yaml
+health:
+  assertion_check: false   # Skip assertions during health checks
 ```
 
 ---

--- a/docs/src/workload-authoring.md
+++ b/docs/src/workload-authoring.md
@@ -55,6 +55,7 @@ extends: string[]               # Parent workloads to inherit from
 packages: object                # Package definitions
 files: array                    # File deployment definitions
 scripts: object                 # Script execution definitions
+commands: object                # Inline command definitions
 environment: object             # Environment variable configuration
 assertions: array               # Declarative health assertions
 health: object                  # Health check configuration
@@ -108,14 +109,17 @@ File deployment definitions (see [File Definitions](#4-file-definitions)).
 #### `scripts`
 Script execution definitions (see [Script Definitions](#5-script-definitions)).
 
+#### `commands`
+Inline command definitions (see [Commands (Inline)](#6-commands-inline)).
+
 #### `environment`
-Environment variable configuration (see [Environment Configuration](#6-environment-configuration)).
+Environment variable configuration (see [Environment Configuration](#7-environment-configuration)).
 
 ---
 
 ## 3. Package Definitions
 
-Define software packages to install via Windows Package Manager (winget).
+Define software packages to install. Anvil supports multiple package managers: **winget** (Windows), **brew** (macOS/Linux), and **apt** (Debian/Ubuntu).
 
 ### Basic Structure
 
@@ -211,6 +215,60 @@ packages:
         - "/SILENT"
 ```
 
+### Multi-Manager Packages
+
+Define packages for multiple package managers in a single workload. Anvil selects the appropriate manager for the current platform.
+
+```yaml
+packages:
+  winget:
+    - id: Git.Git
+    - id: Microsoft.VisualStudioCode
+  brew:
+    - name: git
+    - name: visual-studio-code
+      cask: true
+  apt:
+    - name: git
+    - name: build-essential
+```
+
+### Homebrew Packages (macOS/Linux)
+
+```yaml
+packages:
+  brew:
+    - name: git                        # CLI formula
+    - name: visual-studio-code         # GUI cask
+      cask: true
+    - name: font-cascadia-code         # Cask from a tap
+      cask: true
+      tap: "homebrew/cask-fonts"
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `name` | Yes | - | Homebrew formula or cask name |
+| `cask` | No | `false` | Whether this is a cask (GUI app) vs formula (CLI tool) |
+| `tap` | No | - | Tap source (e.g., `"homebrew/cask-fonts"`) |
+
+### APT Packages (Debian/Ubuntu)
+
+```yaml
+packages:
+  apt:
+    - name: git
+    - name: build-essential
+      version: "12.9"
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `name` | Yes | - | APT package name |
+| `version` | No | - | Specific version constraint |
+
+> **Note:** Homebrew and APT support is schema-complete but not yet fully implemented. Winget is the primary supported manager today.
+
 ---
 
 ## 4. File Definitions
@@ -232,9 +290,8 @@ files:
   - source: relative/path/in/workload/file.conf
     destination: "~/target/path/file.conf"
     backup: true                  # Backup existing file
-    mode: "0644"                  # Optional: file permissions
+    permissions: "0644"           # Optional: file permissions
     template: false               # Process as Handlebars template
-    create_dirs: true             # Create parent directories
 ```
 
 ### File Fields
@@ -244,9 +301,8 @@ files:
 | `source` | Yes | - | Path relative to workload directory |
 | `destination` | Yes | - | Target path on system |
 | `backup` | No | `true` | Backup existing files before overwriting |
-| `mode` | No | - | File permissions (Unix-style, informational on Windows) |
+| `permissions` | No | - | File permissions (Unix-style, informational on Windows) |
 | `template` | No | `false` | Process file as Handlebars template |
-| `create_dirs` | No | `true` | Create parent directories if missing |
 
 ### Path Variables
 
@@ -355,9 +411,6 @@ scripts:
       description: "Configure application settings"
       elevated: false             # Run as administrator
       timeout: 300                # Timeout in seconds
-      continue_on_error: false    # Continue if script fails
-      env:                        # Additional environment variables
-        MY_VAR: "value"
 ```
 
 ### Script Fields
@@ -369,9 +422,8 @@ scripts:
 | `description` | No | - | Human-readable description |
 | `elevated` | No | `false` | Run with administrator privileges |
 | `timeout` | No | `300` | Timeout in seconds |
-| `continue_on_error` | No | `false` | Continue installation if script fails |
-| `env` | No | - | Additional environment variables |
-| `name` | No | - | Display name (for health checks) |
+
+> **Note:** Health check scripts use a separate schema with `name` (required) and `shell` fields, but do not support `timeout` or `elevated`.
 
 ### Health Check Scripts
 
@@ -551,7 +603,93 @@ exit 0
 
 ---
 
-## 6. Environment Configuration
+## 6. Commands (Inline)
+
+Commands let you run arbitrary shell commands directly from `workload.yaml` without creating separate script files. They support conditional execution via the same predicate engine used by [Assertions](#8-assertions).
+
+Use commands for simple one-liners (e.g., `cargo install`, `npm install -g`). Use scripts for complex multi-step logic that benefits from a dedicated file.
+
+### Basic Structure
+
+```yaml
+commands:
+  pre_install:
+    - run: "echo Preparing environment"
+  post_install:
+    - run: "cargo install ripgrep"
+      description: "Install ripgrep via cargo"
+```
+
+### Full Command Options
+
+```yaml
+commands:
+  post_install:
+    - run: "cargo install cargo-watch"
+      description: "Install cargo-watch"
+      timeout: 600                    # Timeout in seconds (default: 300)
+      elevated: false                 # Require admin privileges (default: false)
+      continue_on_error: false        # Continue if this command fails (default: false)
+      when:                           # Condition — skip if not met
+        type: command_exists
+        command: cargo
+```
+
+### Command Fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `run` | Yes | - | Shell command string to execute |
+| `description` | No | - | Human-readable description |
+| `timeout` | No | `300` | Timeout in seconds |
+| `elevated` | No | `false` | Require administrator privileges |
+| `continue_on_error` | No | `false` | Continue to next command if this one fails |
+| `when` | No | - | Condition predicate; command is skipped when not met |
+
+### Conditional Execution
+
+The `when` field accepts any condition type from the [Assertions](#8-assertions) predicate engine:
+
+```yaml
+commands:
+  post_install:
+    # Only runs if cargo is on PATH
+    - run: "cargo install sccache"
+      description: "Install sccache"
+      when:
+        type: command_exists
+        command: cargo
+
+    # Only runs if the config file doesn't already exist
+    - run: "echo '{}' > ~/.config/app/config.json"
+      description: "Create default config"
+      when:
+        type: file_exists
+        path: "~/.config/app/config.json"
+```
+
+### Command Phases
+
+| Phase | When it runs |
+|-------|-------------|
+| `pre_install` | Before package installation |
+| `post_install` | After package installation |
+
+### Error Handling
+
+By default, if a command fails (non-zero exit code), execution stops and subsequent commands are skipped. Set `continue_on_error: true` to keep going:
+
+```yaml
+commands:
+  post_install:
+    - run: "cargo install cargo-watch"
+      continue_on_error: true        # Failure won't stop the next command
+    - run: "cargo install cargo-edit"
+```
+
+---
+
+## 7. Environment Configuration
 
 Configure environment variables and PATH additions.
 
@@ -612,7 +750,7 @@ PATH additions are appended to the existing PATH for the specified scope.
 
 ---
 
-## 7. Assertions
+## 8. Assertions
 
 Assertions are declarative health checks defined directly in `workload.yaml`. They let you validate system state — such as installed commands, existing files, environment variables, and PATH entries — without writing PowerShell scripts.
 
@@ -806,7 +944,7 @@ health:
 
 ---
 
-## 8. Inheritance
+## 9. Inheritance
 
 Workloads can extend other workloads to inherit their configuration.
 
@@ -909,7 +1047,7 @@ anvil show my-workload --resolved
 
 ---
 
-## 9. Variable Expansion
+## 10. Variable Expansion
 
 Use variables in paths and values for dynamic configuration.
 
@@ -959,7 +1097,7 @@ environment:
 
 ---
 
-## 10. Best Practices
+## 11. Best Practices
 
 ### Workload Design
 
@@ -1077,7 +1215,7 @@ environment:
 
 ---
 
-## 11. Example Workloads
+## 12. Example Workloads
 
 ### Minimal Workload
 
@@ -1156,6 +1294,24 @@ scripts:
       name: "Rust Environment"
       description: "Verify Rust development environment"
 
+commands:
+  post_install:
+    - run: "rustup component add rustfmt clippy"
+      description: "Add Rust components"
+      when:
+        type: command_exists
+        command: rustup
+
+assertions:
+  - name: cargo is available
+    check:
+      type: command_exists
+      command: cargo
+  - name: Cargo bin on PATH
+    check:
+      type: path_contains
+      substring: ".cargo/bin"
+
 environment:
   variables:
     - name: RUST_BACKTRACE
@@ -1223,7 +1379,7 @@ catch {
 
 ---
 
-## 12. Private Workload Repositories
+## 13. Private Workload Repositories
 
 You can maintain your own workloads in a separate Git repository and configure Anvil to discover them.
 

--- a/src/cli/banner.rs
+++ b/src/cli/banner.rs
@@ -27,19 +27,55 @@ const LOGO: &[&str] = &[
 /// Gradient from white-hot (top) to deep red (bottom)
 fn gradient_color(line_index: usize) -> Color {
     match line_index {
-        0 => Color::Rgb { r: 254, g: 243, b: 199 },
-        1 => Color::Rgb { r: 253, g: 224, b: 71 },
-        2 => Color::Rgb { r: 251, g: 191, b: 36 },
-        3 => Color::Rgb { r: 245, g: 158, b: 11 },
-        4 => Color::Rgb { r: 249, g: 115, b: 22 },
-        5 => Color::Rgb { r: 239, g: 68, b: 68 },
-        6 => Color::Rgb { r: 220, g: 38, b: 38 },
-        7 => Color::Rgb { r: 185, g: 28, b: 28 },
+        0 => Color::Rgb {
+            r: 254,
+            g: 243,
+            b: 199,
+        },
+        1 => Color::Rgb {
+            r: 253,
+            g: 224,
+            b: 71,
+        },
+        2 => Color::Rgb {
+            r: 251,
+            g: 191,
+            b: 36,
+        },
+        3 => Color::Rgb {
+            r: 245,
+            g: 158,
+            b: 11,
+        },
+        4 => Color::Rgb {
+            r: 249,
+            g: 115,
+            b: 22,
+        },
+        5 => Color::Rgb {
+            r: 239,
+            g: 68,
+            b: 68,
+        },
+        6 => Color::Rgb {
+            r: 220,
+            g: 38,
+            b: 38,
+        },
+        7 => Color::Rgb {
+            r: 185,
+            g: 28,
+            b: 28,
+        },
         _ => Color::White,
     }
 }
 
-const CROSSBAR_COLOR: Color = Color::Rgb { r: 127, g: 29, b: 29 };
+const CROSSBAR_COLOR: Color = Color::Rgb {
+    r: 127,
+    g: 29,
+    b: 29,
+};
 
 /// Print a single logo line with gradient color and crossbar highlighting
 fn print_logo_line(stdout: &mut io::Stdout, index: usize) -> io::Result<()> {
@@ -111,11 +147,19 @@ fn animate_version() -> io::Result<()> {
     thread::sleep(Duration::from_millis(80));
 
     println!();
-    stdout.execute(SetForegroundColor(Color::Rgb { r: 251, g: 191, b: 36 }))?;
+    stdout.execute(SetForegroundColor(Color::Rgb {
+        r: 251,
+        g: 191,
+        b: 36,
+    }))?;
     stdout.execute(SetAttribute(Attribute::Bold))?;
     print!("   anvil ");
     stdout.execute(SetAttribute(Attribute::Reset))?;
-    stdout.execute(SetForegroundColor(Color::Rgb { r: 148, g: 163, b: 184 }))?;
+    stdout.execute(SetForegroundColor(Color::Rgb {
+        r: 148,
+        g: 163,
+        b: 184,
+    }))?;
     println!("v{VERSION}");
 
     // Reset colors and show cursor

--- a/src/cli/banner.rs
+++ b/src/cli/banner.rs
@@ -1,0 +1,125 @@
+//! Animated version banner for Anvil CLI
+//!
+//! Displays the forge lettermark logo with a molten gradient animation
+//! when `anvil --version` is invoked.
+
+use crossterm::{
+    cursor,
+    style::{self, Attribute, Color, SetAttribute, SetForegroundColor},
+    ExecutableCommand,
+};
+use std::io::{self, Write};
+use std::{thread, time::Duration};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const LOGO: &[&str] = &[
+    "          ██          ",
+    "         ████         ",
+    "        ██  ██        ",
+    "       ██    ██       ",
+    "      ██ ████ ██      ",
+    "     ██  ████  ██     ",
+    "    ██   ████   ██    ",
+    "   ████████████████   ",
+];
+
+/// Gradient from white-hot (top) to deep red (bottom)
+fn gradient_color(line_index: usize) -> Color {
+    match line_index {
+        0 => Color::Rgb { r: 254, g: 243, b: 199 },
+        1 => Color::Rgb { r: 253, g: 224, b: 71 },
+        2 => Color::Rgb { r: 251, g: 191, b: 36 },
+        3 => Color::Rgb { r: 245, g: 158, b: 11 },
+        4 => Color::Rgb { r: 249, g: 115, b: 22 },
+        5 => Color::Rgb { r: 239, g: 68, b: 68 },
+        6 => Color::Rgb { r: 220, g: 38, b: 38 },
+        7 => Color::Rgb { r: 185, g: 28, b: 28 },
+        _ => Color::White,
+    }
+}
+
+const CROSSBAR_COLOR: Color = Color::Rgb { r: 127, g: 29, b: 29 };
+
+/// Print a single logo line with gradient color and crossbar highlighting
+fn print_logo_line(stdout: &mut io::Stdout, index: usize) -> io::Result<()> {
+    let outer = gradient_color(index);
+
+    match index {
+        4 => {
+            stdout.execute(SetForegroundColor(outer))?;
+            print!("      ██ ");
+            stdout.execute(SetForegroundColor(CROSSBAR_COLOR))?;
+            print!("████");
+            stdout.execute(SetForegroundColor(outer))?;
+            println!(" ██      ");
+        }
+        5 => {
+            stdout.execute(SetForegroundColor(outer))?;
+            print!("     ██  ");
+            stdout.execute(SetForegroundColor(CROSSBAR_COLOR))?;
+            print!("████");
+            stdout.execute(SetForegroundColor(outer))?;
+            println!("  ██     ");
+        }
+        6 => {
+            stdout.execute(SetForegroundColor(outer))?;
+            print!("    ██   ");
+            stdout.execute(SetForegroundColor(CROSSBAR_COLOR))?;
+            print!("████");
+            stdout.execute(SetForegroundColor(outer))?;
+            println!("   ██    ");
+        }
+        _ => {
+            stdout.execute(SetForegroundColor(outer))?;
+            println!("{}", LOGO[index]);
+        }
+    }
+    stdout.flush()
+}
+
+/// Show the animated version banner. Falls back to plain text if the terminal
+/// doesn't support the animation (e.g., piped output).
+pub fn show_version() {
+    if atty::is(atty::Stream::Stdout) {
+        if animate_version().is_err() {
+            print_plain_version();
+        }
+    } else {
+        print_plain_version();
+    }
+}
+
+fn print_plain_version() {
+    println!("anvil {VERSION}");
+}
+
+fn animate_version() -> io::Result<()> {
+    let mut stdout = io::stdout();
+    let frame_delay = Duration::from_millis(55);
+
+    // Hide cursor during animation
+    stdout.execute(cursor::Hide)?;
+
+    // Reveal logo line by line
+    for i in 0..LOGO.len() {
+        print_logo_line(&mut stdout, i)?;
+        thread::sleep(frame_delay);
+    }
+
+    // Brief pause, then version info
+    thread::sleep(Duration::from_millis(80));
+
+    println!();
+    stdout.execute(SetForegroundColor(Color::Rgb { r: 251, g: 191, b: 36 }))?;
+    stdout.execute(SetAttribute(Attribute::Bold))?;
+    print!("   anvil ");
+    stdout.execute(SetAttribute(Attribute::Reset))?;
+    stdout.execute(SetForegroundColor(Color::Rgb { r: 148, g: 163, b: 184 }))?;
+    println!("v{VERSION}");
+
+    // Reset colors and show cursor
+    stdout.execute(style::ResetColor)?;
+    stdout.execute(cursor::Show)?;
+    stdout.flush()
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,13 +2,13 @@
 //!
 //! This module defines the CLI structure for Anvil using clap's derive macros.
 
+pub mod banner;
 pub mod commands;
 pub mod completions;
 #[allow(dead_code)]
 pub mod formats;
 pub mod output;
 pub mod progress;
-pub mod banner;
 
 use clap::{Parser, Subcommand};
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod completions;
 pub mod formats;
 pub mod output;
 pub mod progress;
+pub mod banner;
 
 use clap::{Parser, Subcommand};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,13 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use crate::cli::{Cli, Commands};
 
 fn main() -> Result<()> {
+    // Show animated banner for --version/-V before clap processes it
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        cli::banner::show_version();
+        return Ok(());
+    }
+
     // Initialize logging
     init_logging();
 


### PR DESCRIPTION
## Description

Complete documentation overhaul, project branding, and animated version banner for the Anvil documentation website.

### What's included

- **Documentation review** — all 7 docs reviewed against the codebase and updated: fixed 30+ incorrect/missing CLI flags in user-guide.md, added missing modules to architecture.md, added 3 new troubleshooting sections, updated roadmap status indicators in specification.md, added commands/assertions/multi-manager coverage to workload-authoring.md
- **CLI reference** — new `cli-reference.md` with every command, subcommand, flag, environment variable, and exit code documented from actual `--help` output
- **Schema reference** — new `schema-reference.md` with complete config file (14 fields) and workload YAML schema (all structs, all 9 condition types)
- **Cookbook** — new `cookbook.md` with 10 self-contained recipes covering packages, files, scripts, assertions, commands, inheritance, env vars, private repos, and reports
- **Branding** — forge lettermark logo (SVG) as favicon, sidebar mark, and centered README header with sponsor badge
- **Website redesign** — Inter body font, Space Grotesk headings, Lilex code font, 18px base size, Ayu/Rust theme only, custom CSS
- **Animated version banner** — `anvil --version` shows the forge "A" with a line-by-line reveal animation and molten color gradient (ratatui/crossterm)

## Related Issues

Closes #24, Closes #26, Closes #27, Closes #28

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)