### PR TITLE
feat!: remove deprecated scripts system in favor of commands block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `scripts.health_check` field — use declarative `assertions` instead
 - `--scripts-only` and `--script` flags from `anvil health` command
+- `scripts.pre_install` and `scripts.post_install` fields — use the `commands` block instead
+- `--skip-scripts`, `--skip-pre-scripts`, `--skip-post-scripts` flags from `anvil install` command
 
 ## [0.6.0] - 2026-04-17
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -37,19 +37,16 @@ These options are available on **all** commands:
 |------|---------|-------------|
 | `-d, --dry-run` | — | Show what would be done without making changes |
 | `-f, --force` | — | Skip confirmation prompts |
-| `-p, --packages-only` | — | Only install packages, skip files and scripts |
+| `-p, --packages-only` | — | Only install packages, skip files |
 | `--skip-packages` | — | Skip package installation |
 | `--skip-files` | — | Skip file operations |
-| `--skip-scripts` | — | Skip all script execution |
-| `--skip-pre-scripts` | — | Skip pre-installation scripts |
-| `--skip-post-scripts` | — | Skip post-installation scripts |
 | `--no-backup` | — | Don't backup existing files before overwriting |
 | `--upgrade` | — | Upgrade existing packages to specified versions |
 | `--retry-failed` | — | Retry only failed packages from previous run |
 | `--parallel` | — | Run installations in parallel where safe |
 | `-j, --jobs <N>` | `4` | Number of parallel package installations |
 | `--timeout <SECONDS>` | `3600` | Global timeout for operations in seconds |
-| `--files-only` | — | Only process files, skip packages and scripts |
+| `--files-only` | — | Only process files, skip packages |
 | `--force-files` | — | Force overwrite files without checking hash |
 
 **Examples:**

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -423,9 +423,9 @@ packages:
   winget:
     - id: Package.ID
 
-scripts:
+commands:
   post_install:
-    - path: scripts/setup.ps1
+    - run: "echo Setting up..."
       description: "Install and configure"
 
 assertions:

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -358,7 +358,7 @@ packages:
 
 - **Packages**: child packages are appended after parent packages
 - **Files**: child files are appended; same destination = child overrides parent
-- **Scripts**: concatenated (parent scripts run first)
+- **Commands**: concatenated (parent commands run first)
 - **Environment**: child variables override same-named parent variables
 - **Assertions**: child assertions are appended after parent assertions
 

--- a/docs/src/schema-reference.md
+++ b/docs/src/schema-reference.md
@@ -199,44 +199,9 @@ files:
     template: true
 ```
 
-### scripts
-
-The `scripts` object organizes script entries by execution phase. All phase keys are optional.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `scripts.pre_install` | list of [ScriptEntry](#scriptentry) | Scripts to run **before** package installation. |
-| `scripts.post_install` | list of [ScriptEntry](#scriptentry) | Scripts to run **after** package installation. |
-
-#### ScriptEntry
-
-Used in `pre_install` and `post_install` phases.
-
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `path` | string | yes | — | Path relative to the workload's `scripts/` directory. |
-| `shell` | string | no | `"powershell"` | Execution shell. |
-| `description` | string | no | `null` | Human-readable description of what the script does. |
-| `elevated` | boolean | no | `false` | Whether the script requires administrator privileges. |
-| `timeout` | integer | no | `300` | Timeout in seconds. |
-
-```yaml
-scripts:
-  pre_install:
-    - path: pre-install.ps1
-      description: "Prepare system for installation"
-      timeout: 60
-
-  post_install:
-    - path: configure-terminal.ps1
-      description: "Configure Windows Terminal settings"
-      timeout: 300
-      elevated: true
-```
-
 ### commands
 
-The `commands` object defines inline shell commands to execute at install phases. This is a lightweight alternative to scripts for simple one-liners.
+The `commands` object defines inline shell commands to execute at install phases.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/src/user-guide.md
+++ b/docs/src/user-guide.md
@@ -211,13 +211,10 @@ anvil install <WORKLOAD> [OPTIONS]
 |--------|-------------|
 | `--dry-run` | Preview actions without making changes |
 | `--force` | Skip confirmation prompts |
-| `-p, --packages-only` | Only install packages, skip files and scripts |
-| `--files-only` | Only process files, skip packages and scripts |
+| `-p, --packages-only` | Only install packages, skip files |
+| `--files-only` | Only process files, skip packages |
 | `--skip-packages` | Skip package installation |
 | `--skip-files` | Skip file operations |
-| `--skip-scripts` | Skip all script execution |
-| `--skip-pre-scripts` | Skip pre-installation scripts only |
-| `--skip-post-scripts` | Skip post-installation scripts only |
 | `--no-backup` | Don't backup existing files before overwriting |
 | `--upgrade` | Upgrade existing packages to specified versions |
 | `--retry-failed` | Retry only failed packages from previous run |

--- a/docs/src/workload-authoring.md
+++ b/docs/src/workload-authoring.md
@@ -54,7 +54,6 @@ description: string             # Human-readable description
 extends: string[]               # Parent workloads to inherit from
 packages: object                # Package definitions
 files: array                    # File deployment definitions
-scripts: object                 # Script execution definitions
 commands: object                # Inline command definitions
 environment: object             # Environment variable configuration
 assertions: array               # Declarative health assertions
@@ -106,11 +105,8 @@ Package installation definitions (see [Package Definitions](#3-package-definitio
 #### `files`
 File deployment definitions (see [File Definitions](#4-file-definitions)).
 
-#### `scripts`
-Script execution definitions (see [Script Definitions](#5-script-definitions)).
-
 #### `commands`
-Inline command definitions (see [Commands (Inline)](#6-commands-inline)).
+Inline command definitions (see [Commands (Inline)](#5-commands-inline)).
 
 #### `environment`
 Environment variable configuration (see [Environment Configuration](#7-environment-configuration)).
@@ -383,215 +379,11 @@ files:
 
 ---
 
-## 5. Script Definitions
+## 5. Commands (Inline)
 
-Define PowerShell or CMD scripts for installation steps and health checks.
+Commands let you run arbitrary shell commands directly from `workload.yaml`. They support conditional execution via the same predicate engine used by [Assertions](#7-assertions).
 
-### Script Categories
-
-```yaml
-scripts:
-  pre_install:     # Run before package installation
-    - path: scripts/pre-install.ps1
-    
-  post_install:    # Run after package installation
-    - path: scripts/post-install.ps1
-```
-
-### Full Script Options
-
-```yaml
-scripts:
-  post_install:
-    - path: scripts/setup.ps1
-      shell: powershell           # powershell, pwsh, cmd
-      description: "Configure application settings"
-      elevated: false             # Run as administrator
-      timeout: 300                # Timeout in seconds
-```
-
-### Script Fields
-
-| Field | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `path` | Yes | - | Path relative to workload directory |
-| `shell` | No | `powershell` | Shell: `powershell`, `pwsh`, `cmd` |
-| `description` | No | - | Human-readable description |
-| `elevated` | No | `false` | Run with administrator privileges |
-| `timeout` | No | `300` | Timeout in seconds |
-
-> **Note:** `scripts.health_check` was removed in v1.0. Use declarative `assertions` instead.
-
-### Script Guidelines
-
-#### Exit Codes
-
-- `0` - Success
-- Non-zero - Failure
-
-```powershell
-# Good: explicit exit codes
-if (Test-Path $requiredFile) {
-    exit 0
-} else {
-    Write-Error "Required file not found"
-    exit 1
-}
-```
-
-#### Output Handling
-
-- Use `Write-Host` for informational output
-- Use `Write-Error` for error messages
-- Use `Write-Warning` for warnings
-
-```powershell
-Write-Host "Installing components..."
-Write-Warning "This may take a while"
-Write-Error "Installation failed"
-```
-
-#### Idempotency
-
-Scripts should be safe to run multiple times:
-
-```powershell
-# Good: check before acting
-if (-not (Test-Path "C:\Tools\mytool")) {
-    Write-Host "Installing mytool..."
-    # Install logic here
-} else {
-    Write-Host "mytool already installed"
-}
-```
-
-#### Error Handling
-
-Use try-catch for robust error handling:
-
-```powershell
-try {
-    # Risky operation
-    Invoke-WebRequest -Uri $url -OutFile $path
-    exit 0
-}
-catch {
-    Write-Error "Failed to download: $_"
-    exit 1
-}
-```
-
-### Sample Scripts
-
-#### Pre-Install Check
-
-```powershell
-# scripts/pre-install.ps1
-# Check prerequisites before installation
-
-$ErrorActionPreference = "Stop"
-
-# Check Windows version
-$version = [Environment]::OSVersion.Version
-if ($version.Major -lt 10) {
-    Write-Error "Windows 10 or later required"
-    exit 1
-}
-
-# Check available disk space (need 1GB)
-$drive = Get-PSDrive C
-$freeGB = [math]::Round($drive.Free / 1GB, 2)
-if ($freeGB -lt 1) {
-    Write-Error "Insufficient disk space. Need 1GB, have ${freeGB}GB"
-    exit 1
-}
-
-Write-Host "Prerequisites check passed"
-exit 0
-```
-
-#### Post-Install Configuration
-
-```powershell
-# scripts/post-install.ps1
-# Configure application after installation
-
-$ErrorActionPreference = "Stop"
-
-try {
-    # Install Rust components
-    Write-Host "Installing Rust components..."
-    rustup component add rustfmt
-    rustup component add clippy
-    
-    # Install common cargo tools
-    Write-Host "Installing cargo tools..."
-    cargo install cargo-watch
-    cargo install cargo-edit
-    
-    Write-Host "Post-install configuration complete"
-    exit 0
-}
-catch {
-    Write-Error "Post-install failed: $_"
-    exit 1
-}
-```
-
-#### Health Check
-
-```powershell
-# scripts/health-check.ps1
-# Verify Rust development environment
-
-$ErrorActionPreference = "Stop"
-$errors = @()
-
-# Check rustc
-try {
-    $rustVersion = rustc --version
-    Write-Host "✓ Rust compiler: $rustVersion"
-}
-catch {
-    $errors += "rustc not found"
-}
-
-# Check cargo
-try {
-    $cargoVersion = cargo --version
-    Write-Host "✓ Cargo: $cargoVersion"
-}
-catch {
-    $errors += "cargo not found"
-}
-
-# Check rustfmt
-try {
-    $null = rustfmt --version
-    Write-Host "✓ rustfmt installed"
-}
-catch {
-    $errors += "rustfmt not installed"
-}
-
-# Report results
-if ($errors.Count -gt 0) {
-    Write-Error "Health check failed:"
-    $errors | ForEach-Object { Write-Error "  - $_" }
-    exit 1
-}
-
-Write-Host "All health checks passed"
-exit 0
-```
-
----
-
-## 6. Commands (Inline)
-
-Commands let you run arbitrary shell commands directly from `workload.yaml` without creating separate script files. They support conditional execution via the same predicate engine used by [Assertions](#8-assertions).
-
-Use commands for simple one-liners (e.g., `cargo install`, `npm install -g`). Use scripts for complex multi-step logic that benefits from a dedicated file.
+> **Note:** `scripts.pre_install` and `scripts.post_install` were removed in v1.0. Use the `commands` block instead.
 
 ### Basic Structure
 
@@ -632,7 +424,7 @@ commands:
 
 ### Conditional Execution
 
-The `when` field accepts any condition type from the [Assertions](#8-assertions) predicate engine:
+The `when` field accepts any condition type from the [Assertions](#7-assertions) predicate engine:
 
 ```yaml
 commands:
@@ -673,7 +465,7 @@ commands:
 
 ---
 
-## 7. Environment Configuration
+## 6. Environment Configuration
 
 Configure environment variables and PATH additions.
 
@@ -734,7 +526,7 @@ PATH additions are appended to the existing PATH for the specified scope.
 
 ---
 
-## 8. Assertions
+## 7. Assertions
 
 Assertions are declarative health checks defined directly in `workload.yaml`. They let you validate system state — such as installed commands, existing files, environment variables, and PATH entries — without writing PowerShell scripts.
 
@@ -927,7 +719,7 @@ health:
 
 ---
 
-## 9. Inheritance
+## 8. Inheritance
 
 Workloads can extend other workloads to inherit their configuration.
 
@@ -961,7 +753,7 @@ When a workload extends parents, configuration is merged:
 |---------|----------------|
 | `packages` | Merged; child packages added to parent packages |
 | `files` | Merged; child files override parent files with same destination |
-| `scripts` | Merged; child scripts run after parent scripts |
+| `commands` | Merged; child commands run after parent commands |
 | `environment` | Merged; child variables override parent variables |
 
 ### Override Example
@@ -1030,7 +822,7 @@ anvil show my-workload --resolved
 
 ---
 
-## 10. Variable Expansion
+## 9. Variable Expansion
 
 Use variables in paths and values for dynamic configuration.
 
@@ -1080,7 +872,7 @@ environment:
 
 ---
 
-## 11. Best Practices
+## 10. Best Practices
 
 ### Workload Design
 
@@ -1199,7 +991,7 @@ environment:
 
 ---
 
-## 12. Example Workloads
+## 11. Example Workloads
 
 ### Minimal Workload
 
@@ -1262,19 +1054,14 @@ files:
     destination: "${APPDATA}/Code/User/settings.json"
     template: true
 
-scripts:
-  pre_install:
-    - path: scripts/pre-check.ps1
-      description: "Check prerequisites"
-      
-  post_install:
-    - path: scripts/setup-rust.ps1
-      description: "Configure Rust toolchain"
-      elevated: false
-      timeout: 600
-
 commands:
+  pre_install:
+    - run: "echo Checking prerequisites..."
+      description: "Check prerequisites"
   post_install:
+    - run: "rustup default stable && rustup update stable"
+      description: "Configure Rust toolchain"
+      timeout: 600
     - run: "rustup component add rustfmt clippy"
       description: "Add Rust components"
       when:
@@ -1319,46 +1106,24 @@ packages:
     - id: Docker.DockerDesktop
     - id: WasmEdge.WasmEdge
 
-scripts:
+commands:
   post_install:
-    - path: scripts/setup-targets.ps1
-      description: "Add Rust compilation targets"
+    - run: "rustup target add wasm32-unknown-unknown"
+      description: "Add WASM target"
+    - run: "rustup target add thumbv7em-none-eabihf"
+      description: "Add embedded target"
+    - run: "cargo install cargo-embed probe-run"
+      description: "Install embedded cargo tools"
+      continue_on_error: true
 
 environment:
   path_additions:
     - "~/.wasmedge/bin"
 ```
 
-With corresponding script:
-
-```powershell
-# rust-advanced/scripts/setup-targets.ps1
-# Add additional Rust compilation targets
-
-$ErrorActionPreference = "Stop"
-
-try {
-    Write-Host "Adding WASM target..."
-    rustup target add wasm32-unknown-unknown
-    
-    Write-Host "Adding embedded targets..."
-    rustup target add thumbv7em-none-eabihf
-    
-    Write-Host "Installing cargo tools for embedded..."
-    cargo install cargo-embed
-    cargo install probe-run
-    
-    exit 0
-}
-catch {
-    Write-Error "Setup failed: $_"
-    exit 1
-}
-```
-
 ---
 
-## 13. Private Workload Repositories
+## 12. Private Workload Repositories
 
 You can maintain your own workloads in a separate Git repository and configure Anvil to discover them.
 

--- a/examples/python-developer/workload.yaml
+++ b/examples/python-developer/workload.yaml
@@ -14,11 +14,10 @@ files:
     destination: "~/pyproject.toml"
     backup: true
 
-scripts:
+commands:
   post_install:
-    - path: post-install.ps1
-      shell: powershell
-      description: "Install Python via uv and configure environment"
+    - run: "uv python install"
+      description: "Install latest Python via uv"
       timeout: 300
 
 environment:

--- a/examples/rust-developer/workload.yaml
+++ b/examples/rust-developer/workload.yaml
@@ -19,12 +19,21 @@ files:
     destination: "~/.cargo/config.toml"
     backup: true
 
-scripts:
+commands:
   post_install:
-    - path: post-install.ps1
-      shell: powershell
-      description: "Install Rust components, toolchains, and cargo tools"
+    - run: "rustup default stable"
+      description: "Set default Rust toolchain to stable"
+      timeout: 120
+    - run: "rustup update stable"
+      description: "Update stable toolchain"
+      timeout: 300
+    - run: "rustup component add rust-src rust-analyzer clippy rustfmt llvm-tools"
+      description: "Install Rust components"
+      timeout: 300
+    - run: "cargo install cargo-watch cargo-nextest cargo-audit"
+      description: "Install common cargo tools"
       timeout: 900
+      continue_on_error: true
 
 environment:
   variables:

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -102,18 +102,6 @@ pub struct InstallArgs {
     #[arg(long)]
     pub skip_files: bool,
 
-    /// Skip all script execution
-    #[arg(long)]
-    pub skip_scripts: bool,
-
-    /// Skip pre-installation scripts
-    #[arg(long)]
-    pub skip_pre_scripts: bool,
-
-    /// Skip post-installation scripts
-    #[arg(long)]
-    pub skip_post_scripts: bool,
-
     /// Don't backup existing files before overwriting
     #[arg(long)]
     pub no_backup: bool,

--- a/src/config/inheritance.rs
+++ b/src/config/inheritance.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace};
 
 use super::workload::{
     AptPackage, BrewPackage, CommandBlock, CommandEntry, Environment, FileEntry, Packages,
-    ScriptEntry, Scripts, WingetPackage, Workload,
+    WingetPackage, Workload,
 };
 use super::ConfigManager;
 
@@ -342,9 +342,8 @@ impl InheritanceError {
 /// | description | Child overwrites |
 /// | packages.winget | Append (child after parent) |
 /// | files | Append (same destinations overwritten by child) |
-/// | scripts.pre_install | Parent first, then child |
-/// | scripts.post_install | Parent first, then child |
-/// | ~~scripts.health_check~~ | *(removed in v1.0)* |
+/// | commands.pre_install | Parent first, then child |
+/// | commands.post_install | Parent first, then child |
 /// | environment.variables | Child overwrites same-named |
 /// | environment.path_additions | Append |
 ///
@@ -506,9 +505,6 @@ fn merge_workloads(parent: Workload, child: Workload) -> Workload {
         // Merge files (child can override same destinations)
         files: merge_files(parent.files, child.files),
 
-        // Merge scripts
-        scripts: merge_scripts(parent.scripts, child.scripts),
-
         // Merge commands
         commands: merge_commands(parent.commands, child.commands),
 
@@ -636,54 +632,6 @@ fn merge_files(
                     parent.push(child_file);
                 }
             }
-            Some(parent)
-        }
-    }
-}
-
-/// Merge script definitions
-///
-/// Strategy:
-/// - pre_install: Parent scripts first, then child scripts
-/// - post_install: Parent scripts first, then child scripts
-fn merge_scripts(parent: Option<Scripts>, child: Option<Scripts>) -> Option<Scripts> {
-    match (parent, child) {
-        (None, None) => None,
-        (Some(p), None) => Some(p),
-        (None, Some(c)) => Some(c),
-        (Some(parent), Some(child)) => {
-            let mut result = Scripts {
-                pre_install: None,
-                post_install: None,
-            };
-
-            // Pre-install: parent first, then child
-            result.pre_install = merge_script_list(parent.pre_install, child.pre_install);
-
-            // Post-install: parent first, then child
-            result.post_install = merge_script_list(parent.post_install, child.post_install);
-
-            // Only return Some if at least one script list is present
-            if result.pre_install.is_some() || result.post_install.is_some() {
-                Some(result)
-            } else {
-                None
-            }
-        }
-    }
-}
-
-/// Merge two script entry lists (parent first, then child)
-fn merge_script_list(
-    parent: Option<Vec<ScriptEntry>>,
-    child: Option<Vec<ScriptEntry>>,
-) -> Option<Vec<ScriptEntry>> {
-    match (parent, child) {
-        (None, None) => None,
-        (Some(p), None) => Some(p),
-        (None, Some(c)) => Some(c),
-        (Some(mut parent), Some(child)) => {
-            parent.extend(child);
             Some(parent)
         }
     }
@@ -1123,34 +1071,6 @@ mod tests {
 
         let merged = merge_workloads(parent, child);
         assert!(merged.extends.is_none());
-    }
-
-    #[test]
-    fn test_merge_scripts_order() {
-        use crate::config::workload::ScriptEntry;
-
-        let parent = Some(Scripts {
-            pre_install: Some(vec![ScriptEntry::new("parent-pre.ps1")]),
-            post_install: Some(vec![ScriptEntry::new("parent-post.ps1")]),
-        });
-        let child = Some(Scripts {
-            pre_install: Some(vec![ScriptEntry::new("child-pre.ps1")]),
-            post_install: Some(vec![ScriptEntry::new("child-post.ps1")]),
-        });
-
-        let merged = merge_scripts(parent, child).unwrap();
-
-        // Pre-install: parent first, then child
-        let pre = merged.pre_install.unwrap();
-        assert_eq!(pre.len(), 2);
-        assert_eq!(pre[0].path, "parent-pre.ps1");
-        assert_eq!(pre[1].path, "child-pre.ps1");
-
-        // Post-install: parent first, then child
-        let post = merged.post_install.unwrap();
-        assert_eq!(post.len(), 2);
-        assert_eq!(post[0].path, "parent-post.ps1");
-        assert_eq!(post[1].path, "child-post.ps1");
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -187,9 +187,6 @@ impl SchemaValidator {
         // Validate files
         self.validate_files(workload, &mut result);
 
-        // Validate scripts
-        self.validate_scripts(workload, &mut result);
-
         // Validate commands
         self.validate_commands(workload, &mut result);
 
@@ -212,14 +209,14 @@ impl SchemaValidator {
 
         let mut result = self.validate(&workload);
 
-        // Check for removed health_check field in raw YAML
-        Self::check_removed_health_check(&content, &mut result);
+        // Check for removed scripts fields in raw YAML
+        Self::check_removed_scripts_fields(&content, &mut result);
 
         Ok(result)
     }
 
-    /// Check raw YAML content for the removed scripts.health_check field
-    pub fn check_removed_health_check(content: &str, result: &mut ValidationResult) {
+    /// Check raw YAML content for removed scripts fields
+    pub fn check_removed_scripts_fields(content: &str, result: &mut ValidationResult) {
         // Parse as serde_yaml::Value to detect removed fields
         if let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(content) {
             if let Some(scripts) = value.get("scripts") {
@@ -227,6 +224,12 @@ impl SchemaValidator {
                     result.add_error(
                         "scripts.health_check",
                         "scripts.health_check has been removed in v1.0. Use declarative assertions instead. See https://anvil.kafkade.com/workload-authoring.html",
+                    );
+                }
+                if scripts.get("pre_install").is_some() || scripts.get("post_install").is_some() {
+                    result.add_error(
+                        "scripts",
+                        "scripts.pre_install and scripts.post_install have been removed in v1.0. Use the commands block instead. See https://anvil.kafkade.com/workload-authoring.html",
                     );
                 }
             }
@@ -497,80 +500,6 @@ impl SchemaValidator {
                     );
                 }
             }
-        }
-    }
-
-    /// Validate script definitions
-    fn validate_scripts(&self, workload: &Workload, result: &mut ValidationResult) {
-        if let Some(scripts) = &workload.scripts {
-            // Validate pre-install scripts
-            if let Some(pre_scripts) = &scripts.pre_install {
-                for (i, script) in pre_scripts.iter().enumerate() {
-                    let path = format!("scripts.pre_install[{}]", i);
-                    self.validate_script_entry(&path, script, result);
-                }
-            }
-
-            // Validate post-install scripts
-            if let Some(post_scripts) = &scripts.post_install {
-                for (i, script) in post_scripts.iter().enumerate() {
-                    let path = format!("scripts.post_install[{}]", i);
-                    self.validate_script_entry(&path, script, result);
-                }
-            }
-        }
-    }
-
-    /// Validate a single script entry
-    fn validate_script_entry(
-        &self,
-        path: &str,
-        script: &super::workload::ScriptEntry,
-        result: &mut ValidationResult,
-    ) {
-        // Path is required
-        if script.path.is_empty() {
-            result.add_error(format!("{}.path", path), "Script path is required");
-        }
-
-        // Validate shell value
-        let valid_shells = ["powershell", "pwsh", "cmd", "bash"];
-        if !valid_shells.contains(&script.shell.to_lowercase().as_str()) {
-            result.add_warning(
-                format!("{}.shell", path),
-                format!(
-                    "Unknown shell '{}'. Expected one of: {:?}",
-                    script.shell, valid_shells
-                ),
-            );
-        }
-
-        // Validate timeout values
-        if script.timeout < 5 {
-            result.add_warning(
-                format!("{}.timeout", path),
-                format!(
-                    "Timeout of {} seconds may be too short. Consider at least 5 seconds.",
-                    script.timeout
-                ),
-            );
-        } else if script.timeout > 3600 {
-            result.add_warning(
-                format!("{}.timeout", path),
-                format!(
-                    "Timeout of {} seconds ({:.1} hours) is very long. Consider if this is intentional.",
-                    script.timeout,
-                    script.timeout as f64 / 3600.0
-                ),
-            );
-        }
-
-        // Warn about elevated scripts
-        if script.elevated && self.strict {
-            result.add_info(
-                format!("{}.elevated", path),
-                "Script requires elevated privileges. Ensure this is necessary.",
-            );
         }
     }
 

--- a/src/config/workload.rs
+++ b/src/config/workload.rs
@@ -30,10 +30,6 @@ pub struct Workload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<FileEntry>>,
 
-    /// Script definitions
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub scripts: Option<Scripts>,
-
     /// Inline command definitions
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commands: Option<CommandBlock>,
@@ -66,7 +62,6 @@ impl Workload {
             extends: None,
             packages: None,
             files: None,
-            scripts: None,
             commands: None,
             environment: None,
             health: None,
@@ -83,7 +78,6 @@ impl Workload {
             extends: None,
             packages: None,
             files: None,
-            scripts: None,
             commands: None,
             environment: None,
             health: None,
@@ -123,18 +117,6 @@ impl Workload {
     /// Get the total number of files
     pub fn file_count(&self) -> usize {
         self.files.as_ref().map(|f| f.len()).unwrap_or(0)
-    }
-
-    /// Get the total number of scripts (pre_install + post_install)
-    pub fn script_count(&self) -> usize {
-        self.scripts
-            .as_ref()
-            .map(|s| {
-                let pre = s.pre_install.as_ref().map(|p| p.len()).unwrap_or(0);
-                let post = s.post_install.as_ref().map(|p| p.len()).unwrap_or(0);
-                pre + post
-            })
-            .unwrap_or(0)
     }
 
     /// Get the total number of commands (pre_install + post_install)
@@ -298,65 +280,6 @@ impl FileEntry {
     }
 }
 
-/// Script definitions for various phases
-#[allow(dead_code)]
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Scripts {
-    /// Scripts to run before package installation
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pre_install: Option<Vec<ScriptEntry>>,
-
-    /// Scripts to run after package installation
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_install: Option<Vec<ScriptEntry>>,
-}
-
-/// A script to execute
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScriptEntry {
-    /// Relative path from workload's scripts/ directory
-    pub path: String,
-
-    /// Execution shell (default: "powershell")
-    #[serde(default = "default_shell")]
-    pub shell: String,
-
-    /// Description of what the script does
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-
-    /// Whether to require admin privileges (default: false)
-    #[serde(default)]
-    pub elevated: bool,
-
-    /// Timeout in seconds (default: 300)
-    #[serde(default = "default_timeout")]
-    pub timeout: u64,
-}
-
-fn default_shell() -> String {
-    "powershell".to_string()
-}
-
-fn default_timeout() -> u64 {
-    300
-}
-
-#[allow(dead_code)]
-impl ScriptEntry {
-    /// Create a new script entry
-    pub fn new(path: impl Into<String>) -> Self {
-        Self {
-            path: path.into(),
-            shell: default_shell(),
-            description: None,
-            elevated: false,
-            timeout: default_timeout(),
-        }
-    }
-}
-
 /// Commands block for inline command execution
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -368,6 +291,10 @@ pub struct CommandBlock {
     /// Commands to run after package installation
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub post_install: Option<Vec<CommandEntry>>,
+}
+
+fn default_timeout() -> u64 {
+    300
 }
 
 /// A single command to execute
@@ -510,10 +437,6 @@ packages:
 files:
   - source: config.toml
     destination: "~/.config/app/config.toml"
-scripts:
-  post_install:
-    - path: setup.ps1
-      description: "Run setup"
 "#;
         let workload: Workload = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(workload.name, "full-workload");

--- a/src/operations/init.rs
+++ b/src/operations/init.rs
@@ -295,10 +295,10 @@ description: "TODO: Add description for {name}"
 #   - source: config.toml
 #     destination: "~/.config/app/config.toml"
 #
-# scripts:
+# commands:
 #   post_install:
-#     - path: setup.ps1
-#       shell: powershell
+#     - run: echo "Setup complete"
+#       description: "Post-install setup"
 "#,
         name = name,
         extends_section = extends_section.trim_start()
@@ -341,13 +341,12 @@ files:
   #   destination: "~/.config/app/config.toml"
   #   backup: true  # Backup existing file before overwriting
 
-scripts:
-  # Post-installation script - runs after packages are installed
+commands:
+  # Post-installation commands - runs after packages are installed
   post_install:
-    - path: post-install.ps1
-      shell: powershell
+    - run: echo "Configure {name} environment"
       description: "Configure {name} environment"
-      timeout: 300  # Timeout in seconds
+      timeout: 300
 
 # Optional: Health check settings
 health:
@@ -422,20 +421,17 @@ files:
   #   destination: "~/.app/config"
   #   template: true
 
-# Scripts to execute at various stages
-scripts:
+# Commands to execute at various stages
+commands:
   # Pre-installation: Check prerequisites
   pre_install:
-    - path: pre-install.ps1
-      shell: powershell         # powershell, pwsh, cmd, bash
+    - run: echo "Checking prerequisites for {name}..."
       description: "Check prerequisites for {name}"
-      timeout: 60               # Seconds (default: 300)
-      # elevated: true          # Require admin (default: false)
+      timeout: 60
 
   # Post-installation: Configure the environment
   post_install:
-    - path: post-install.ps1
-      shell: powershell
+    - run: echo "Configuring {name} environment..."
       description: "Configure {name} environment"
       timeout: 300
 
@@ -642,7 +638,7 @@ mod tests {
         assert!(yaml.contains("name: my-app"));
         assert!(yaml.contains("packages:"));
         assert!(yaml.contains("files:"));
-        assert!(yaml.contains("scripts:"));
+        assert!(yaml.contains("commands:"));
         assert!(yaml.contains("health:"));
     }
 
@@ -654,7 +650,7 @@ mod tests {
         assert!(yaml.contains("- parent"));
         assert!(yaml.contains("packages:"));
         assert!(yaml.contains("files:"));
-        assert!(yaml.contains("scripts:"));
+        assert!(yaml.contains("commands:"));
         assert!(yaml.contains("environment:"));
         assert!(yaml.contains("health:"));
     }

--- a/src/operations/install.rs
+++ b/src/operations/install.rs
@@ -3,13 +3,13 @@
 //! This module implements the `anvil install` command which applies
 //! a workload configuration to the system by:
 //! 1. Validating winget availability
-//! 2. Running pre-installation scripts
+//! 2. Running pre-install commands
 //! 3. Installing packages via winget (with progress tracking)
 //! 4. Copying files to target destinations
-//! 5. Running post-installation scripts
+//! 5. Running post-install commands
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 
@@ -21,10 +21,6 @@ use crate::config::workload::{WingetPackage, Workload};
 use crate::config::ConfigManager;
 use crate::providers::backup::BackupManager;
 use crate::providers::filesystem::{CopyOptions, CopyResult};
-use crate::providers::script::{
-    OutputMode, ScriptConfig, ScriptContext, ScriptExecutionResult, ScriptExecutionSummary,
-    ScriptPhase, ScriptProvider,
-};
 use crate::providers::template::TemplateProcessor;
 use crate::providers::{create_registry, FilesystemProvider, PackageSpec, ProviderConfig};
 use crate::state::{FileState, FileStateManager, InstallationState, PackageCache};
@@ -161,45 +157,6 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
         }
     }
 
-    // Deprecation warning: scripts alongside commands
-    if let (Some(commands), Some(scripts)) = (&workload.commands, &workload.scripts) {
-        let has_cmd_pre = commands
-            .pre_install
-            .as_ref()
-            .map(|c| !c.is_empty())
-            .unwrap_or(false);
-        let has_script_pre = scripts
-            .pre_install
-            .as_ref()
-            .map(|s| !s.is_empty())
-            .unwrap_or(false);
-        if has_cmd_pre && has_script_pre {
-            print_warning(
-                "Deprecation notice: `scripts.pre_install` is deprecated when used alongside \
-                 `commands.pre_install`. Migrate scripts to inline commands. \
-                 See docs/src/specification.md for details.",
-            );
-        }
-
-        let has_cmd_post = commands
-            .post_install
-            .as_ref()
-            .map(|c| !c.is_empty())
-            .unwrap_or(false);
-        let has_script_post = scripts
-            .post_install
-            .as_ref()
-            .map(|s| !s.is_empty())
-            .unwrap_or(false);
-        if has_cmd_post && has_script_post {
-            print_warning(
-                "Deprecation notice: `scripts.post_install` is deprecated when used alongside \
-                 `commands.post_install`. Migrate scripts to inline commands. \
-                 See docs/src/specification.md for details.",
-            );
-        }
-    }
-
     if !args.force && !args.dry_run && !confirm_installation(&workload)? {
         print_info("Installation cancelled by user");
         return Ok(());
@@ -214,12 +171,6 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
     } else {
         crate::commands::CommandSummary::new()
     };
-
-    // Run pre-installation scripts (skip if files_only)
-    let mut pre_script_summary = ScriptExecutionSummary::new();
-    if !args.skip_scripts && !args.skip_pre_scripts && !args.files_only {
-        pre_script_summary = run_pre_install_scripts(&context, args)?;
-    }
 
     // Install packages (skip if files_only)
     let mut summary = InstallationSummary::default();
@@ -241,16 +192,7 @@ pub fn execute(args: &InstallArgs, cli: &Cli) -> Result<()> {
         crate::commands::CommandSummary::new()
     };
 
-    // Run post-installation scripts (skip if files_only)
-    let mut post_script_summary = ScriptExecutionSummary::new();
-    if !args.skip_scripts && !args.skip_post_scripts && !args.packages_only && !args.files_only {
-        post_script_summary = run_post_install_scripts(&context, args)?;
-    }
-
-    // Check if any scripts or commands require reboot
-    if pre_script_summary.requires_reboot || post_script_summary.requires_reboot {
-        summary.reboot_required = true;
-    }
+    // Check if any commands require reboot
     if pre_cmd_summary.requires_reboot || post_cmd_summary.requires_reboot {
         summary.reboot_required = true;
     }
@@ -449,7 +391,7 @@ fn print_install_header(workload: &Workload, dry_run: bool, file_count: usize) {
     println!("Description: {}", workload.description);
     println!("Packages:    {}", workload.package_count());
     println!("Files:       {}", file_count);
-    println!("Scripts:     {}", workload.script_count());
+    println!("Commands:    {}", workload.command_count());
     println!();
 }
 
@@ -656,165 +598,6 @@ fn print_command_summary(summary: &crate::commands::CommandSummary, phase: &str)
             phase, summary.succeeded, summary.failed, summary.skipped
         ));
     }
-}
-
-/// Run pre-installation scripts with enhanced output and tracking
-fn run_pre_install_scripts(
-    context: &OperationContext,
-    _args: &InstallArgs,
-) -> Result<ScriptExecutionSummary> {
-    let scripts = match &context.workload.scripts {
-        Some(s) => s.pre_install.as_ref(),
-        None => None,
-    };
-
-    let mut summary = ScriptExecutionSummary::new();
-
-    if scripts.is_none() || scripts.unwrap().is_empty() {
-        context.debug("No pre-installation scripts to run");
-        return Ok(summary);
-    }
-
-    let scripts = scripts.unwrap();
-    println!();
-    print_info(&format!(
-        "Running {} pre-installation script(s)...",
-        scripts.len()
-    ));
-
-    let scripts_dir = context.workload_path.join("scripts");
-    let mut provider = ScriptProvider::new()
-        .with_dry_run(context.dry_run)
-        .with_verbose(context.verbosity > 1)
-        .with_base_path(&scripts_dir);
-
-    // Create script context for environment injection
-    let script_context = ScriptContext::new(&context.workload.name, &context.workload_path)
-        .with_phase(ScriptPhase::PreInstall)
-        .with_dry_run(context.dry_run)
-        .with_verbose(context.verbosity > 1);
-
-    for (idx, script) in scripts.iter().enumerate() {
-        let script_name = script
-            .description
-            .clone()
-            .unwrap_or_else(|| script.path.clone());
-
-        println!();
-        print_info(&format!(
-            "  [{}/{}] {}",
-            idx + 1,
-            scripts.len(),
-            script_name
-        ));
-
-        // Build script configuration
-        let mut config = ScriptConfig::new(&script.path)
-            .with_timeout(Duration::from_secs(script.timeout))
-            .with_elevated(script.elevated)
-            .with_working_dir(&scripts_dir);
-
-        // Set output mode based on verbosity
-        if context.verbosity > 0 {
-            config = config
-                .with_output_mode(OutputMode::Both)
-                .with_output_prefix("        ");
-        }
-
-        // Inject environment variables
-        provider.inject_environment_variables(&mut config, &script_context);
-
-        let start = Instant::now();
-        match provider.execute(&config) {
-            Ok(result) => {
-                let exec_result = ScriptExecutionResult::from_result(
-                    &result,
-                    script_name.clone(),
-                    scripts_dir.join(&script.path),
-                    ScriptPhase::PreInstall,
-                );
-
-                if result.success {
-                    print_success(&format!(
-                        "        ✓ {} completed ({:.1}s)",
-                        script.path,
-                        result.duration.as_secs_f64()
-                    ));
-
-                    if result.requires_reboot {
-                        print_warning("        Script indicates reboot required");
-                    }
-
-                    summary.add_result(exec_result);
-                } else {
-                    print_error(&format!(
-                        "        ✗ {} failed (exit code: {})",
-                        script.path, result.exit_code
-                    ));
-
-                    if !result.stderr.is_empty() && context.verbosity > 0 {
-                        for line in result.stderr.lines().take(5) {
-                            eprintln!("          {}", line);
-                        }
-                    }
-
-                    summary.add_result(exec_result);
-                    anyhow::bail!("Pre-installation script failed: {}", script.path);
-                }
-            }
-            Err(e) => {
-                let duration = start.elapsed();
-
-                // Create a failed result for tracking
-                let exec_result = ScriptExecutionResult {
-                    script_name: script_name.clone(),
-                    script_path: scripts_dir.join(&script.path),
-                    phase: ScriptPhase::PreInstall,
-                    exit_code: -1,
-                    stdout: String::new(),
-                    stderr: e.to_string(),
-                    duration,
-                    success: false,
-                    requires_reboot: false,
-                };
-                summary.add_result(exec_result);
-
-                // Provide helpful error messages
-                match &e {
-                    crate::providers::script::ScriptError::ElevationRequired { .. } => {
-                        print_error(&format!("        ✗ {} requires elevation", script.path));
-                        print_warning(
-                            "        Run Anvil as Administrator or use --skip-pre-scripts",
-                        );
-                    }
-                    crate::providers::script::ScriptError::Timeout {
-                        timeout_seconds, ..
-                    } => {
-                        print_error(&format!(
-                            "        ✗ {} timed out after {}s",
-                            script.path, timeout_seconds
-                        ));
-                        print_warning("        Increase timeout in workload.yaml or check script");
-                    }
-                    _ => {
-                        print_error(&format!("        ✗ {} error: {}", script.path, e));
-                    }
-                }
-
-                anyhow::bail!("Pre-installation script error: {}", e);
-            }
-        }
-    }
-
-    if summary.succeeded > 0 {
-        println!();
-        print_success(&format!(
-            "Pre-installation scripts complete ({} succeeded)",
-            summary.succeeded
-        ));
-    }
-
-    Ok(summary)
 }
 
 /// Install packages with progress tracking
@@ -1667,185 +1450,6 @@ fn format_file_size(bytes: u64) -> String {
     } else {
         format!("{} B", bytes)
     }
-}
-
-/// Run post-installation scripts with enhanced output and tracking
-fn run_post_install_scripts(
-    context: &OperationContext,
-    _args: &InstallArgs,
-) -> Result<ScriptExecutionSummary> {
-    let scripts = match &context.workload.scripts {
-        Some(s) => s.post_install.as_ref(),
-        None => None,
-    };
-
-    let mut summary = ScriptExecutionSummary::new();
-
-    if scripts.is_none() || scripts.unwrap().is_empty() {
-        context.debug("No post-installation scripts to run");
-        return Ok(summary);
-    }
-
-    let scripts = scripts.unwrap();
-    println!();
-    print_info(&format!(
-        "Running {} post-installation script(s)...",
-        scripts.len()
-    ));
-
-    let scripts_dir = context.workload_path.join("scripts");
-    let mut provider = ScriptProvider::new()
-        .with_dry_run(context.dry_run)
-        .with_verbose(context.verbosity > 1)
-        .with_base_path(&scripts_dir);
-
-    // Create script context for environment injection
-    let script_context = ScriptContext::new(&context.workload.name, &context.workload_path)
-        .with_phase(ScriptPhase::PostInstall)
-        .with_dry_run(context.dry_run)
-        .with_verbose(context.verbosity > 1);
-
-    for (idx, script) in scripts.iter().enumerate() {
-        let script_name = script
-            .description
-            .clone()
-            .unwrap_or_else(|| script.path.clone());
-
-        println!();
-        print_info(&format!(
-            "  [{}/{}] {}",
-            idx + 1,
-            scripts.len(),
-            script_name
-        ));
-
-        // Build script configuration
-        let mut config = ScriptConfig::new(&script.path)
-            .with_timeout(Duration::from_secs(script.timeout))
-            .with_elevated(script.elevated)
-            .with_working_dir(&scripts_dir);
-
-        // Set output mode - always stream for post-install (users want to see progress)
-        if context.verbosity > 0 {
-            config = config
-                .with_output_mode(OutputMode::Both)
-                .with_output_prefix("        ");
-        } else {
-            // Even without verbose, stream output for post-install
-            config = config
-                .with_output_mode(OutputMode::Stream)
-                .with_output_prefix("        ");
-        }
-
-        // Inject environment variables
-        provider.inject_environment_variables(&mut config, &script_context);
-
-        let start = Instant::now();
-        match provider.execute(&config) {
-            Ok(result) => {
-                let exec_result = ScriptExecutionResult::from_result(
-                    &result,
-                    script_name.clone(),
-                    scripts_dir.join(&script.path),
-                    ScriptPhase::PostInstall,
-                );
-
-                if result.success {
-                    print_success(&format!(
-                        "        ✓ {} completed ({:.1}s)",
-                        script.path,
-                        result.duration.as_secs_f64()
-                    ));
-
-                    if result.requires_reboot {
-                        print_warning("        Script indicates reboot required");
-                        summary.requires_reboot = true;
-                    }
-
-                    summary.add_result(exec_result);
-                } else {
-                    print_warning(&format!(
-                        "        ⚠ {} completed with exit code {} ({:.1}s)",
-                        script.path,
-                        result.exit_code,
-                        result.duration.as_secs_f64()
-                    ));
-
-                    if !result.stderr.is_empty() && context.verbosity > 0 {
-                        for line in result.stderr.lines().take(5) {
-                            eprintln!("          {}", line);
-                        }
-                    }
-
-                    summary.add_result(exec_result);
-                    // Don't fail on post-install script non-zero exit, just warn
-                }
-            }
-            Err(e) => {
-                let duration = start.elapsed();
-
-                // Create a failed result for tracking
-                let exec_result = ScriptExecutionResult {
-                    script_name: script_name.clone(),
-                    script_path: scripts_dir.join(&script.path),
-                    phase: ScriptPhase::PostInstall,
-                    exit_code: -1,
-                    stdout: String::new(),
-                    stderr: e.to_string(),
-                    duration,
-                    success: false,
-                    requires_reboot: false,
-                };
-                summary.add_result(exec_result);
-
-                // Provide helpful error messages but don't fail
-                match &e {
-                    crate::providers::script::ScriptError::ElevationRequired { .. } => {
-                        print_warning(&format!(
-                            "        ⚠ {} requires elevation (skipped)",
-                            script.path
-                        ));
-                        print_info(
-                            "        Run Anvil as Administrator to execute elevated scripts",
-                        );
-                    }
-                    crate::providers::script::ScriptError::Timeout {
-                        timeout_seconds, ..
-                    } => {
-                        print_warning(&format!(
-                            "        ⚠ {} timed out after {}s",
-                            script.path, timeout_seconds
-                        ));
-                        print_info("        Increase timeout in workload.yaml if needed");
-                    }
-                    _ => {
-                        print_warning(&format!("        ⚠ {} error: {}", script.path, e));
-                    }
-                }
-
-                // Don't fail on post-install script errors
-                print_info(
-                    "        Post-installation script failed, but installation may still work",
-                );
-            }
-        }
-    }
-
-    println!();
-    if summary.failed > 0 {
-        print_warning(&format!(
-            "Post-installation scripts: {} succeeded, {} failed",
-            summary.succeeded, summary.failed
-        ));
-    } else if summary.succeeded > 0 {
-        print_success(&format!(
-            "Post-installation scripts complete ({} succeeded, {:.1}s total)",
-            summary.succeeded,
-            summary.total_duration.as_secs_f64()
-        ));
-    }
-
-    Ok(summary)
 }
 
 /// Print final installation summary

--- a/src/operations/show.rs
+++ b/src/operations/show.rs
@@ -118,18 +118,18 @@ fn display_workload_summary(workload: &Workload, use_color: bool, is_resolved: b
     // Summary counts
     let package_count = workload.package_count();
     let file_count = workload.file_count();
-    let script_count = workload.script_count();
+    let command_count = workload.command_count();
 
     if use_color {
         println!("{}", "Summary:".bold());
         println!("  📦 {} package(s)", package_count.to_string().cyan());
         println!("  📄 {} file(s)", file_count.to_string().cyan());
-        println!("  📜 {} script(s)", script_count.to_string().cyan());
+        println!("  ⚡ {} command(s)", command_count.to_string().cyan());
     } else {
         println!("Summary:");
         println!("  Packages: {}", package_count);
         println!("  Files: {}", file_count);
-        println!("  Scripts: {}", script_count);
+        println!("  Commands: {}", command_count);
     }
 
     // Packages summary
@@ -183,45 +183,6 @@ fn display_workload_summary(workload: &Workload, use_color: bool, is_resolved: b
                     );
                 } else {
                     println!("  - {} -> {}", file.source, file.destination);
-                }
-            }
-        }
-    }
-
-    // Scripts summary
-    if let Some(ref scripts) = workload.scripts {
-        let mut _has_scripts = false;
-
-        if let Some(ref pre) = scripts.pre_install {
-            if !pre.is_empty() {
-                if !_has_scripts {
-                    println!();
-                    _has_scripts = true;
-                }
-                if use_color {
-                    println!("{}", "Pre-install Scripts:".bold());
-                } else {
-                    println!("Pre-install Scripts:");
-                }
-                for script in pre {
-                    print_script_entry(&script.path, script.description.as_deref(), use_color);
-                }
-            }
-        }
-
-        if let Some(ref post) = scripts.post_install {
-            if !post.is_empty() {
-                if !_has_scripts {
-                    println!();
-                    _has_scripts = true;
-                }
-                if use_color {
-                    println!("{}", "Post-install Scripts:".bold());
-                } else {
-                    println!("Post-install Scripts:");
-                }
-                for script in post {
-                    print_script_entry(&script.path, script.description.as_deref(), use_color);
                 }
             }
         }
@@ -290,20 +251,6 @@ fn print_field(label: &str, value: &str, use_color: bool) {
     }
 }
 
-/// Print a script entry
-fn print_script_entry(path: &str, description: Option<&str>, use_color: bool) {
-    if use_color {
-        let desc = description
-            .map(|d| format!(" - {}", d.dimmed()))
-            .unwrap_or_default();
-        println!("  {} {}{}", "•".dimmed(), path.cyan(), desc);
-    } else {
-        let desc = description.map(|d| format!(" - {}", d)).unwrap_or_default();
-        println!("  - {}{}", path, desc);
-    }
-}
-
-/// Count total number of scripts in a workload
 /// Display inheritance tree for a workload
 fn show_inheritance_tree(
     workload_name: &str,
@@ -390,7 +337,7 @@ fn show_inheritance_tree(
 
     let package_count = resolved.package_count();
     let file_count = resolved.file_count();
-    let script_count = resolved.script_count();
+    let command_count = resolved.command_count();
 
     if use_color {
         println!(
@@ -399,7 +346,7 @@ fn show_inheritance_tree(
             stats.total_workloads
         );
         println!("  Files: {}", file_count.to_string().cyan());
-        println!("  Scripts: {}", script_count.to_string().cyan());
+        println!("  Commands: {}", command_count.to_string().cyan());
         println!(
             "  Inheritance depth: {}",
             stats.max_depth.to_string().cyan()
@@ -410,7 +357,7 @@ fn show_inheritance_tree(
             package_count, stats.total_workloads
         );
         println!("  Files: {}", file_count);
-        println!("  Scripts: {}", script_count);
+        println!("  Commands: {}", command_count);
         println!("  Inheritance depth: {}", stats.max_depth);
     }
 
@@ -423,25 +370,9 @@ mod tests {
     use crate::config::workload::{Packages, WingetPackage};
 
     #[test]
-    fn test_script_count_empty() {
+    fn test_command_count_empty() {
         let workload = Workload::new("test", "1.0.0", "Test workload");
-        assert_eq!(workload.script_count(), 0);
-    }
-
-    #[test]
-    fn test_script_count_with_scripts() {
-        use crate::config::workload::{ScriptEntry, Scripts};
-
-        let mut workload = Workload::new("test", "1.0.0", "Test workload");
-        workload.scripts = Some(Scripts {
-            pre_install: Some(vec![ScriptEntry::new("pre.ps1")]),
-            post_install: Some(vec![
-                ScriptEntry::new("post1.ps1"),
-                ScriptEntry::new("post2.ps1"),
-            ]),
-        });
-
-        assert_eq!(workload.script_count(), 3);
+        assert_eq!(workload.command_count(), 0);
     }
 
     #[test]

--- a/src/operations/validate.rs
+++ b/src/operations/validate.rs
@@ -14,7 +14,6 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use std::collections::HashSet;
 use std::path::Path;
-use std::time::Duration;
 use tracing::{debug, trace};
 
 use crate::cli::commands::ValidateArgs;
@@ -23,7 +22,6 @@ use crate::cli::Cli;
 use crate::config::schema::{SchemaValidator, ValidationResult, ValidationSeverity};
 use crate::config::workload::Workload;
 use crate::config::ConfigManager;
-use crate::providers::script::{ScriptConfig, ScriptProvider, Shell};
 
 /// Execute the validate command
 pub fn execute(args: &ValidateArgs, cli: &Cli) -> Result<()> {
@@ -101,10 +99,10 @@ pub fn execute(args: &ValidateArgs, cli: &Cli) -> Result<()> {
     // Run schema validation
     let mut result = validator.validate(&workload);
 
-    // Check for removed scripts.health_check field in raw YAML
-    SchemaValidator::check_removed_health_check(&content, &mut result);
+    // Check for removed scripts fields in raw YAML
+    SchemaValidator::check_removed_scripts_fields(&content, &mut result);
 
-    // Check for files and scripts existence
+    // Check for files existence
     let base_dir = workload_file.parent().unwrap_or(Path::new("."));
     let file_result = validate_referenced_files(&workload, base_dir, args.strict);
     result.merge(file_result);
@@ -112,20 +110,6 @@ pub fn execute(args: &ValidateArgs, cli: &Cli) -> Result<()> {
     // Validate parent workloads exist and check for circular dependencies
     let inheritance_result = validate_inheritance(&workload, base_dir, args.strict);
     result.merge(inheritance_result);
-
-    // Validate script syntax if requested
-    if args.check_scripts {
-        if !cli.quiet {
-            println!();
-            if use_color {
-                println!("{} Validating script syntax...", "ℹ".blue());
-            } else {
-                print_info("Validating script syntax...");
-            }
-        }
-        let script_result = validate_script_syntax(&workload, base_dir, args.strict, cli.quiet);
-        result.merge(script_result);
-    }
 
     // Print results
     if !result.messages.is_empty() {
@@ -279,212 +263,6 @@ fn validate_referenced_files(
                         format!("files[{}].source", i),
                         format!("File exists but cannot be read: {}", e),
                     );
-                }
-            }
-        }
-    }
-
-    // Check scripts
-    if let Some(scripts) = &workload.scripts {
-        let scripts_dir = base_dir.join("scripts");
-
-        // Check pre-install scripts
-        if let Some(pre_scripts) = &scripts.pre_install {
-            for (i, script) in pre_scripts.iter().enumerate() {
-                let script_path = scripts_dir.join(&script.path);
-                if !script_path.exists() {
-                    let msg = format!("Script file not found: {}", script_path.display());
-                    if strict {
-                        result.add_error(format!("scripts.pre_install[{}].path", i), msg);
-                    } else {
-                        result.add_warning(format!("scripts.pre_install[{}].path", i), msg);
-                    }
-                } else {
-                    // Check for common script issues
-                    check_script_file(
-                        &script_path,
-                        &format!("scripts.pre_install[{}]", i),
-                        &mut result,
-                    );
-                }
-            }
-        }
-
-        // Check post-install scripts
-        if let Some(post_scripts) = &scripts.post_install {
-            for (i, script) in post_scripts.iter().enumerate() {
-                let script_path = scripts_dir.join(&script.path);
-                if !script_path.exists() {
-                    let msg = format!("Script file not found: {}", script_path.display());
-                    if strict {
-                        result.add_error(format!("scripts.post_install[{}].path", i), msg);
-                    } else {
-                        result.add_warning(format!("scripts.post_install[{}].path", i), msg);
-                    }
-                } else {
-                    check_script_file(
-                        &script_path,
-                        &format!("scripts.post_install[{}]", i),
-                        &mut result,
-                    );
-                }
-            }
-        }
-    }
-
-    result
-}
-
-/// Check a script file for common issues (BOM, encoding, line endings)
-fn check_script_file(path: &Path, field_path: &str, result: &mut ValidationResult) {
-    // Read file as bytes to check for BOM
-    if let Ok(bytes) = std::fs::read(path) {
-        // Check for UTF-8 BOM (EF BB BF)
-        if bytes.len() >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF {
-            result.add_info(
-                field_path.to_string(),
-                "Script has UTF-8 BOM (may cause issues with some tools)".to_string(),
-            );
-        }
-
-        // Check for UTF-16 BOM
-        if bytes.len() >= 2
-            && ((bytes[0] == 0xFF && bytes[1] == 0xFE) || (bytes[0] == 0xFE && bytes[1] == 0xFF))
-        {
-            result.add_warning(
-                field_path.to_string(),
-                "Script appears to be UTF-16 encoded (may cause issues)".to_string(),
-            );
-        }
-
-        // Try to parse as UTF-8
-        if let Ok(content) = String::from_utf8(bytes.clone()) {
-            // Check for mixed line endings
-            let has_crlf = content.contains("\r\n");
-            let has_lf_only = content.contains('\n') && !content.contains('\r');
-            if has_crlf && has_lf_only {
-                result.add_info(
-                    field_path.to_string(),
-                    "Script has mixed line endings (CRLF and LF)".to_string(),
-                );
-            }
-
-            // Check for empty script
-            if content.trim().is_empty() {
-                result.add_warning(field_path.to_string(), "Script file is empty".to_string());
-            }
-        } else {
-            result.add_warning(
-                field_path.to_string(),
-                "Script is not valid UTF-8".to_string(),
-            );
-        }
-    }
-}
-
-/// Validate PowerShell script syntax using the parser
-fn validate_script_syntax(
-    workload: &Workload,
-    base_dir: &Path,
-    strict: bool,
-    quiet: bool,
-) -> ValidationResult {
-    let mut result = ValidationResult::new();
-
-    let scripts = match &workload.scripts {
-        Some(s) => s,
-        None => return result,
-    };
-
-    let scripts_dir = base_dir.join("scripts");
-    let provider = ScriptProvider::new().with_base_path(&scripts_dir);
-
-    let mut scripts_to_validate: Vec<(&str, &str, &str)> = Vec::new();
-
-    // Collect all scripts
-    if let Some(pre) = &scripts.pre_install {
-        for script in pre {
-            scripts_to_validate.push(("pre_install", &script.path, &script.shell));
-        }
-    }
-    if let Some(post) = &scripts.post_install {
-        for script in post {
-            scripts_to_validate.push(("post_install", &script.path, &script.shell));
-        }
-    }
-
-    if scripts_to_validate.is_empty() {
-        return result;
-    }
-
-    for (phase, script_path, shell_name) in scripts_to_validate {
-        let full_path = scripts_dir.join(script_path);
-
-        if !full_path.exists() {
-            // Already reported in file existence check
-            continue;
-        }
-
-        // Determine shell
-        let shell = Shell::from_str(shell_name).unwrap_or(Shell::PowerShell);
-
-        // Only validate PowerShell scripts
-        if shell != Shell::PowerShell && shell != Shell::Pwsh {
-            if !quiet {
-                result.add_info(
-                    format!("scripts.{}.{}", phase, script_path),
-                    format!("Skipping syntax check for {} script", shell_name),
-                );
-            }
-            continue;
-        }
-
-        // Build config for validation
-        let config = ScriptConfig::new(script_path)
-            .with_shell(shell)
-            .with_timeout(Duration::from_secs(30));
-
-        // Validate syntax
-        match provider.validate_syntax(&config) {
-            Ok(()) => {
-                if !quiet {
-                    result.add_info(
-                        format!("scripts.{}.{}", phase, script_path),
-                        "Syntax OK".to_string(),
-                    );
-                }
-            }
-            Err(e) => {
-                let msg = match &e {
-                    crate::providers::script::ScriptError::SyntaxError { message, .. } => {
-                        // Check if the error might be related to Unicode characters
-                        // which is common in scripts using emoji or special chars
-                        let is_unicode_issue = message.contains("Unexpected token")
-                            && (message.contains("recommended")
-                                || message.contains("}")
-                                || message.contains("GB"));
-
-                        if is_unicode_issue {
-                            format!(
-                                "Possible encoding issue (Unicode chars): {}",
-                                message.lines().next().unwrap_or("unknown")
-                            )
-                        } else {
-                            format!(
-                                "Syntax error: {}",
-                                message.lines().next().unwrap_or("unknown")
-                            )
-                        }
-                    }
-                    _ => format!("Validation error: {}", e),
-                };
-
-                // Unicode-related issues are always warnings, not errors
-                let is_likely_unicode = msg.contains("Possible encoding issue");
-                if strict && !is_likely_unicode {
-                    result.add_error(format!("scripts.{}.{}", phase, script_path), msg);
-                } else {
-                    result.add_warning(format!("scripts.{}.{}", phase, script_path), msg);
                 }
             }
         }
@@ -726,13 +504,6 @@ fn print_json_schema() -> Result<()> {
         }
       }
     },
-    "scripts": {
-      "type": "object",
-      "properties": {
-        "pre_install": { "$ref": "#/definitions/scriptList" },
-        "post_install": { "$ref": "#/definitions/scriptList" }
-      }
-    },
     "commands": {
       "type": "object",
       "description": "Inline command definitions",
@@ -801,37 +572,6 @@ fn print_json_schema() -> Result<()> {
     }
   },
   "definitions": {
-    "scriptList": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["path"],
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "Relative path from workload's scripts/ directory"
-          },
-          "shell": {
-            "type": "string",
-            "default": "powershell",
-            "enum": ["powershell", "pwsh", "cmd", "bash"]
-          },
-          "description": { "type": "string" },
-          "elevated": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether to require admin privileges"
-          },
-          "timeout": {
-            "type": "integer",
-            "default": 300,
-            "minimum": 5,
-            "maximum": 3600,
-            "description": "Timeout in seconds"
-          }
-        }
-      }
-    },
     "commandList": {
       "type": "array",
       "items": {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -456,25 +456,6 @@ mod install_command {
     }
 
     #[test]
-    fn install_with_skip_scripts() {
-        assert_or_skip_winget!(anvil().args([
-            "install",
-            "./examples/minimal",
-            "--dry-run",
-            "--skip-scripts"
-        ]));
-        anvil()
-            .args([
-                "install",
-                "./examples/minimal",
-                "--dry-run",
-                "--skip-scripts",
-            ])
-            .assert()
-            .success();
-    }
-
-    #[test]
     fn install_with_all_skip_flags() {
         anvil()
             .args([
@@ -483,7 +464,6 @@ mod install_command {
                 "--dry-run",
                 "--skip-packages",
                 "--skip-files",
-                "--skip-scripts",
             ])
             .assert()
             .success();
@@ -508,27 +488,18 @@ mod install_command {
     }
 
     #[test]
-    fn install_deprecation_warning_when_commands_and_scripts_coexist() {
+    fn install_rejects_removed_scripts_fields() {
         let temp = TempDir::new().unwrap();
         common::create_workload_with_commands_and_scripts(temp.path(), "coexist-test").unwrap();
         let workload_path = temp.path().join("coexist-test");
 
-        // When both commands and scripts exist for the same phase, stderr should contain deprecation warnings
+        // Validation should report an error for the removed scripts fields
         anvil()
-            .args([
-                "install",
-                workload_path.to_str().unwrap(),
-                "--dry-run",
-                "--skip-scripts",
-                "--skip-packages",
-            ])
+            .args(["validate", workload_path.to_str().unwrap()])
             .assert()
-            .success()
-            .stderr(predicate::str::contains(
-                "scripts.pre_install` is deprecated when used alongside `commands.pre_install`",
-            ))
-            .stderr(predicate::str::contains(
-                "scripts.post_install` is deprecated when used alongside `commands.post_install`",
+            .failure()
+            .stdout(predicate::str::contains(
+                "scripts.pre_install and scripts.post_install have been removed in v1.0",
             ));
     }
 }
@@ -1008,20 +979,18 @@ files:
     }
 
     #[test]
-    fn workload_with_scripts() {
+    fn workload_with_commands() {
         let temp = TempDir::new().unwrap();
-        let workload_dir = temp.path().join("scripts-workload");
-        let scripts_dir = workload_dir.join("scripts");
-        fs::create_dir_all(&scripts_dir).unwrap();
-        fs::write(scripts_dir.join("post-install.ps1"), "exit 0").unwrap();
+        let workload_dir = temp.path().join("commands-workload");
+        fs::create_dir_all(&workload_dir).unwrap();
         fs::write(
             workload_dir.join("workload.yaml"),
-            r#"name: scripts-workload
+            r#"name: commands-workload
 version: "1.0.0"
-description: "Workload with scripts"
-scripts:
+description: "Workload with commands"
+commands:
   post_install:
-    - path: scripts/post-install.ps1
+    - run: echo "Post-install setup"
       description: "Post-install setup"
 "#,
         )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -139,10 +139,8 @@ extends:
 /// Result indicating success or IO error
 pub fn create_full_workload(dir: &Path, name: &str) -> std::io::Result<()> {
     let workload_dir = dir.join(name);
-    let scripts_dir = workload_dir.join("scripts");
     let files_dir = workload_dir.join("files");
 
-    fs::create_dir_all(&scripts_dir)?;
     fs::create_dir_all(&files_dir)?;
 
     // Create workload.yaml
@@ -163,14 +161,13 @@ files:
     backup: true
     template: false
 
-scripts:
+commands:
   pre_install:
-    - path: scripts/pre-install.ps1
+    - run: echo "Pre-installation checks"
       description: "Pre-installation checks"
       timeout: 60
-
   post_install:
-    - path: scripts/post-install.ps1
+    - run: echo "Post-installation configuration"
       description: "Post-installation configuration"
       timeout: 120
 
@@ -194,34 +191,6 @@ environment:
   "setting1": "value1",
   "setting2": "value2"
 }
-"#,
-    )?;
-
-    // Create pre-install script
-    fs::write(
-        scripts_dir.join("pre-install.ps1"),
-        r#"# Pre-installation script
-Write-Host "Running pre-installation checks..."
-exit 0
-"#,
-    )?;
-
-    // Create post-install script
-    fs::write(
-        scripts_dir.join("post-install.ps1"),
-        r#"# Post-installation script
-Write-Host "Running post-installation configuration..."
-exit 0
-"#,
-    )?;
-
-    // Create health check script
-    fs::write(
-        scripts_dir.join("health-check.ps1"),
-        r#"# Health check script
-Write-Host "Running health checks..."
-Write-Host "All checks passed!"
-exit 0
 "#,
     )?;
 
@@ -439,18 +408,17 @@ exit 0
     Ok(())
 }
 
-/// Create a workload with both commands and scripts for testing
-/// the deprecation warning when both coexist
+/// Create a workload with the removed scripts fields for testing
+/// that validation correctly rejects them
 #[allow(dead_code)]
 pub fn create_workload_with_commands_and_scripts(dir: &Path, name: &str) -> std::io::Result<()> {
     let workload_dir = dir.join(name);
-    let scripts_dir = workload_dir.join("scripts");
-    fs::create_dir_all(&scripts_dir)?;
+    fs::create_dir_all(&workload_dir)?;
 
     let yaml = format!(
         r#"name: {name}
 version: "1.0.0"
-description: "Workload with both commands and scripts"
+description: "Workload with removed scripts fields"
 
 commands:
   pre_install:
@@ -471,20 +439,6 @@ scripts:
     );
 
     fs::write(workload_dir.join("workload.yaml"), yaml)?;
-    fs::write(
-        scripts_dir.join("pre-install.ps1"),
-        r#"# Pre-install script
-Write-Host "Pre-install running..."
-exit 0
-"#,
-    )?;
-    fs::write(
-        scripts_dir.join("post-install.ps1"),
-        r#"# Post-install script
-Write-Host "Post-install running..."
-exit 0
-"#,
-    )?;
 
     Ok(())
 }
@@ -529,9 +483,6 @@ mod tests {
         let workload_dir = temp.path().join("full-test");
         assert!(workload_dir.join("workload.yaml").exists());
         assert!(workload_dir.join("files/config.json").exists());
-        assert!(workload_dir.join("scripts/pre-install.ps1").exists());
-        assert!(workload_dir.join("scripts/post-install.ps1").exists());
-        assert!(workload_dir.join("scripts/health-check.ps1").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Remove the deprecated `scripts` system entirely — `scripts.pre_install`, `scripts.post_install`, and the `Scripts`/`ScriptEntry` structs. Users should use the `commands` block instead.

### What's included

- **Removed `scripts` field** from the `Workload` struct — the `Scripts` and `ScriptEntry` structs are fully deleted
- **Removed `--skip-scripts`, `--skip-pre-scripts`, `--skip-post-scripts`** flags from `anvil install`
- **Removed ~400 lines** of script execution logic from `install.rs` (pre/post install script runners)
- **Removed script inheritance** — `merge_scripts`/`merge_script_list` deleted from `inheritance.rs`
- **Removed script validation** — `validate_scripts`/`validate_script_entry`/`check_script_file` deleted from `validate.rs` and `schema.rs`
- **Schema validation** now emits an error if `scripts.pre_install` or `scripts.post_install` is present, with migration guidance
- **Updated `anvil init` templates** — all three templates (minimal/standard/full) now use `commands` instead of `scripts`
- **Converted example workloads** — `rust-developer` and `python-developer` now use `commands.post_install`
- **Updated 7 documentation files** to reflect the removal

### Migration

```yaml
# Before (removed)
scripts:
  post_install:
    - path: setup.ps1
      description: "Run setup"

# After (use commands)
commands:
  post_install:
    - run: "./scripts/setup.ps1"
      description: "Run setup"
```

## Related Issues

Closes #40

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [x] Other (describe below)

**Breaking change**: removes `scripts.pre_install`, `scripts.post_install`, `Scripts` struct, `ScriptEntry` struct, and 3 CLI flags.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)