### PR TITLE
feat!: remove deprecated scripts.health_check in favor of assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- `scripts.health_check` field — use declarative `assertions` instead
+- `--scripts-only` and `--script` flags from `anvil health` command
+
 ## [0.6.0] - 2026-04-17
 
 ### Added
@@ -35,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests no longer fail on Linux and macOS due to winget-dependent tests running on non-Windows platforms
 
 ### Deprecated
-- `scripts.health_check` when used alongside `assertions` (migrate to declarative assertions; removal planned for v1.0)
+- ~~`scripts.health_check` when used alongside `assertions`~~ — **removed** (see Removed above)
 - `scripts.pre_install` and `scripts.post_install` when used alongside `commands` (migrate to inline commands; removal planned for v1.0)
 
 ## [0.5.0] - 2026-04-17

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,10 +422,15 @@ packages:
     - id: Package.ID
 
 scripts:
-  health_check:
-    - path: scripts/health.ps1
-      name: "Verification"
-      description: "Verify installation"
+  post_install:
+    - path: scripts/setup.ps1
+      description: "Install and configure"
+
+assertions:
+  - name: "Tool is available"
+    check:
+      type: command_exists
+      command: my-tool
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -121,10 +121,12 @@ scripts:
   post_install:
     - path: scripts/setup.ps1
       description: "Install Rust components"
-      
-  health_check:
-    - path: scripts/health.ps1
-      name: "Rust Toolchain"
+
+assertions:
+  - name: "Cargo is available"
+    check:
+      type: command_exists
+      command: cargo
 ```
 
 ## 🔧 CLI Reference

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -27,10 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crate renamed to `anvil-cli` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-cli`)
 
 ### Deprecated
-- `scripts.health_check` when used alongside `assertions` (migrate to declarative assertions; removal planned for v1.0)
+- ~~`scripts.health_check` when used alongside `assertions`~~ — **removed in this release** (see Removed)
 - `scripts.pre_install` and `scripts.post_install` when used alongside `commands` (migrate to inline commands; removal planned for v1.0)
 
-## [0.5.0] - 2026-04-17
+### Removed
+- `scripts.health_check` field — use declarative `assertions` instead
+- `--scripts-only` and `--script` flags from `anvil health` command
+- `script_check` field from `health` configuration
+
+## [0.5.0]- 2026-04-17
 
 This is the first release from the new repository home at [kafkade/anvil](https://github.com/kafkade/anvil). It marks a fresh start with modernized CI/CD, updated documentation, and a clear cross-platform direction. Prior changelog entries (v0.1.0–v0.3.1) are preserved below for historical context.
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -102,14 +102,12 @@ anvil install essentials --files-only --force-files
 | `--fail-fast` | — | Stop on first failure |
 | `--packages-only` | — | Only check packages |
 | `--files-only` | — | Only check files |
-| `--scripts-only` | — | Only run health check scripts |
 | `--assertions-only` | — | Only evaluate declarative assertions |
 | `-s, --strict` | — | Treat warnings as errors |
 | `--fix` | — | Attempt to install missing packages |
 | `--update` | — | Update packages with available updates |
 | `--no-cache` | — | Skip cache and query winget directly |
 | `--show-diff` | — | Show file differences for modified files |
-| `--script <NAME>` | — | Run only a specific health check script by name |
 
 **Examples:**
 
@@ -125,9 +123,6 @@ anvil health essentials --packages-only --fail-fast
 
 # Auto-fix missing packages
 anvil health essentials --fix
-
-# Run a single health check script
-anvil health essentials --script "Git Configuration"
 
 # Strict mode — warnings become errors
 anvil health essentials --strict
@@ -683,7 +678,7 @@ anvil config path
 | `ANVIL_WORKLOAD_PATH` | Absolute path to the workload directory. | Scripts |
 | `ANVIL_DRY_RUN` | Set to `"true"` or `"false"` during script execution. | Scripts |
 | `ANVIL_VERBOSE` | Verbosity level (`0`–`3`) during script execution. | Scripts |
-| `ANVIL_PHASE` | Current execution phase: `pre_install`, `post_install`, or `health_check`. | Scripts |
+| `ANVIL_PHASE` | Current execution phase: `pre_install`, `post_install`, or `validation`. | Scripts |
 | `ANVIL_VERSION` | Anvil version string. Available in scripts and Handlebars templates. | Scripts, templates |
 | `RUST_LOG` | Controls Rust log output (e.g., `RUST_LOG=debug`). Standard `env_logger` / `tracing` variable. | Debugging |
 | `RUST_BACKTRACE` | Enables Rust backtraces on panic (`1` = short, `full` = complete). | Debugging |

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -424,10 +424,15 @@ packages:
     - id: Package.ID
 
 scripts:
-  health_check:
-    - path: scripts/health.ps1
-      name: "Verification"
-      description: "Verify installation"
+  post_install:
+    - path: scripts/setup.ps1
+      description: "Install and configure"
+
+assertions:
+  - name: "Tool is available"
+    check:
+      type: command_exists
+      command: my-tool
 ```
 
 ---

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -138,57 +138,11 @@ files:
 anvil install my-setup --files-only --dry-run
 ```
 
-## Writing Health Check Scripts
-
-Health check scripts validate that your environment is correctly configured. They return exit code 0 for success, 1 for failure.
-
-### Basic health check
-
-Create `scripts/health-check.ps1`:
-
-```powershell
-# health-check.ps1 - Verify development tools
-$ErrorActionPreference = "Continue"
-$exitCode = 0
-
-function Test-Tool($name) {
-    if (Get-Command $name -ErrorAction SilentlyContinue) {
-        Write-Host "  [PASS] $name found" -ForegroundColor Green
-    } else {
-        Write-Host "  [FAIL] $name not found" -ForegroundColor Red
-        $script:exitCode = 1
-    }
-}
-
-Write-Host "Checking tools..." -ForegroundColor Cyan
-Test-Tool "git"
-Test-Tool "code"
-Test-Tool "cargo"
-
-exit $exitCode
-```
-
-Reference it in `workload.yaml`:
-
-```yaml
-scripts:
-  health_check:
-    - path: health-check.ps1
-      name: "Development Tools"
-      description: "Verifies core development tools are installed"
-```
-
-Run the check:
-
-```sh
-anvil health my-setup                     # all checks
-anvil health my-setup --scripts-only      # scripts only
-anvil health my-setup --script "Development Tools"  # one script
-```
-
 ## Using Assertions for Declarative Health Checks
 
-Assertions are a declarative alternative to health check scripts — no scripting needed.
+Assertions are the recommended way to validate your environment — no scripting needed.
+
+> **Note:** `scripts.health_check` was removed in v1.0. Use declarative `assertions` instead.
 
 ### Check that commands exist
 

--- a/docs/src/schema-reference.md
+++ b/docs/src/schema-reference.md
@@ -207,7 +207,6 @@ The `scripts` object organizes script entries by execution phase. All phase keys
 |-------|------|-------------|
 | `scripts.pre_install` | list of [ScriptEntry](#scriptentry) | Scripts to run **before** package installation. |
 | `scripts.post_install` | list of [ScriptEntry](#scriptentry) | Scripts to run **after** package installation. |
-| `scripts.health_check` | list of [HealthCheckScript](#healthcheckscript) | Scripts for health validation. |
 
 #### ScriptEntry
 
@@ -221,17 +220,6 @@ Used in `pre_install` and `post_install` phases.
 | `elevated` | boolean | no | `false` | Whether the script requires administrator privileges. |
 | `timeout` | integer | no | `300` | Timeout in seconds. |
 
-#### HealthCheckScript
-
-Used in the `health_check` phase. Requires a `name` field (unlike other script types).
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `path` | string | yes | — | Path relative to the workload's `scripts/` directory. |
-| `name` | string | yes | — | Display name for the health check. |
-| `description` | string | no | `null` | Description of what this check validates. |
-| `shell` | string | no | `"powershell"` | Execution shell. |
-
 ```yaml
 scripts:
   pre_install:
@@ -244,14 +232,6 @@ scripts:
       description: "Configure Windows Terminal settings"
       timeout: 300
       elevated: true
-
-  health_check:
-    - path: health-check/check-tools.ps1
-      name: "Developer Tools"
-      description: "Verify developer tools are installed"
-    - path: health-check/check-config.ps1
-      name: "Configuration Files"
-      description: "Verify configuration files are deployed"
 ```
 
 ### commands
@@ -327,14 +307,12 @@ Flags that control which categories of health checks are evaluated during `anvil
 |-------|------|----------|---------|-------------|
 | `package_check` | boolean | no | `true` | Verify that declared packages are installed. |
 | `file_check` | boolean | no | `true` | Verify that declared files are deployed. |
-| `script_check` | boolean | no | `true` | Run `scripts.health_check` scripts. |
 | `assertion_check` | boolean | no | `true` | Evaluate declarative assertions. |
 
 ```yaml
 health:
   package_check: true
   file_check: true
-  script_check: true
   assertion_check: true
 ```
 
@@ -520,11 +498,6 @@ scripts:
       timeout: 300
       elevated: true
 
-  health_check:
-    - path: health-check/check-tools.ps1
-      name: "Developer Tools"
-      description: "Verify all developer tools are installed"
-
 commands:
   post_install:
     - run: "rustup default stable"
@@ -550,7 +523,6 @@ environment:
 health:
   package_check: true
   file_check: true
-  script_check: true
   assertion_check: true
 
 assertions:

--- a/docs/src/user-guide.md
+++ b/docs/src/user-guide.md
@@ -280,14 +280,12 @@ anvil health <WORKLOAD> [OPTIONS]
 | `--fail-fast` | Stop on first failure |
 | `--packages-only` | Only check packages |
 | `--files-only` | Only check files |
-| `--scripts-only` | Only run health check scripts |
 | `--assertions-only` | Only evaluate declarative assertions |
 | `-s, --strict` | Treat warnings as errors |
 | `--fix` | Attempt to install missing packages |
 | `--update` | Update packages with available updates |
 | `--no-cache` | Skip cache and query winget directly |
 | `--show-diff` | Show file differences for modified files |
-| `--script <NAME>` | Run only a specific health check script by name |
 
 **Examples:**
 ```powershell
@@ -312,9 +310,6 @@ anvil health rust-developer --assertions-only
 # Auto-fix missing packages
 anvil health rust-developer --fix
 
-# Run a specific health check script
-anvil health rust-developer --script "Git Health"
-
 # Show file diffs for modified config files
 anvil health rust-developer --show-diff
 ```
@@ -324,7 +319,6 @@ anvil health rust-developer --show-diff
 Health checks verify:
 - **Packages**: Are required packages installed? Correct versions?
 - **Files**: Do configuration files exist with expected content?
-- **Scripts**: Do health check scripts pass?
 - **Assertions**: Do declarative condition checks pass? (see [Assertion-Based Health Checks](#assertion-based-health-checks))
 
 Status indicators:
@@ -1173,7 +1167,7 @@ anvil install my-workload
 In your workload scripts, handle errors gracefully:
 
 ```powershell
-# health-check.ps1
+# post-install.ps1
 try {
     $rustVersion = rustc --version
     if ($LASTEXITCODE -ne 0) {
@@ -1184,7 +1178,7 @@ try {
     exit 0
 }
 catch {
-    Write-Error "Health check failed: $_"
+    Write-Error "Script failed: $_"
     exit 1
 }
 ```
@@ -1193,7 +1187,7 @@ catch {
 
 ## 11. Assertion-Based Health Checks
 
-In addition to package, file, and script checks, workloads can define **declarative assertions** using a built-in condition engine. Assertions let you express health checks directly in YAML without writing PowerShell scripts.
+In addition to package and file checks, workloads can define **declarative assertions** using a built-in condition engine. Assertions let you express health checks directly in YAML without writing PowerShell scripts.
 
 ### Defining Assertions
 

--- a/docs/src/workload-authoring.md
+++ b/docs/src/workload-authoring.md
@@ -396,9 +396,6 @@ scripts:
     
   post_install:    # Run after package installation
     - path: scripts/post-install.ps1
-    
-  health_check:    # Run during health checks
-    - path: scripts/health-check.ps1
 ```
 
 ### Full Script Options
@@ -423,20 +420,7 @@ scripts:
 | `elevated` | No | `false` | Run with administrator privileges |
 | `timeout` | No | `300` | Timeout in seconds |
 
-> **Note:** Health check scripts use a separate schema with `name` (required) and `shell` fields, but do not support `timeout` or `elevated`.
-
-### Health Check Scripts
-
-Health check scripts verify system state:
-
-```yaml
-scripts:
-  health_check:
-    - path: scripts/check-rust.ps1
-      name: "Rust Toolchain"
-      description: "Verify Rust is installed and configured"
-      timeout: 30
-```
+> **Note:** `scripts.health_check` was removed in v1.0. Use declarative `assertions` instead.
 
 ### Script Guidelines
 
@@ -899,7 +883,6 @@ Assertions are evaluated during `anvil health` when `assertion_check` is enabled
 health:
   package_check: true
   file_check: true
-  script_check: true
   assertion_check: true   # Evaluate declarative assertions
 ```
 
@@ -1189,12 +1172,13 @@ environment:
    }
    ```
 
-3. **Include Health Checks**
+3. **Include Assertions**
    ```yaml
-   scripts:
-     health_check:
-       - path: scripts/verify.ps1
-         name: "Installation Verification"
+   assertions:
+     - name: "Installation verified"
+       check:
+         type: command_exists
+         command: my-tool
    ```
 
 ### Testing
@@ -1288,11 +1272,6 @@ scripts:
       description: "Configure Rust toolchain"
       elevated: false
       timeout: 600
-      
-  health_check:
-    - path: scripts/health.ps1
-      name: "Rust Environment"
-      description: "Verify Rust development environment"
 
 commands:
   post_install:

--- a/examples/python-developer/workload.yaml
+++ b/examples/python-developer/workload.yaml
@@ -21,11 +21,6 @@ scripts:
       description: "Install Python via uv and configure environment"
       timeout: 300
 
-  health_check:
-    - path: health-check.ps1
-      name: "Python Environment"
-      description: "Verifies Python and uv are properly installed"
-
 environment:
   variables:
     - name: UV_PYTHON_PREFERENCE
@@ -53,5 +48,4 @@ assertions:
 health:
   package_check: true
   file_check: true
-  script_check: true
   assertion_check: true

--- a/examples/rust-developer/workload.yaml
+++ b/examples/rust-developer/workload.yaml
@@ -26,11 +26,6 @@ scripts:
       description: "Install Rust components, toolchains, and cargo tools"
       timeout: 900
 
-  health_check:
-    - path: health-check.ps1
-      name: "Rust Toolchain"
-      description: "Verifies rustc, cargo, rustup, and components are properly installed"
-
 environment:
   variables:
     - name: RUST_BACKTRACE
@@ -73,5 +68,4 @@ assertions:
 health:
   package_check: true
   file_check: true
-  script_check: true
   assertion_check: true

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -174,10 +174,6 @@ pub struct HealthArgs {
     #[arg(long)]
     pub files_only: bool,
 
-    /// Only run health check scripts
-    #[arg(long)]
-    pub scripts_only: bool,
-
     /// Only evaluate declarative assertions
     #[arg(long)]
     pub assertions_only: bool,
@@ -201,10 +197,6 @@ pub struct HealthArgs {
     /// Show file differences for modified files
     #[arg(long)]
     pub show_diff: bool,
-
-    /// Run only a specific health check script by name
-    #[arg(long, value_name = "NAME")]
-    pub script: Option<String>,
 }
 
 /// Arguments for the `list` command

--- a/src/config/inheritance.rs
+++ b/src/config/inheritance.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use tracing::{debug, trace};
 
 use super::workload::{
-    AptPackage, BrewPackage, CommandBlock, CommandEntry, Environment, FileEntry, HealthCheckScript,
-    Packages, ScriptEntry, Scripts, WingetPackage, Workload,
+    AptPackage, BrewPackage, CommandBlock, CommandEntry, Environment, FileEntry, Packages,
+    ScriptEntry, Scripts, WingetPackage, Workload,
 };
 use super::ConfigManager;
 
@@ -344,7 +344,7 @@ impl InheritanceError {
 /// | files | Append (same destinations overwritten by child) |
 /// | scripts.pre_install | Parent first, then child |
 /// | scripts.post_install | Parent first, then child |
-/// | scripts.health_check | Combine all |
+/// | ~~scripts.health_check~~ | *(removed in v1.0)* |
 /// | environment.variables | Child overwrites same-named |
 /// | environment.path_additions | Append |
 ///
@@ -646,7 +646,6 @@ fn merge_files(
 /// Strategy:
 /// - pre_install: Parent scripts first, then child scripts
 /// - post_install: Parent scripts first, then child scripts
-/// - health_check: Combine all (parent first, then child)
 fn merge_scripts(parent: Option<Scripts>, child: Option<Scripts>) -> Option<Scripts> {
     match (parent, child) {
         (None, None) => None,
@@ -656,7 +655,6 @@ fn merge_scripts(parent: Option<Scripts>, child: Option<Scripts>) -> Option<Scri
             let mut result = Scripts {
                 pre_install: None,
                 post_install: None,
-                health_check: None,
             };
 
             // Pre-install: parent first, then child
@@ -665,14 +663,8 @@ fn merge_scripts(parent: Option<Scripts>, child: Option<Scripts>) -> Option<Scri
             // Post-install: parent first, then child
             result.post_install = merge_script_list(parent.post_install, child.post_install);
 
-            // Health check: combine all (using merge_health_check_list)
-            result.health_check = merge_health_check_list(parent.health_check, child.health_check);
-
             // Only return Some if at least one script list is present
-            if result.pre_install.is_some()
-                || result.post_install.is_some()
-                || result.health_check.is_some()
-            {
+            if result.pre_install.is_some() || result.post_install.is_some() {
                 Some(result)
             } else {
                 None
@@ -686,22 +678,6 @@ fn merge_script_list(
     parent: Option<Vec<ScriptEntry>>,
     child: Option<Vec<ScriptEntry>>,
 ) -> Option<Vec<ScriptEntry>> {
-    match (parent, child) {
-        (None, None) => None,
-        (Some(p), None) => Some(p),
-        (None, Some(c)) => Some(c),
-        (Some(mut parent), Some(child)) => {
-            parent.extend(child);
-            Some(parent)
-        }
-    }
-}
-
-/// Merge two health check script lists
-fn merge_health_check_list(
-    parent: Option<Vec<HealthCheckScript>>,
-    child: Option<Vec<HealthCheckScript>>,
-) -> Option<Vec<HealthCheckScript>> {
     match (parent, child) {
         (None, None) => None,
         (Some(p), None) => Some(p),
@@ -1156,12 +1132,10 @@ mod tests {
         let parent = Some(Scripts {
             pre_install: Some(vec![ScriptEntry::new("parent-pre.ps1")]),
             post_install: Some(vec![ScriptEntry::new("parent-post.ps1")]),
-            health_check: None,
         });
         let child = Some(Scripts {
             pre_install: Some(vec![ScriptEntry::new("child-pre.ps1")]),
             post_install: Some(vec![ScriptEntry::new("child-post.ps1")]),
-            health_check: None,
         });
 
         let merged = merge_scripts(parent, child).unwrap();

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -210,7 +210,27 @@ impl SchemaValidator {
         let workload: Workload = serde_yaml::from_str(&content)
             .with_context(|| format!("Failed to parse YAML: {}", path.display()))?;
 
-        Ok(self.validate(&workload))
+        let mut result = self.validate(&workload);
+
+        // Check for removed health_check field in raw YAML
+        Self::check_removed_health_check(&content, &mut result);
+
+        Ok(result)
+    }
+
+    /// Check raw YAML content for the removed scripts.health_check field
+    pub fn check_removed_health_check(content: &str, result: &mut ValidationResult) {
+        // Parse as serde_yaml::Value to detect removed fields
+        if let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(content) {
+            if let Some(scripts) = value.get("scripts") {
+                if scripts.get("health_check").is_some() {
+                    result.add_error(
+                        "scripts.health_check",
+                        "scripts.health_check has been removed in v1.0. Use declarative assertions instead. See https://anvil.kafkade.com/workload-authoring.html",
+                    );
+                }
+            }
+        }
     }
 
     /// Validate workload metadata
@@ -496,38 +516,6 @@ impl SchemaValidator {
                 for (i, script) in post_scripts.iter().enumerate() {
                     let path = format!("scripts.post_install[{}]", i);
                     self.validate_script_entry(&path, script, result);
-                }
-            }
-
-            // Validate health check scripts
-            if let Some(health_scripts) = &scripts.health_check {
-                for (i, script) in health_scripts.iter().enumerate() {
-                    let path = format!("scripts.health_check[{}]", i);
-
-                    // Path is required
-                    if script.path.is_empty() {
-                        result.add_error(format!("{}.path", path), "Script path is required");
-                    }
-
-                    // Health check scripts should have a name
-                    if script.name.is_empty() {
-                        result.add_warning(
-                            format!("{}.name", path),
-                            "Health check scripts should have a display name",
-                        );
-                    }
-
-                    // Validate shell value
-                    let valid_shells = ["powershell", "pwsh", "cmd", "bash"];
-                    if !valid_shells.contains(&script.shell.to_lowercase().as_str()) {
-                        result.add_warning(
-                            format!("{}.shell", path),
-                            format!(
-                                "Unknown shell '{}'. Expected one of: {:?}",
-                                script.shell, valid_shells
-                            ),
-                        );
-                    }
                 }
             }
         }

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -125,15 +125,14 @@ impl Workload {
         self.files.as_ref().map(|f| f.len()).unwrap_or(0)
     }
 
-    /// Get the total number of scripts (pre_install + post_install + health_check)
+    /// Get the total number of scripts (pre_install + post_install)
     pub fn script_count(&self) -> usize {
         self.scripts
             .as_ref()
             .map(|s| {
                 let pre = s.pre_install.as_ref().map(|p| p.len()).unwrap_or(0);
                 let post = s.post_install.as_ref().map(|p| p.len()).unwrap_or(0);
-                let health = s.health_check.as_ref().map(|h| h.len()).unwrap_or(0);
-                pre + post + health
+                pre + post
             })
             .unwrap_or(0)
     }
@@ -310,10 +309,6 @@ pub struct Scripts {
     /// Scripts to run after package installation
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub post_install: Option<Vec<ScriptEntry>>,
-
-    /// Scripts for health validation
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub health_check: Option<Vec<HealthCheckScript>>,
 }
 
 /// A script to execute
@@ -358,38 +353,6 @@ impl ScriptEntry {
             description: None,
             elevated: false,
             timeout: default_timeout(),
-        }
-    }
-}
-
-/// A health check script with metadata
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HealthCheckScript {
-    /// Relative path from workload's scripts/ directory
-    pub path: String,
-
-    /// Display name for the check
-    pub name: String,
-
-    /// Description of what this check validates
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Execution shell (default: "powershell")
-    #[serde(default = "default_shell")]
-    pub shell: String,
-}
-
-#[allow(dead_code)]
-impl HealthCheckScript {
-    /// Create a new health check script
-    pub fn new(path: impl Into<String>, name: impl Into<String>) -> Self {
-        Self {
-            path: path.into(),
-            name: name.into(),
-            description: None,
-            shell: default_shell(),
         }
     }
 }
@@ -499,10 +462,6 @@ pub struct HealthConfig {
     #[serde(default = "default_true")]
     pub file_check: bool,
 
-    /// Whether to run health check scripts (default: true)
-    #[serde(default = "default_true")]
-    pub script_check: bool,
-
     /// Whether to evaluate declarative assertions (default: true)
     #[serde(default = "default_true")]
     pub assertion_check: bool,
@@ -513,7 +472,6 @@ impl Default for HealthConfig {
         Self {
             package_check: true,
             file_check: true,
-            script_check: true,
             assertion_check: true,
         }
     }

--- a/src/operations/health.rs
+++ b/src/operations/health.rs
@@ -4,7 +4,6 @@
 //! the current system state against a workload definition.
 
 use std::path::Path;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 
@@ -16,9 +15,6 @@ use crate::cli::progress::SimpleProgress;
 use crate::cli::Cli;
 use crate::config::{expand_variables, ConfigManager};
 use crate::providers::backup::compute_file_hash;
-use crate::providers::script::{
-    OutputMode, ScriptConfig, ScriptContext, ScriptPhase, ScriptProvider,
-};
 use crate::providers::winget::version;
 use crate::providers::{create_registry, ProviderConfig};
 use crate::state::{CachedPackageInfo, FileStateManager, PackageCache};
@@ -49,25 +45,6 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
         tracing::info!("Checking health for workload: {}", workload.name);
     }
 
-    // Deprecation warning: scripts.health_check alongside assertions
-    let has_assertions = workload
-        .assertions
-        .as_ref()
-        .map(|a| !a.is_empty())
-        .unwrap_or(false);
-    let has_health_check_scripts = workload
-        .scripts
-        .as_ref()
-        .and_then(|s| s.health_check.as_ref())
-        .map(|h| !h.is_empty())
-        .unwrap_or(false);
-    if has_assertions && has_health_check_scripts {
-        print_warning(
-            "Deprecation notice: `scripts.health_check` is deprecated when used alongside `assertions`. \
-             Migrate health check scripts to declarative assertions. See docs/src/specification.md for details.",
-        );
-    }
-
     // Show spinner while checking
     let spinner = if !quiet {
         Some(SimpleProgress::spinner("Checking system health..."))
@@ -81,7 +58,7 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
     let mut _packages_to_update: Vec<String> = Vec::new();
 
     // Package checks
-    if !args.files_only && !args.scripts_only && !args.assertions_only {
+    if !args.files_only && !args.assertions_only {
         let (package_checks, fix_list, update_list) = check_packages(&workload, verbosity, quiet)?;
         checks.extend(package_checks);
         _packages_to_fix = fix_list;
@@ -96,7 +73,7 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
     }
 
     // File checks
-    if !args.packages_only && !args.scripts_only && !args.assertions_only {
+    if !args.packages_only && !args.assertions_only {
         let file_checks = check_files(&workload, &workload_path, verbosity, args.show_diff)?;
         checks.extend(file_checks);
 
@@ -109,7 +86,7 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
     }
 
     // Assertion checks
-    if !args.packages_only && !args.files_only && !args.scripts_only {
+    if !args.packages_only && !args.files_only {
         let health_config = workload.health.as_ref().cloned().unwrap_or_default();
         if health_config.assertion_check {
             if let Some(assertions) = &workload.assertions {
@@ -134,17 +111,6 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
                 }
             }
         }
-    }
-
-    // Script checks
-    if !args.packages_only && !args.files_only && !args.assertions_only {
-        if let Some(s) = &spinner {
-            s.set_message("Running health check scripts...");
-        }
-
-        let script_checks =
-            run_health_scripts(&workload, &workload_path, verbosity, args.script.as_deref())?;
-        checks.extend(script_checks);
     }
 
     if let Some(s) = spinner {
@@ -648,261 +614,6 @@ fn format_file_size(bytes: u64) -> String {
     } else {
         format!("{} B", bytes)
     }
-}
-
-/// Run health check scripts defined in the workload
-fn run_health_scripts(
-    workload: &crate::config::workload::Workload,
-    workload_path: &Path,
-    verbosity: u8,
-    script_filter: Option<&str>,
-) -> Result<Vec<CheckResult>> {
-    let mut results = Vec::new();
-
-    let scripts = match &workload.scripts {
-        Some(s) => s.health_check.as_deref().unwrap_or(&[]),
-        None => return Ok(results),
-    };
-
-    if scripts.is_empty() {
-        return Ok(results);
-    }
-
-    // Resolve scripts directory
-    let scripts_dir = workload_path.join("scripts");
-
-    // Create script provider
-    let mut provider = ScriptProvider::new()
-        .with_base_path(&scripts_dir)
-        .with_verbose(verbosity > 1);
-
-    // Create script context for environment injection
-    let context = ScriptContext::new(&workload.name, workload_path)
-        .with_phase(ScriptPhase::HealthCheck)
-        .with_verbose(verbosity > 1);
-
-    for script in scripts {
-        let display_name = &script.name;
-
-        // Filter by name if specified
-        if let Some(filter) = script_filter {
-            if !display_name.to_lowercase().contains(&filter.to_lowercase()) {
-                continue;
-            }
-        }
-
-        if verbosity > 1 {
-            tracing::debug!("Running health check script: {}", display_name);
-        }
-
-        // Resolve script path
-        let script_path = scripts_dir.join(&script.path);
-
-        if !script_path.exists() {
-            results.push(CheckResult::fail(
-                display_name,
-                "Scripts",
-                format!("Script not found: {}", script.path),
-            ));
-            continue;
-        }
-
-        // Build script configuration
-        let mut config = ScriptConfig::new(&script.path)
-            .with_timeout(Duration::from_secs(60)) // Default 60s timeout for health checks
-            .with_working_dir(&scripts_dir);
-
-        // Set output mode based on verbosity
-        if verbosity > 1 {
-            config = config.with_output_mode(OutputMode::Both);
-        }
-
-        // Inject environment variables
-        provider.inject_environment_variables(&mut config, &context);
-
-        // Execute the script
-        match provider.execute(&config) {
-            Ok(result) => {
-                let check_result = match result.exit_code {
-                    0 => {
-                        // Parse output for summary
-                        if let Some(ref parsed) = result.parsed {
-                            if parsed.summary.passed > 0
-                                || parsed.summary.failed > 0
-                                || parsed.summary.warnings > 0
-                            {
-                                // Build message including warnings if present
-                                let message = if parsed.summary.warnings > 0 {
-                                    format!(
-                                        "{} passed, {} failed, {} warning(s)",
-                                        parsed.summary.passed,
-                                        parsed.summary.failed,
-                                        parsed.summary.warnings
-                                    )
-                                } else {
-                                    format!(
-                                        "{} passed, {} failed",
-                                        parsed.summary.passed, parsed.summary.failed
-                                    )
-                                };
-
-                                // Use WARN status if there are warnings
-                                if parsed.summary.warnings > 0 {
-                                    CheckResult::warn_with_script_counts(
-                                        display_name,
-                                        "Scripts",
-                                        message,
-                                        parsed.summary.passed as usize,
-                                        parsed.summary.failed as usize,
-                                        parsed.summary.warnings as usize,
-                                    )
-                                } else {
-                                    CheckResult::ok_with_script_counts(
-                                        display_name,
-                                        "Scripts",
-                                        message,
-                                        parsed.summary.passed as usize,
-                                        parsed.summary.failed as usize,
-                                        parsed.summary.warnings as usize,
-                                    )
-                                }
-                            } else {
-                                let message =
-                                    format!("Completed in {:.1}s", result.duration.as_secs_f64());
-                                CheckResult::ok_with_message(display_name, "Scripts", message)
-                            }
-                        } else {
-                            let message =
-                                format!("Completed in {:.1}s", result.duration.as_secs_f64());
-                            CheckResult::ok_with_message(display_name, "Scripts", message)
-                        }
-                    }
-                    1 => {
-                        // Extract failure details from stdout
-                        let details: Vec<String> = result
-                            .stdout
-                            .lines()
-                            .filter(|line| {
-                                let line_lower = line.to_lowercase();
-                                let trimmed = line.trim();
-                                // Include lines with failure indicators
-                                (line_lower.contains("[fail]")
-                                    || line_lower.contains("fail:")
-                                    || line_lower.contains("error:"))
-                                    // But exclude generic summary lines
-                                    && !trimmed.eq_ignore_ascii_case("some checks failed.")
-                                    && !trimmed.eq_ignore_ascii_case("some checks failed")
-                            })
-                            .map(|s| s.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect();
-
-                        // Parse failure details from output
-                        if let Some(ref parsed) = result.parsed {
-                            if parsed.summary.failed > 0 || parsed.summary.passed > 0 {
-                                let message = format!(
-                                    "{} checks failed (passed: {})",
-                                    parsed.summary.failed, parsed.summary.passed
-                                );
-                                CheckResult::fail_with_script_counts(
-                                    display_name,
-                                    "Scripts",
-                                    message,
-                                    details,
-                                    parsed.summary.passed as usize,
-                                    parsed.summary.failed as usize,
-                                    parsed.summary.warnings as usize,
-                                )
-                            } else {
-                                CheckResult::fail_with_details(
-                                    display_name,
-                                    "Scripts",
-                                    "Health check reported failures",
-                                    details,
-                                )
-                            }
-                        } else {
-                            CheckResult::fail_with_details(
-                                display_name,
-                                "Scripts",
-                                "Health check reported failures",
-                                details,
-                            )
-                        }
-                    }
-                    2 => {
-                        // Warnings only
-                        if let Some(ref parsed) = result.parsed {
-                            if parsed.summary.warnings > 0 || parsed.summary.passed > 0 {
-                                let message = format!(
-                                    "{} warnings (passed: {})",
-                                    parsed.summary.warnings, parsed.summary.passed
-                                );
-                                CheckResult::warn_with_script_counts(
-                                    display_name,
-                                    "Scripts",
-                                    message,
-                                    parsed.summary.passed as usize,
-                                    parsed.summary.failed as usize,
-                                    parsed.summary.warnings as usize,
-                                )
-                            } else {
-                                CheckResult::warn(
-                                    display_name,
-                                    "Scripts",
-                                    "Health check reported warnings",
-                                )
-                            }
-                        } else {
-                            CheckResult::warn(
-                                display_name,
-                                "Scripts",
-                                "Health check reported warnings",
-                            )
-                        }
-                    }
-                    code => {
-                        // Extract any error output for unexpected exit codes
-                        let details: Vec<String> = result
-                            .stderr
-                            .lines()
-                            .chain(result.stdout.lines().filter(|line| {
-                                let line_lower = line.to_lowercase();
-                                line_lower.contains("error") || line_lower.contains("fail")
-                            }))
-                            .filter(|line| !line.trim().is_empty())
-                            .take(10) // Limit to 10 lines
-                            .map(|s| s.trim().to_string())
-                            .collect();
-
-                        CheckResult::fail_with_details(
-                            display_name,
-                            "Scripts",
-                            format!("Script exited with code {}", code),
-                            details,
-                        )
-                    }
-                };
-                results.push(check_result);
-            }
-            Err(e) => {
-                let message = match &e {
-                    crate::providers::script::ScriptError::Timeout {
-                        timeout_seconds, ..
-                    } => {
-                        format!("Script timed out after {}s", timeout_seconds)
-                    }
-                    crate::providers::script::ScriptError::ElevationRequired { .. } => {
-                        "Script requires elevated privileges".to_string()
-                    }
-                    _ => e.to_string(),
-                };
-                results.push(CheckResult::fail(display_name, "Scripts", message));
-            }
-        }
-    }
-
-    Ok(results)
 }
 
 /// Generate and output the health report, then exit with appropriate code

--- a/src/operations/init.rs
+++ b/src/operations/init.rs
@@ -153,14 +153,6 @@ pub fn execute(args: &InitArgs, cli: &Cli) -> Result<()> {
             post_install,
         )
         .context("Failed to write post-install.ps1")?;
-
-        debug!("Creating health-check script");
-        let health_check = generate_health_check_script(&args.name);
-        fs::write(
-            output_dir.join("scripts").join("health-check.ps1"),
-            health_check,
-        )
-        .context("Failed to write health-check.ps1")?;
     }
 
     // Create a pre-install script for full template
@@ -357,17 +349,18 @@ scripts:
       description: "Configure {name} environment"
       timeout: 300  # Timeout in seconds
 
-  # Health check script - validates the installation
-  health_check:
-    - path: health-check.ps1
-      name: "{name} Health Check"
-      description: "Verify {name} is properly configured"
-
 # Optional: Health check settings
 health:
   package_check: true   # Verify packages are installed
   file_check: true      # Verify files are deployed
-  script_check: true    # Run health check scripts
+  assertion_check: true # Evaluate declarative assertions
+
+# Optional: Declarative health assertions
+# assertions:
+#   - name: "Example command exists"
+#     check:
+#       type: command_exists
+#       command: my-tool
 "#,
         name = name,
         extends_section = extends_section.trim_start()
@@ -446,12 +439,6 @@ scripts:
       description: "Configure {name} environment"
       timeout: 300
 
-  # Health checks: Validate installation
-  health_check:
-    - path: health-check.ps1
-      name: "{name} Health Check"
-      description: "Verify {name} is properly configured"
-
 # Environment configuration
 environment:
   # Environment variables to set
@@ -493,7 +480,6 @@ assertions:
 health:
   package_check: true    # Verify all packages are installed
   file_check: true       # Verify all files are deployed correctly
-  script_check: true     # Run all health check scripts
   assertion_check: true  # Evaluate declarative assertions
 "#,
         name = name,
@@ -594,87 +580,6 @@ exit 0
     )
 }
 
-fn generate_health_check_script(name: &str) -> String {
-    format!(
-        r#"# health-check.ps1 - {name} Workload
-# This script validates that the {name} environment is properly configured
-#
-# Exit codes:
-#   0 - All checks passed
-#   1 - One or more checks failed
-
-$ErrorActionPreference = "Continue"
-$exitCode = 0
-
-Write-Host "{name} Health Check" -ForegroundColor Cyan
-Write-Host ("=" * 40) -ForegroundColor Cyan
-Write-Host ""
-
-# Helper function for consistent output
-function Test-Check {{
-    param(
-        [string]$Name,
-        [scriptblock]$Test
-    )
-
-    try {{
-        $result = & $Test
-        if ($result) {{
-            Write-Host "  [PASS] $Name" -ForegroundColor Green
-            return $true
-        }} else {{
-            Write-Host "  [FAIL] $Name" -ForegroundColor Red
-            return $false
-        }}
-    }} catch {{
-        Write-Host "  [FAIL] $Name - $($_.Exception.Message)" -ForegroundColor Red
-        return $false
-    }}
-}}
-
-# TODO: Add your health checks here
-# Examples:
-
-# Check if a command is available
-# if (-not (Test-Check "Git is installed" {{ Get-Command git -ErrorAction Stop }})) {{
-#     $exitCode = 1
-# }}
-
-# Check if a file exists
-# if (-not (Test-Check "Config file exists" {{ Test-Path "~/.config/myapp/config.toml" }})) {{
-#     $exitCode = 1
-# }}
-
-# Check environment variable
-# if (-not (Test-Check "MY_VAR is set" {{ $env:MY_VAR -ne $null }})) {{
-#     $exitCode = 1
-# }}
-
-# Check a directory is in PATH
-# if (-not (Test-Check "~/.local/bin in PATH" {{ $env:Path -like "*\.local\bin*" }})) {{
-#     $exitCode = 1
-# }}
-
-# Placeholder check - remove after adding real checks
-if (-not (Test-Check "Placeholder check (always passes)" {{ $true }})) {{
-    $exitCode = 1
-}}
-
-Write-Host ""
-Write-Host ("-" * 40) -ForegroundColor Gray
-
-if ($exitCode -eq 0) {{
-    Write-Host "All checks passed!" -ForegroundColor Green
-}} else {{
-    Write-Host "Some checks failed." -ForegroundColor Red
-}}
-
-exit $exitCode
-"#,
-        name = name
-    )
-}
-
 fn generate_sample_config(name: &str) -> String {
     format!(
         r#"# Sample configuration file for {name}
@@ -760,15 +665,6 @@ mod tests {
         assert!(script.contains("post-install.ps1"));
         assert!(script.contains("test"));
         assert!(script.contains("exit 0"));
-    }
-
-    #[test]
-    fn test_generate_health_check_script() {
-        let script = generate_health_check_script("test");
-        assert!(script.contains("health-check.ps1"));
-        assert!(script.contains("test"));
-        assert!(script.contains("[PASS]"));
-        assert!(script.contains("[FAIL]"));
     }
 
     #[test]

--- a/src/operations/show.rs
+++ b/src/operations/show.rs
@@ -190,13 +190,13 @@ fn display_workload_summary(workload: &Workload, use_color: bool, is_resolved: b
 
     // Scripts summary
     if let Some(ref scripts) = workload.scripts {
-        let mut has_scripts = false;
+        let mut _has_scripts = false;
 
         if let Some(ref pre) = scripts.pre_install {
             if !pre.is_empty() {
-                if !has_scripts {
+                if !_has_scripts {
                     println!();
-                    has_scripts = true;
+                    _has_scripts = true;
                 }
                 if use_color {
                     println!("{}", "Pre-install Scripts:".bold());
@@ -211,9 +211,9 @@ fn display_workload_summary(workload: &Workload, use_color: bool, is_resolved: b
 
         if let Some(ref post) = scripts.post_install {
             if !post.is_empty() {
-                if !has_scripts {
+                if !_has_scripts {
                     println!();
-                    has_scripts = true;
+                    _has_scripts = true;
                 }
                 if use_color {
                     println!("{}", "Post-install Scripts:".bold());
@@ -222,31 +222,6 @@ fn display_workload_summary(workload: &Workload, use_color: bool, is_resolved: b
                 }
                 for script in post {
                     print_script_entry(&script.path, script.description.as_deref(), use_color);
-                }
-            }
-        }
-
-        if let Some(ref health) = scripts.health_check {
-            if !health.is_empty() {
-                if !has_scripts {
-                    println!();
-                }
-                if use_color {
-                    println!("{}", "Health Check Scripts:".bold());
-                } else {
-                    println!("Health Check Scripts:");
-                }
-                for script in health {
-                    if use_color {
-                        println!(
-                            "  {} {} ({})",
-                            "•".dimmed(),
-                            script.name.cyan(),
-                            script.path.dimmed()
-                        );
-                    } else {
-                        println!("  - {} ({})", script.name, script.path);
-                    }
                 }
             }
         }
@@ -455,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_script_count_with_scripts() {
-        use crate::config::workload::{HealthCheckScript, ScriptEntry, Scripts};
+        use crate::config::workload::{ScriptEntry, Scripts};
 
         let mut workload = Workload::new("test", "1.0.0", "Test workload");
         workload.scripts = Some(Scripts {
@@ -464,10 +439,9 @@ mod tests {
                 ScriptEntry::new("post1.ps1"),
                 ScriptEntry::new("post2.ps1"),
             ]),
-            health_check: Some(vec![HealthCheckScript::new("health.ps1", "Health Check")]),
         });
 
-        assert_eq!(workload.script_count(), 4);
+        assert_eq!(workload.script_count(), 3);
     }
 
     #[test]

--- a/src/operations/validate.rs
+++ b/src/operations/validate.rs
@@ -101,6 +101,9 @@ pub fn execute(args: &ValidateArgs, cli: &Cli) -> Result<()> {
     // Run schema validation
     let mut result = validator.validate(&workload);
 
+    // Check for removed scripts.health_check field in raw YAML
+    SchemaValidator::check_removed_health_check(&content, &mut result);
+
     // Check for files and scripts existence
     let base_dir = workload_file.parent().unwrap_or(Path::new("."));
     let file_result = validate_referenced_files(&workload, base_dir, args.strict);
@@ -327,27 +330,6 @@ fn validate_referenced_files(
                 }
             }
         }
-
-        // Check health check scripts
-        if let Some(health_scripts) = &scripts.health_check {
-            for (i, script) in health_scripts.iter().enumerate() {
-                let script_path = scripts_dir.join(&script.path);
-                if !script_path.exists() {
-                    let msg = format!("Script file not found: {}", script_path.display());
-                    if strict {
-                        result.add_error(format!("scripts.health_check[{}].path", i), msg);
-                    } else {
-                        result.add_warning(format!("scripts.health_check[{}].path", i), msg);
-                    }
-                } else {
-                    check_script_file(
-                        &script_path,
-                        &format!("scripts.health_check[{}]", i),
-                        &mut result,
-                    );
-                }
-            }
-        }
     }
 
     result
@@ -428,11 +410,6 @@ fn validate_script_syntax(
     if let Some(post) = &scripts.post_install {
         for script in post {
             scripts_to_validate.push(("post_install", &script.path, &script.shell));
-        }
-    }
-    if let Some(health) = &scripts.health_check {
-        for script in health {
-            scripts_to_validate.push(("health_check", &script.path, &script.shell));
         }
     }
 
@@ -753,30 +730,7 @@ fn print_json_schema() -> Result<()> {
       "type": "object",
       "properties": {
         "pre_install": { "$ref": "#/definitions/scriptList" },
-        "post_install": { "$ref": "#/definitions/scriptList" },
-        "health_check": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["path", "name"],
-            "properties": {
-              "path": {
-                "type": "string",
-                "description": "Relative path from workload's scripts/ directory"
-              },
-              "name": {
-                "type": "string",
-                "description": "Display name for the check"
-              },
-              "description": { "type": "string" },
-              "shell": {
-                "type": "string",
-                "default": "powershell",
-                "enum": ["powershell", "pwsh", "cmd", "bash"]
-              }
-            }
-          }
-        }
+        "post_install": { "$ref": "#/definitions/scriptList" }
       }
     },
     "commands": {

--- a/src/providers/script.rs
+++ b/src/providers/script.rs
@@ -154,7 +154,6 @@ pub enum OutputMode {
 pub enum ScriptPhase {
     PreInstall,
     PostInstall,
-    HealthCheck,
     Validation,
 }
 
@@ -163,7 +162,6 @@ impl std::fmt::Display for ScriptPhase {
         match self {
             ScriptPhase::PreInstall => write!(f, "pre_install"),
             ScriptPhase::PostInstall => write!(f, "post_install"),
-            ScriptPhase::HealthCheck => write!(f, "health_check"),
             ScriptPhase::Validation => write!(f, "validation"),
         }
     }
@@ -561,7 +559,7 @@ impl ScriptContext {
             workload_path: workload_path.into(),
             dry_run: false,
             verbose: false,
-            phase: ScriptPhase::HealthCheck,
+            phase: ScriptPhase::Validation,
         }
     }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -715,18 +715,18 @@ mod health_command {
     }
 
     #[test]
-    fn health_deprecation_warning_when_both_assertions_and_scripts() {
+    fn validate_rejects_removed_health_check_field() {
         let temp = TempDir::new().unwrap();
         common::create_workload_with_both_assertions_and_scripts(temp.path(), "both-test").unwrap();
         let workload_path = temp.path().join("both-test");
 
-        // When both assertions and scripts.health_check exist, stderr should contain deprecation warning
+        // validate should report an error for the removed scripts.health_check field
         anvil()
-            .args(["health", workload_path.to_str().unwrap()])
+            .args(["validate", workload_path.to_str().unwrap()])
             .assert()
-            .code(predicate::in_iter([0, 1]))
-            .stderr(predicate::str::contains(
-                "scripts.health_check` is deprecated when used alongside `assertions`",
+            .failure()
+            .stdout(predicate::str::contains(
+                "scripts.health_check has been removed in v1.0",
             ));
     }
 }
@@ -1013,17 +1013,16 @@ files:
         let workload_dir = temp.path().join("scripts-workload");
         let scripts_dir = workload_dir.join("scripts");
         fs::create_dir_all(&scripts_dir).unwrap();
-        fs::write(scripts_dir.join("health.ps1"), "exit 0").unwrap();
+        fs::write(scripts_dir.join("post-install.ps1"), "exit 0").unwrap();
         fs::write(
             workload_dir.join("workload.yaml"),
             r#"name: scripts-workload
 version: "1.0.0"
 description: "Workload with scripts"
 scripts:
-  health_check:
-    - path: scripts/health.ps1
-      name: "Basic Check"
-      description: "Simple health check"
+  post_install:
+    - path: scripts/post-install.ps1
+      description: "Post-install setup"
 "#,
         )
         .unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,23 +29,10 @@ packages:
     - id: Microsoft.WindowsTerminal
 
 files: []
-
-scripts:
-  health_check:
-    - path: scripts/health.ps1
-      name: "Basic Check"
-      description: "Simple health check script"
 "#
     );
 
     fs::write(workload_dir.join("workload.yaml"), yaml)?;
-    fs::write(
-        workload_dir.join("scripts/health.ps1"),
-        r#"# Basic health check script
-Write-Host "Health check running..."
-exit 0
-"#,
-    )?;
 
     Ok(())
 }
@@ -186,12 +173,6 @@ scripts:
     - path: scripts/post-install.ps1
       description: "Post-installation configuration"
       timeout: 120
-
-  health_check:
-    - path: scripts/health-check.ps1
-      name: "Full Health Check"
-      description: "Comprehensive system verification"
-      timeout: 60
 
 environment:
   variables:
@@ -416,8 +397,8 @@ assertions:
     Ok(())
 }
 
-/// Create a workload with both assertions and health_check scripts
-/// for testing the deprecation warning
+/// Create a workload with the removed health_check field
+/// for testing that validation correctly rejects it
 #[allow(dead_code)]
 pub fn create_workload_with_both_assertions_and_scripts(
     dir: &Path,
@@ -430,7 +411,7 @@ pub fn create_workload_with_both_assertions_and_scripts(
     let yaml = format!(
         r#"name: {name}
 version: "1.0.0"
-description: "Workload with both assertions and health_check scripts"
+description: "Workload with removed health_check field"
 
 assertions:
   - name: "PATH is set"
@@ -519,10 +500,6 @@ mod tests {
         create_test_workload(temp.path(), "test-workload").unwrap();
 
         assert!(temp.path().join("test-workload/workload.yaml").exists());
-        assert!(temp
-            .path()
-            .join("test-workload/scripts/health.ps1")
-            .exists());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Remove the deprecated `scripts.health_check` field, completing the deprecation timeline from the specification. Users should use declarative `assertions` instead.

### What's included

- **Removed `scripts.health_check`** from the workload schema — the `HealthCheckScript` struct and `health_check` field on `Scripts` are gone
- **Removed `--scripts-only` and `--script` flags** from `anvil health` — these only applied to health check scripts
- **Removed `script_check`** from `HealthConfig` — no longer needed
- **Removed ~250 lines** of health check script execution logic from `health.rs`
- **Schema validation** now emits an error if `scripts.health_check` is present, with a migration hint pointing to assertions
- **Removed health check script generation** from `anvil init` templates
- **Updated inheritance** to no longer merge health_check script lists
- **Updated examples** — `rust-developer` and `python-developer` workloads now use assertions only
- **Updated 8 documentation files** to reflect the removal

### Migration

```yaml
# Before (removed)
scripts:
  health_check:
    - path: check-git.ps1
      name: "Git installed"

# After (use assertions)
assertions:
  - name: Git installed
    check:
      type: command_exists
      command: git
```

## Related Issues

Closes #39

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [x] Other (describe below)

**Breaking change**: removes `scripts.health_check`, `--scripts-only`, and `--script` flags.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)