### PR TITLE
feat: automated crates.io publishing, release script, and cross-platform docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,17 @@ jobs:
             --notes "${{ steps.extract.outputs.release_notes }}" \
             ${{ steps.prerelease.outputs.flag }} \
             artifacts/*
+
+  publish:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --no-verify

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -365,17 +365,26 @@ anvil status -o json
 
 **Examples:**
 
-```sh
-# PowerShell — add to $PROFILE
+**PowerShell:**
+```powershell
+anvil completions powershell | Out-String | Invoke-Expression
+
+# Or persist to $PROFILE
 anvil completions powershell >> $PROFILE
+```
 
-# Bash
+**Bash:**
+```bash
 anvil completions bash > ~/.local/share/bash-completion/completions/anvil
+```
 
-# Zsh
+**Zsh:**
+```zsh
 anvil completions zsh > ~/.zfunc/_anvil
+```
 
-# Fish
+**Fish:**
+```fish
 anvil completions fish > ~/.config/fish/completions/anvil.fish
 ```
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -90,7 +90,7 @@ What actually happened.
 
 ### Building
 
-```powershell
+```sh
 # Clone your fork
 git clone https://github.com/YOUR_USERNAME/anvil.git
 cd anvil
@@ -116,7 +116,7 @@ cargo run -- -vvv list
 
 ### Running Tests
 
-```powershell
+```sh
 # Run all tests
 cargo test
 
@@ -429,6 +429,58 @@ scripts:
       name: "Verification"
       description: "Verify installation"
 ```
+
+---
+
+## Releasing
+
+Releases are automated via the `scripts/release.ps1` script and GitHub Actions.
+
+### Cutting a release
+
+```powershell
+# Preview what will happen
+./scripts/release.ps1 minor -DryRun
+
+# Bump version, stamp changelog, commit, tag, and push
+./scripts/release.ps1 minor -Push
+
+# Patch release (0.6.0 → 0.6.1)
+./scripts/release.ps1 patch -Push
+
+# Major release (0.6.0 → 1.0.0)
+./scripts/release.ps1 major -Push
+```
+
+The script validates (clean tree, main branch, tests pass, clippy clean) before making any changes. On push, the release workflow automatically:
+
+1. Builds binaries for 5 platforms (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64)
+2. Creates a GitHub Release with changelog notes and SHA256 checksums
+3. Publishes to [crates.io](https://crates.io/crates/anvil-cli)
+
+### Required secrets
+
+| Secret | Where to create | Used by |
+|--------|----------------|---------|
+| `CARGO_REGISTRY_TOKEN` | [crates.io/settings/tokens](https://crates.io/settings/tokens) | `cargo publish` |
+
+The `GITHUB_TOKEN` is provided automatically by GitHub Actions.
+
+### Setting up crates.io publishing (one-time)
+
+1. Log in at [crates.io](https://crates.io) with your GitHub account
+2. Go to [Account Settings → API Tokens](https://crates.io/settings/tokens)
+3. Click **New Token**
+4. Name: `anvil-release` (or any descriptive name)
+5. Scopes: select **publish-update** (allows publishing new versions of existing crates)
+6. Click **Create**
+7. Copy the token (it's shown only once)
+8. In the GitHub repo, go to **Settings → Secrets and variables → Actions**
+9. Click **New repository secret**
+10. Name: `CARGO_REGISTRY_TOKEN`, Value: paste the token
+11. Click **Add secret**
+
+For the first publish, you must also run `cargo publish` locally once to claim the crate name on crates.io.
 
 ---
 

--- a/docs/src/user-guide.md
+++ b/docs/src/user-guide.md
@@ -48,17 +48,35 @@ cargo install anvil-cli
 1. Download the latest release from the [Releases page](https://github.com/kafkade/anvil/releases)
 
 2. Extract the archive:
+
+   **PowerShell (Windows):**
    ```powershell
    Expand-Archive anvil-v0.3.1-windows-x64.zip -DestinationPath C:\Tools\anvil
    ```
 
+   **Bash / Zsh (macOS / Linux):**
+   ```bash
+   tar xzf anvil-v0.3.1-linux-x64.tar.gz -C ~/.local/bin
+   ```
+
 3. Add to your PATH:
+
+   **PowerShell:**
    ```powershell
    # Add to current session
    $env:PATH += ";C:\Tools\anvil"
    
    # Add permanently (User scope)
    [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";C:\Tools\anvil", "User")
+   ```
+
+   **Bash / Zsh:**
+   ```bash
+   # Add to current session
+   export PATH="$HOME/.local/bin:$PATH"
+
+   # Add permanently
+   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc   # or ~/.zshrc
    ```
 
 ### Build from Source
@@ -411,15 +429,24 @@ anvil validate <PATH> [OPTIONS]
 | `--scripts-only` | Only validate scripts (skip other validation) |
 
 **Examples:**
-```powershell
+```sh
 # Basic validation
 anvil validate my-workload
 
 # Strict mode (treats warnings as errors)
 anvil validate my-workload --strict
+```
 
-# Validate all bundled workloads
+Validate all bundled workloads:
+
+**PowerShell:**
+```powershell
 anvil list --output json | ConvertFrom-Json | ForEach-Object { anvil validate $_.name }
+```
+
+**Bash / Zsh:**
+```bash
+anvil list --output json | jq -r '.[].name' | xargs -I {} anvil validate {} --strict
 ```
 
 **Common Validation Errors:**
@@ -660,12 +687,18 @@ anvil completions <SHELL>
 - `<SHELL>` - Target shell: powershell, bash, zsh, fish, elvish
 
 **Examples:**
-```powershell
-# Generate PowerShell completions
-anvil completions powershell
 
-# Generate and install bash completions
-anvil completions bash > /etc/bash_completion.d/anvil
+**PowerShell:**
+```powershell
+anvil completions powershell | Out-String | Invoke-Expression
+
+# Or save to a file and source it from $PROFILE
+anvil completions powershell > $HOME\Documents\WindowsPowerShell\anvil.ps1
+```
+
+**Bash:**
+```bash
+anvil completions bash > ~/.local/share/bash-completion/completions/anvil
 ```
 
 ---
@@ -973,6 +1006,7 @@ Generates a styled HTML document with:
 
 **Examples:**
 
+**PowerShell:**
 ```powershell
 # Use custom config file
 $env:ANVIL_CONFIG = "C:\config\anvil.yaml"
@@ -988,6 +1022,25 @@ anvil install rust-developer
 
 # Disable colors
 $env:NO_COLOR = "1"
+anvil list
+```
+
+**Bash / Zsh:**
+```bash
+# Use custom config file
+export ANVIL_CONFIG="$HOME/.config/anvil.yaml"
+anvil list
+
+# Add workload search paths
+export ANVIL_WORKLOADS="$HOME/workloads:$HOME/more-workloads"
+anvil list
+
+# Enable debug logging
+export ANVIL_LOG=debug
+anvil install rust-developer
+
+# Disable colors
+export NO_COLOR=1
 anvil list
 ```
 
@@ -1076,6 +1129,7 @@ packages:
 
 Add validation to your CI/CD pipeline:
 
+**PowerShell:**
 ```powershell
 # Validate all workloads
 Get-ChildItem -Directory | ForEach-Object {
@@ -1083,16 +1137,34 @@ Get-ChildItem -Directory | ForEach-Object {
 }
 ```
 
+**Bash / Zsh:**
+```bash
+# Validate all workloads
+for dir in */; do
+    anvil validate "${dir%/}" --strict
+done
+```
+
 ### Use Verbose Output for Debugging
 
 When things go wrong:
 
-```powershell
+```sh
 # Increase verbosity
 anvil -vvv install my-workload
+```
 
+**PowerShell:**
+```powershell
 # Enable trace logging
 $env:ANVIL_LOG = "trace"
+anvil install my-workload
+```
+
+**Bash / Zsh:**
+```bash
+# Enable trace logging
+export ANVIL_LOG=trace
 anvil install my-workload
 ```
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -421,9 +421,7 @@ mod install_command {
 
     #[test]
     fn install_dry_run_shows_plan() {
-        assert_or_skip_winget!(
-            anvil().args(["install", "./examples/minimal", "--dry-run"])
-        );
+        assert_or_skip_winget!(anvil().args(["install", "./examples/minimal", "--dry-run"]));
     }
 
     #[test]
@@ -449,16 +447,22 @@ mod install_command {
 
     #[test]
     fn install_with_skip_files() {
-        assert_or_skip_winget!(
-            anvil().args(["install", "./examples/minimal", "--dry-run", "--skip-files"])
-        );
+        assert_or_skip_winget!(anvil().args([
+            "install",
+            "./examples/minimal",
+            "--dry-run",
+            "--skip-files"
+        ]));
     }
 
     #[test]
     fn install_with_skip_scripts() {
-        assert_or_skip_winget!(
-            anvil().args(["install", "./examples/minimal", "--dry-run", "--skip-scripts"])
-        );
+        assert_or_skip_winget!(anvil().args([
+            "install",
+            "./examples/minimal",
+            "--dry-run",
+            "--skip-scripts"
+        ]));
         anvil()
             .args([
                 "install",
@@ -487,9 +491,12 @@ mod install_command {
 
     #[test]
     fn install_packages_only() {
-        assert_or_skip_winget!(
-            anvil().args(["install", "./examples/minimal", "--dry-run", "--packages-only"])
-        );
+        assert_or_skip_winget!(anvil().args([
+            "install",
+            "./examples/minimal",
+            "--dry-run",
+            "--packages-only"
+        ]));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Add automated crates.io publishing, cross-platform documentation, release tooling, and test resilience improvements.

### What's included

- **Automated crates.io publishing** — new `publish` job in the release workflow runs `cargo publish` after the GitHub Release is created, using the `CARGO_REGISTRY_TOKEN` secret
- **Release script** — `scripts/release.ps1` automates version bumping, changelog stamping, and tagging with `patch`/`minor`/`major` support and preflight checks (tests, clippy, clean tree)
- **Cross-platform documentation** — added PowerShell and Bash/Zsh equivalents for shell-specific commands in user-guide, cli-reference, and contributing docs
- **Resilient winget tests** — replaced compile-time `#[cfg(target_os)]` guards with runtime `assert_or_skip_winget!` macro that skips tests when winget is flaky, not just absent
- **Release process docs** — new "Releasing" section in contributing.md covering the release script, required secrets, and crates.io setup steps

## Related Issues

Relates to #41

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] CI / infrastructure
- [ ] Refactoring (no functional changes)
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)