### PR TITLE
feat: add promotional website and Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,16 @@ jobs:
           test -f docs/src/workload-authoring.md
           test -f docs/src/troubleshooting.md
 
+      - name: Install mdbook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+
+      - name: Build site
+        run: |
+          chmod +x scripts/build-site.sh
+          bash scripts/build-site.sh
+
   ci-pass:
     name: CI Pass
     needs: [validate, build, docs]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Promotional landing page at `anvil.kafkade.com` with feature overview, code demo, and installation instructions
+- Separate mdbook documentation served at `anvil.kafkade.com/docs/`
+- Self-contained site build script (`scripts/build-site.sh`) that auto-installs mdbook
+- Redirect rules for old root-level documentation URLs to `/docs/` subpath
+
+### Changed
+- Documentation URLs now use `/docs/` subpath (e.g., `anvil.kafkade.com/docs/user-guide.html`)
+- CI `Documentation` job now validates the full site build (promotional site + mdbook)
+
 ### Removed
 - `scripts.health_check` field — use declarative `assertions` instead
 - `--scripts-only` and `--script` flags from `anvil health` command

--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ Global Options:
 
 | Document | Description |
 |----------|-------------|
-| [User Guide](https://anvil.kafkade.com/user-guide.html) | Complete usage instructions |
-| [Workload Authoring](https://anvil.kafkade.com/workload-authoring.html) | Creating custom workloads |
-| [Troubleshooting](https://anvil.kafkade.com/troubleshooting.html) | Common issues and solutions |
-| [Specification](https://anvil.kafkade.com/specification.html) | Technical spec and roadmap |
-| [Architecture](https://anvil.kafkade.com/architecture.html) | Internal code architecture |
+| [User Guide](https://anvil.kafkade.com/docs/user-guide.html) | Complete usage instructions |
+| [Workload Authoring](https://anvil.kafkade.com/docs/workload-authoring.html) | Creating custom workloads |
+| [Troubleshooting](https://anvil.kafkade.com/docs/troubleshooting.html) | Common issues and solutions |
+| [Specification](https://anvil.kafkade.com/docs/specification.html) | Technical spec and roadmap |
+| [Architecture](https://anvil.kafkade.com/docs/architecture.html) | Internal code architecture |
 | [Contributing](CONTRIBUTING.md) | Contribution guidelines |
 | [Changelog](CHANGELOG.md) | Version history |
 
@@ -175,7 +175,7 @@ Global Options:
 - [Windows Package Manager (winget)](https://github.com/microsoft/winget-cli)
 - PowerShell 5.1 or later
 
-> Cross-platform support (macOS via Homebrew, Linux via APT) is on the [roadmap](https://anvil.kafkade.com/specification.html#8-roadmap).
+> Cross-platform support (macOS via Homebrew, Linux via APT) is on the [roadmap](https://anvil.kafkade.com/docs/specification.html#8-roadmap).
 
 ## 🛠️ Building from Source
 

--- a/book.toml
+++ b/book.toml
@@ -14,8 +14,7 @@ preferred-dark-theme = "ayu"
 theme = "docs/theme"
 git-repository-url = "https://github.com/kafkade/anvil"
 edit-url-template = "https://github.com/kafkade/anvil/edit/main/{path}"
-site-url = "https://anvil.kafkade.com/"
-cname = "anvil.kafkade.com"
+site-url = "https://anvil.kafkade.com/docs/"
 no-section-label = false
 additional-css = ["docs/theme/custom.css"]
 

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -19,8 +19,10 @@ fi
 # Install mdbook if not available
 if ! command -v mdbook >/dev/null 2>&1; then
   echo "==> Installing mdbook v${MDBOOK_VERSION}"
+  mkdir -p "$ROOT_DIR/.bin"
   curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
-    | tar xz -C /usr/local/bin
+    | tar xz -C "$ROOT_DIR/.bin"
+  export PATH="$ROOT_DIR/.bin:$PATH"
 fi
 echo "    mdbook $(mdbook --version)"
 

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# build-site.sh — Builds the Anvil promotional site + mdbook docs into dist/
+# Works standalone in any Linux environment (CI, Cloudflare Pages, local).
+set -euo pipefail
+
+MDBOOK_VERSION="${MDBOOK_VERSION:-0.4.44}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+# Preflight
+if [ ! -d "site" ]; then
+  echo "Error: site/ directory not found" >&2
+  exit 1
+fi
+
+# Install mdbook if not available
+if ! command -v mdbook >/dev/null 2>&1; then
+  echo "==> Installing mdbook v${MDBOOK_VERSION}"
+  curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+    | tar xz -C /usr/local/bin
+fi
+echo "    mdbook $(mdbook --version)"
+
+echo "==> Cleaning dist/"
+rm -rf dist
+mkdir -p dist
+
+echo "==> Copying promotional site"
+cp -a site/. dist/
+
+echo "==> Building mdbook documentation"
+mdbook build
+
+echo "==> Copying docs to dist/docs/"
+cp -r docs/book dist/docs
+
+echo "==> Build complete (output: dist/)"
+echo "    Site:  dist/index.html"
+echo "    Docs:  dist/docs/index.html"

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,0 +1,12 @@
+# Redirects for old docs URLs (before /docs/ subpath migration)
+/introduction.html        /docs/introduction.html        301
+/user-guide.html           /docs/user-guide.html           301
+/workload-authoring.html   /docs/workload-authoring.html   301
+/cookbook.html              /docs/cookbook.html              301
+/troubleshooting.html      /docs/troubleshooting.html      301
+/cli-reference.html        /docs/cli-reference.html        301
+/schema-reference.html     /docs/schema-reference.html     301
+/specification.html        /docs/specification.html        301
+/architecture.html         /docs/architecture.html         301
+/changelog.html            /docs/changelog.html            301
+/contributing.html         /docs/contributing.html         301

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,65 +1,190 @@
-/* Anvil promotional site — forge-themed dark design */
+/* Anvil — cartoonish forge-themed design */
 
-/* ===== Reset & Custom Properties ===== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+/* ===== Design tokens ===== */
 
 :root {
-  --bg-primary: #0f172a;
-  --bg-secondary: #1e293b;
-  --bg-code: #151d2e;
-  --bg-card: #162032;
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
-  --accent-red: #dc2626;
-  --accent-orange: #f97316;
-  --accent-amber: #fbbf24;
-  --accent-cream: #fef3c7;
-  --gradient-forge: linear-gradient(135deg, #dc2626 0%, #f97316 40%, #fbbf24 100%);
-  --gradient-forge-text: linear-gradient(135deg, #f97316 0%, #fbbf24 50%, #fef3c7 100%);
-  --border-color: rgba(148, 163, 184, 0.12);
-  --border-accent: rgba(249, 115, 22, 0.25);
+  --bg-body: #fff8f0;
+  --bg-card: #ffffff;
+  --bg-mint: #e4ffd4;
+  --bg-lavender: #f0eaff;
+  --bg-peach: #fff0e0;
+  --bg-ink: #1a1a1a;
+  --bg-code: #faf8f4;
+  --bg-nav: rgba(255, 248, 240, 0.92);
+  --bg-nav-mobile: rgba(255, 248, 240, 0.97);
+
+  --text-strong: #1a1a1a;
+  --text-body: #333;
+  --text-soft: #666;
+  --text-faint: #999;
+  --text-on-ink: #f5f0ea;
+
+  --stroke: #1a1a1a;
+  --stroke-soft: #e0d8d0;
+
+  --brand-red: #dc2626;
+  --brand-orange: #ff771c;
+  --brand-amber: #fbbf24;
+
+  --shadow: 4px 4px 0 var(--stroke);
+  --shadow-sm: 3px 3px 0 var(--stroke);
+
+  --hl-key: #0369a1;
+  --hl-str: #166534;
+  --hl-lit: #c2410c;
+  --hl-ok: #15803d;
+  --hl-cmd: #0369a1;
+
   --max-width: 1100px;
-  --nav-height: 60px;
+  --nav-height: 64px;
+  --radius: 14px;
+  --radius-pill: 999px;
 }
 
-html {
-  scroll-behavior: smooth;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+[data-theme="dark"] {
+  --bg-body: #1a1a2e;
+  --bg-card: #28284a;
+  --bg-mint: #1c2e1a;
+  --bg-lavender: #281c3e;
+  --bg-peach: #2e281a;
+  --bg-ink: #111122;
+  --bg-code: #222240;
+  --bg-nav: rgba(26, 26, 46, 0.92);
+  --bg-nav-mobile: rgba(26, 26, 46, 0.97);
+
+  --text-strong: #f0ece6;
+  --text-body: #c8c4be;
+  --text-soft: #908c86;
+  --text-faint: #706c66;
+  --text-on-ink: #d0ccc6;
+
+  --stroke: #706c66;
+  --stroke-soft: #3a3a4e;
+
+  --shadow: 4px 4px 0 #444;
+  --shadow-sm: 3px 3px 0 #444;
+
+  --hl-key: #7dd3fc;
+  --hl-str: #a5d6a7;
+  --hl-lit: #ffab91;
+  --hl-ok: #4ade80;
+  --hl-cmd: #7dd3fc;
 }
+
+/* ===== Matrix Theme (Konami easter egg) ===== */
+
+[data-theme="matrix"] {
+  --bg-body: transparent;
+  --bg-card: rgba(0, 16, 0, 0.88);
+  --bg-mint: rgba(0, 22, 0, 0.45);
+  --bg-lavender: rgba(0, 16, 6, 0.45);
+  --bg-peach: rgba(0, 20, 0, 0.45);
+  --bg-ink: rgba(0, 8, 0, 0.92);
+  --bg-code: rgba(0, 14, 0, 0.9);
+  --bg-nav: rgba(0, 8, 0, 0.92);
+  --bg-nav-mobile: rgba(0, 8, 0, 0.95);
+
+  --text-strong: #00ff41;
+  --text-body: #00cc33;
+  --text-soft: #009925;
+  --text-faint: #006618;
+  --text-on-ink: #00ff41;
+
+  --stroke: #00aa2e;
+  --stroke-soft: #004a12;
+
+  --brand-red: #00ff41;
+  --brand-orange: #00ff41;
+  --brand-amber: #33ff66;
+
+  --shadow: 4px 4px 0 #003a0e;
+  --shadow-sm: 3px 3px 0 #003a0e;
+
+  --hl-key: #33ff66;
+  --hl-str: #88ffaa;
+  --hl-lit: #55ff77;
+  --hl-ok: #00ff41;
+  --hl-cmd: #33ff66;
+}
+
+[data-theme="matrix"] main,
+[data-theme="matrix"] .footer {
+  position: relative;
+  z-index: 1;
+}
+
+[data-theme="matrix"] .nav {
+  border-bottom-color: #00aa2e;
+}
+
+[data-theme="matrix"] .hero-badge {
+  background: rgba(0, 16, 0, 0.88);
+}
+
+[data-theme="matrix"] .demo-dot {
+  background: #00ff41 !important;
+  border-color: #006618;
+}
+
+#matrix-canvas {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.matrix-dismiss {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 200;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #00ff41;
+  background: rgba(0, 8, 0, 0.88);
+  border: 1.5px solid #00aa2e;
+  border-radius: var(--radius-pill);
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  letter-spacing: 0.04em;
+  transition: background 0.15s, color 0.15s;
+}
+
+.matrix-dismiss:hover {
+  background: #00ff41;
+  color: #000a00;
+}
+
+/* ===== Base ===== */
+
+html { scroll-behavior: smooth; }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: var(--bg-primary);
-  color: var(--text-primary);
+  font-family: 'Nunito', -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--bg-body);
+  color: var(--text-body);
   line-height: 1.6;
-  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+a { color: inherit; text-decoration: none; }
 
 /* ===== Navigation ===== */
 
 .nav {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  top: 0; left: 0; right: 0;
   height: var(--nav-height);
   z-index: 100;
-  background: rgba(15, 23, 42, 0.85);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-nav);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 2px solid var(--stroke);
 }
 
 .nav-inner {
@@ -76,57 +201,59 @@ a {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 700;
-  font-size: 1.15rem;
-  letter-spacing: -0.02em;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 900;
+  font-size: 1.25rem;
+  color: var(--text-strong);
 }
 
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 1.75rem;
+  gap: 0.5rem;
 }
 
-.nav-links a {
+.nav-links a,
+.nav-links button {
+  font-family: 'Nunito', sans-serif;
   font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-  transition: color 0.2s ease;
+  font-weight: 700;
+  color: var(--text-soft);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-pill);
+  transition: background 0.15s, color 0.15s;
 }
 
-.nav-links a:hover {
-  color: var(--text-primary);
+.nav-links a:hover,
+.nav-links button:hover {
+  background: var(--stroke);
+  color: var(--text-on-ink);
 }
 
-.nav-docs {
-  color: var(--accent-amber) !important;
-}
+.nav-docs { color: var(--brand-orange) !important; }
 
 .nav-github {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
-.nav-toggle-input {
-  display: none;
-}
+.nav-toggle-input { display: none; }
 
 .nav-toggle {
   display: none;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
   cursor: pointer;
-  padding: 4px;
+  padding: 6px;
 }
 
 .nav-toggle span {
   display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--text-secondary);
-  border-radius: 1px;
+  width: 22px;
+  height: 2.5px;
+  background: var(--text-strong);
+  border-radius: 2px;
   transition: transform 0.2s, opacity 0.2s;
 }
 
@@ -141,60 +268,45 @@ a {
 /* ===== Hero ===== */
 
 .hero {
-  position: relative;
-  padding: calc(var(--nav-height) + 5rem) 0 5rem;
+  padding: calc(var(--nav-height) + 4rem) 0 4rem;
   text-align: center;
-  overflow: hidden;
-}
-
-.hero-glow {
-  position: absolute;
-  top: -120px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 600px;
-  height: 400px;
-  background: radial-gradient(ellipse, rgba(249, 115, 22, 0.08) 0%, transparent 70%);
-  pointer-events: none;
+  background: var(--bg-body);
 }
 
 .hero-badge {
   display: inline-block;
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--text-muted);
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-  padding: 0.35rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-soft);
+  border: 2px solid var(--stroke);
+  border-radius: var(--radius-pill);
+  padding: 0.3rem 1rem;
   margin-bottom: 2rem;
-  letter-spacing: 0.03em;
+  box-shadow: var(--shadow-sm);
+  background: var(--bg-card);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
-.hero-logo {
-  margin-bottom: 1.5rem;
-}
+.hero-logo { margin-bottom: 1.25rem; }
 
 .hero h1 {
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 700;
-  font-size: clamp(2.4rem, 5.5vw, 3.8rem);
-  line-height: 1.15;
-  letter-spacing: -0.035em;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 900;
+  font-size: clamp(2.6rem, 6vw, 4.2rem);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  color: var(--text-strong);
   margin-bottom: 1.25rem;
 }
 
-.gradient-text {
-  background: var(--gradient-forge-text);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
+.accent { color: var(--brand-orange); }
 
 .hero-subtitle {
   font-size: 1.1rem;
-  line-height: 1.7;
-  color: var(--text-secondary);
-  max-width: 600px;
+  line-height: 1.65;
+  color: var(--text-soft);
+  max-width: 560px;
   margin: 0 auto 2.5rem;
 }
 
@@ -206,241 +318,243 @@ a {
   margin-bottom: 2.5rem;
 }
 
-/* Buttons */
+/* ===== Buttons (cartoon 3D) ===== */
 
 .btn {
   display: inline-flex;
   align-items: center;
-  font-family: 'Inter', sans-serif;
-  font-weight: 600;
-  font-size: 0.9rem;
-  padding: 0.7rem 1.5rem;
-  border-radius: 8px;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  gap: 0.4rem;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  padding: 0.7rem 1.6rem;
+  border: 2px solid var(--stroke);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  text-decoration: none;
 }
 
 .btn:hover {
-  transform: translateY(-1px);
+  transform: translate(1px, 1px);
+  box-shadow: 2px 2px 0 var(--stroke);
 }
 
 .btn:active {
-  transform: translateY(0);
+  transform: translate(3px, 3px);
+  box-shadow: none;
 }
 
 .btn-primary {
-  background: var(--gradient-forge);
-  color: #0f172a;
-  box-shadow: 0 4px 16px rgba(249, 115, 22, 0.25);
-}
-
-.btn-primary:hover {
-  box-shadow: 0 6px 24px rgba(249, 115, 22, 0.35);
+  background: var(--brand-orange);
+  color: #fff;
 }
 
 .btn-secondary {
-  background: transparent;
-  color: var(--text-primary);
-  border: 1px solid var(--border-color);
+  background: var(--bg-card);
+  color: var(--text-strong);
 }
 
-.btn-secondary:hover {
-  border-color: var(--text-muted);
-}
-
-/* Install banner */
+/* ===== Hero install ===== */
 
 .hero-install {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  background: var(--bg-code);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 0.6rem 1rem;
+  background: var(--bg-card);
+  border: 2px solid var(--stroke);
+  border-radius: var(--radius-pill);
+  padding: 0.55rem 1rem;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.85rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .hero-install-prompt {
-  color: var(--accent-amber);
+  color: var(--brand-orange);
+  font-weight: 700;
   user-select: none;
 }
 
-.hero-install code {
-  color: var(--text-secondary);
-}
+.hero-install code { color: var(--text-soft); }
 
 .hero-install-copy {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-faint);
   cursor: pointer;
   padding: 2px;
-  transition: color 0.15s;
   display: inline-flex;
+  transition: color 0.15s;
 }
 
-.hero-install-copy:hover {
-  color: var(--text-primary);
-}
+.hero-install-copy:hover { color: var(--text-strong); }
 
-/* ===== Sections ===== */
+/* ===== Section headings ===== */
 
 .section-title {
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 700;
-  font-size: clamp(1.8rem, 4vw, 2.5rem);
-  letter-spacing: -0.03em;
-  line-height: 1.2;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 900;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: -0.025em;
+  line-height: 1.15;
   text-align: center;
-  margin-bottom: 1rem;
+  color: var(--text-strong);
+  margin-bottom: 0.75rem;
 }
 
 .section-subtitle {
   text-align: center;
-  color: var(--text-secondary);
+  color: var(--text-soft);
   font-size: 1.05rem;
-  max-width: 560px;
+  max-width: 520px;
   margin: 0 auto 3rem;
 }
 
 /* ===== Features ===== */
 
 .features {
-  padding: 6rem 0;
+  padding: 5rem 0;
+  background: var(--bg-mint);
+  border-top: 2px solid var(--stroke);
 }
 
-.features .section-title {
-  margin-bottom: 3.5rem;
-}
+.features .section-title { margin-bottom: 3rem; }
 
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 1.25rem;
 }
 
 .feature-card {
   background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 1.75rem;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  border: 2px solid var(--stroke);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .feature-card:hover {
-  border-color: var(--border-accent);
-  transform: translateY(-2px);
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--stroke);
 }
 
 .feature-icon {
-  font-size: 1.6rem;
-  margin-bottom: 0.75rem;
+  font-size: 1.8rem;
+  margin-bottom: 0.6rem;
 }
 
 .feature-card h3 {
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 600;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 700;
   font-size: 1.1rem;
-  margin-bottom: 0.5rem;
-  letter-spacing: -0.01em;
+  color: var(--text-strong);
+  margin-bottom: 0.4rem;
 }
 
 .feature-card p {
   font-size: 0.9rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
+  color: var(--text-soft);
+  line-height: 1.55;
 }
 
 /* ===== Demo ===== */
 
 .demo {
-  padding: 6rem 0;
+  padding: 5rem 0;
+  background: var(--bg-body);
+  border-top: 2px solid var(--stroke);
 }
 
 .demo-panels {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1.25rem;
-  margin-top: 3rem;
+  margin-top: 2.5rem;
 }
 
 .demo-panel {
   background: var(--bg-code);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
+  border: 2px solid var(--stroke);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
   overflow: hidden;
 }
 
 .demo-header {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.5rem;
   padding: 0.65rem 1rem;
-  background: rgba(0, 0, 0, 0.2);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 2px solid var(--stroke);
+  background: var(--bg-card);
 }
 
 .demo-dot {
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  opacity: 0.7;
+  border: 1.5px solid var(--stroke);
 }
 
 .demo-filename {
-  margin-left: 0.5rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.75rem;
-  color: var(--text-muted);
+  margin-left: 0.4rem;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 700;
+  font-size: 0.78rem;
+  color: var(--text-soft);
 }
 
 .demo-code {
   padding: 1.25rem;
   margin: 0;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   line-height: 1.65;
   overflow-x: auto;
   border: none;
   background: transparent;
 }
 
-.demo-code code {
-  font-family: inherit;
-}
+.demo-code code { font-family: inherit; }
 
-/* Syntax highlight classes */
-.hl-key { color: #7dd3fc; }
-.hl-str { color: #a5d6a7; }
-.hl-lit { color: #ffab91; }
-.hl-p { color: var(--text-muted); }
-.hl-comment { color: var(--text-muted); font-style: italic; }
-.hl-prompt { color: var(--accent-amber); user-select: none; }
-.hl-cmd { color: #7dd3fc; font-weight: 500; }
-.hl-ok { color: #4ade80; }
-.hl-muted { color: var(--text-muted); }
-.hl-bold { font-weight: 600; }
+/* Syntax */
+.hl-key { color: var(--hl-key); }
+.hl-str { color: var(--hl-str); }
+.hl-lit { color: var(--hl-lit); }
+.hl-p { color: var(--text-faint); }
+.hl-comment { color: var(--text-faint); font-style: italic; }
+.hl-prompt { color: var(--brand-orange); font-weight: 700; user-select: none; }
+.hl-cmd { color: var(--hl-cmd); font-weight: 600; }
+.hl-ok { color: var(--hl-ok); }
+.hl-muted { color: var(--text-faint); }
+.hl-bold { font-weight: 700; }
 
 /* ===== Install ===== */
 
 .install {
-  padding: 6rem 0;
+  padding: 5rem 0;
+  background: var(--bg-lavender);
+  border-top: 2px solid var(--stroke);
 }
 
 .install-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 1.25rem;
-  margin-top: 3rem;
+  margin-top: 2.5rem;
 }
 
 .install-card {
   position: relative;
   background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 1.75rem;
+  border: 2px solid var(--stroke);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
 }
@@ -449,35 +563,38 @@ a {
   position: absolute;
   top: -0.6rem;
   left: 1.25rem;
-  background: var(--gradient-forge);
-  color: #0f172a;
+  background: var(--brand-orange);
+  color: #fff;
+  font-family: 'Gabarito', sans-serif;
   font-size: 0.7rem;
-  font-weight: 600;
-  padding: 0.15rem 0.6rem;
-  border-radius: 4px;
+  font-weight: 700;
+  padding: 0.15rem 0.7rem;
+  border-radius: var(--radius-pill);
+  border: 2px solid var(--stroke);
   letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .install-card h3 {
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 600;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 700;
   font-size: 1.1rem;
-  margin-bottom: 0.4rem;
-  letter-spacing: -0.01em;
+  color: var(--text-strong);
+  margin-bottom: 0.35rem;
 }
 
 .install-card p {
   font-size: 0.875rem;
-  color: var(--text-secondary);
+  color: var(--text-soft);
   margin-bottom: 1rem;
   flex-grow: 1;
 }
 
 .install-code {
   background: var(--bg-code);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
+  border: 2px solid var(--stroke);
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
   margin: 0;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.78rem;
@@ -487,21 +604,92 @@ a {
 
 .install-code code {
   font-family: inherit;
-  color: var(--text-secondary);
+  color: var(--text-soft);
+}
+
+/* ===== Support ===== */
+
+.support {
+  padding: 5rem 0;
+  background: var(--bg-peach);
+  border-top: 2px solid var(--stroke);
+}
+
+.support-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 2.5rem;
+}
+
+.support-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1.25rem;
+  border: 2px solid var(--stroke);
+  border-radius: var(--radius-pill);
+  background: var(--bg-card);
+  font-family: 'Gabarito', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-strong);
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.support-link:hover {
+  transform: translate(1px, 1px);
+  box-shadow: 2px 2px 0 var(--stroke);
+}
+
+.support-link:active {
+  transform: translate(3px, 3px);
+  box-shadow: none;
+}
+
+.support-link svg {
+  color: var(--text-faint);
+  transition: color 0.15s;
+}
+
+.support-link:hover svg { color: var(--brand-orange); }
+
+.support-link--secondary {
+  background: transparent;
+  border-color: var(--stroke-soft);
+  box-shadow: none;
+  color: var(--text-soft);
+  font-size: 0.825rem;
+}
+
+.support-link--secondary:hover {
+  border-color: var(--stroke);
+  background: var(--bg-card);
+  color: var(--text-strong);
+  box-shadow: var(--shadow-sm);
 }
 
 /* ===== CTA ===== */
 
 .cta {
-  padding: 5rem 0 6rem;
+  padding: 5rem 0;
   text-align: center;
+  background: var(--bg-ink);
+  border-top: 2px solid var(--stroke);
 }
+
+.cta .section-title { color: var(--text-on-ink); }
+.cta .accent { color: var(--brand-amber); }
 
 /* ===== Footer ===== */
 
 .footer {
-  border-top: 1px solid var(--border-color);
+  background: var(--bg-ink);
   padding: 2rem 0;
+  border-top: 2px solid var(--stroke);
 }
 
 .footer-inner {
@@ -516,66 +704,78 @@ a {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 700;
+  font-family: 'Gabarito', sans-serif;
+  font-weight: 900;
   font-size: 0.95rem;
-  letter-spacing: -0.02em;
+  color: var(--text-on-ink);
 }
 
-.footer-links {
-  display: flex;
-  gap: 1.25rem;
-}
+.footer-links { display: flex; gap: 1.25rem; flex-wrap: wrap; }
 
 .footer-links a {
   font-size: 0.8rem;
-  color: var(--text-muted);
-  transition: color 0.15s;
+  font-weight: 600;
+  color: var(--text-on-ink);
+  opacity: 0.6;
+  transition: opacity 0.15s;
 }
 
-.footer-links a:hover {
-  color: var(--text-secondary);
-}
+.footer-links a:hover { opacity: 1; }
+
+.footer-sep { color: var(--text-on-ink); opacity: 0.3; user-select: none; }
 
 .footer-license {
   font-size: 0.75rem;
-  color: var(--text-muted);
+  color: var(--text-on-ink);
+  opacity: 0.4;
 }
+
+/* ===== Theme toggle ===== */
+
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--text-soft);
+  cursor: pointer;
+  padding: 0.35rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  transition: background 0.15s, color 0.15s;
+}
+
+.theme-toggle:hover {
+  background: var(--stroke);
+  color: var(--text-on-ink);
+}
+
+[data-theme="dark"] .icon-moon { display: none; }
+[data-theme="light"] .icon-sun { display: none; }
 
 /* ===== Responsive ===== */
 
 @media (max-width: 900px) {
-  .features-grid,
-  .install-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .demo-panels {
-    grid-template-columns: 1fr;
-  }
+  .demo-panels { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 640px) {
-  .nav-toggle {
-    display: flex;
-  }
+  .nav-toggle { display: flex; }
 
   .nav-links {
     position: fixed;
     top: var(--nav-height);
-    left: 0;
-    right: 0;
+    left: 0; right: 0;
     flex-direction: column;
-    background: rgba(15, 23, 42, 0.95);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    background: var(--bg-nav-mobile);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
     padding: 1.5rem;
-    gap: 1rem;
-    border-bottom: 1px solid var(--border-color);
-    transform: translateY(-100%);
+    gap: 0.5rem;
+    border-bottom: 2px solid var(--stroke);
+    transform: translateY(-110%);
     opacity: 0;
     pointer-events: none;
-    transition: transform 0.25s ease, opacity 0.25s ease;
+    transition: transform 0.25s, opacity 0.25s;
   }
 
   .nav-toggle-input:checked ~ .nav-links {
@@ -584,47 +784,16 @@ a {
     pointer-events: auto;
   }
 
-  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(1) {
-    transform: translateY(6px) rotate(45deg);
-  }
+  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(1) { transform: translateY(7.5px) rotate(45deg); }
+  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(2) { opacity: 0; }
+  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(3) { transform: translateY(-7.5px) rotate(-45deg); }
 
-  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(2) {
-    opacity: 0;
-  }
+  .nav-links a { font-size: 1rem; }
 
-  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(3) {
-    transform: translateY(-6px) rotate(-45deg);
-  }
+  .hero { padding-top: calc(var(--nav-height) + 2.5rem); padding-bottom: 3rem; }
+  .hero-subtitle br { display: none; }
+  .features, .demo, .install, .support { padding: 3.5rem 0; }
 
-  .nav-links a {
-    font-size: 1rem;
-  }
-
-  .features-grid,
-  .install-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .hero {
-    padding-top: calc(var(--nav-height) + 3rem);
-    padding-bottom: 3rem;
-  }
-
-  .hero-subtitle br {
-    display: none;
-  }
-
-  .features, .demo, .install {
-    padding: 4rem 0;
-  }
-
-  .footer-inner {
-    flex-direction: column;
-    text-align: center;
-  }
-
-  .footer-links {
-    flex-wrap: wrap;
-    justify-content: center;
-  }
+  .footer-inner { flex-direction: column; text-align: center; }
+  .footer-links { justify-content: center; }
 }

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,0 +1,630 @@
+/* Anvil promotional site — forge-themed dark design */
+
+/* ===== Reset & Custom Properties ===== */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --bg-primary: #0f172a;
+  --bg-secondary: #1e293b;
+  --bg-code: #151d2e;
+  --bg-card: #162032;
+  --text-primary: #f1f5f9;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --accent-red: #dc2626;
+  --accent-orange: #f97316;
+  --accent-amber: #fbbf24;
+  --accent-cream: #fef3c7;
+  --gradient-forge: linear-gradient(135deg, #dc2626 0%, #f97316 40%, #fbbf24 100%);
+  --gradient-forge-text: linear-gradient(135deg, #f97316 0%, #fbbf24 50%, #fef3c7 100%);
+  --border-color: rgba(148, 163, 184, 0.12);
+  --border-accent: rgba(249, 115, 22, 0.25);
+  --max-width: 1100px;
+  --nav-height: 60px;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* ===== Navigation ===== */
+
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--nav-height);
+  z-index: 100;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.nav-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 1.15rem;
+  letter-spacing: -0.02em;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.nav-links a {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: color 0.2s ease;
+}
+
+.nav-links a:hover {
+  color: var(--text-primary);
+}
+
+.nav-docs {
+  color: var(--accent-amber) !important;
+}
+
+.nav-github {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.nav-toggle-input {
+  display: none;
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text-secondary);
+  border-radius: 1px;
+  transition: transform 0.2s, opacity 0.2s;
+}
+
+/* ===== Layout ===== */
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+/* ===== Hero ===== */
+
+.hero {
+  position: relative;
+  padding: calc(var(--nav-height) + 5rem) 0 5rem;
+  text-align: center;
+  overflow: hidden;
+}
+
+.hero-glow {
+  position: absolute;
+  top: -120px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 600px;
+  height: 400px;
+  background: radial-gradient(ellipse, rgba(249, 115, 22, 0.08) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.35rem 1rem;
+  margin-bottom: 2rem;
+  letter-spacing: 0.03em;
+}
+
+.hero-logo {
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: clamp(2.4rem, 5.5vw, 3.8rem);
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+  margin-bottom: 1.25rem;
+}
+
+.gradient-text {
+  background: var(--gradient-forge-text);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto 2.5rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+}
+
+/* Buttons */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.7rem 1.5rem;
+  border-radius: 8px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn-primary {
+  background: var(--gradient-forge);
+  color: #0f172a;
+  box-shadow: 0 4px 16px rgba(249, 115, 22, 0.25);
+}
+
+.btn-primary:hover {
+  box-shadow: 0 6px 24px rgba(249, 115, 22, 0.35);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.btn-secondary:hover {
+  border-color: var(--text-muted);
+}
+
+/* Install banner */
+
+.hero-install {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-code);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 0.6rem 1rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+}
+
+.hero-install-prompt {
+  color: var(--accent-amber);
+  user-select: none;
+}
+
+.hero-install code {
+  color: var(--text-secondary);
+}
+
+.hero-install-copy {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px;
+  transition: color 0.15s;
+  display: inline-flex;
+}
+
+.hero-install-copy:hover {
+  color: var(--text-primary);
+}
+
+/* ===== Sections ===== */
+
+.section-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.section-subtitle {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  max-width: 560px;
+  margin: 0 auto 3rem;
+}
+
+/* ===== Features ===== */
+
+.features {
+  padding: 6rem 0;
+}
+
+.features .section-title {
+  margin-bottom: 3.5rem;
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.feature-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.75rem;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.feature-card:hover {
+  border-color: var(--border-accent);
+  transform: translateY(-2px);
+}
+
+.feature-icon {
+  font-size: 1.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.feature-card h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+}
+
+.feature-card p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ===== Demo ===== */
+
+.demo {
+  padding: 6rem 0;
+}
+
+.demo-panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin-top: 3rem;
+}
+
+.demo-panel {
+  background: var(--bg-code);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.demo-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.demo-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  opacity: 0.7;
+}
+
+.demo-filename {
+  margin-left: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.demo-code {
+  padding: 1.25rem;
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  border: none;
+  background: transparent;
+}
+
+.demo-code code {
+  font-family: inherit;
+}
+
+/* Syntax highlight classes */
+.hl-key { color: #7dd3fc; }
+.hl-str { color: #a5d6a7; }
+.hl-lit { color: #ffab91; }
+.hl-p { color: var(--text-muted); }
+.hl-comment { color: var(--text-muted); font-style: italic; }
+.hl-prompt { color: var(--accent-amber); user-select: none; }
+.hl-cmd { color: #7dd3fc; font-weight: 500; }
+.hl-ok { color: #4ade80; }
+.hl-muted { color: var(--text-muted); }
+.hl-bold { font-weight: 600; }
+
+/* ===== Install ===== */
+
+.install {
+  padding: 6rem 0;
+}
+
+.install-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  margin-top: 3rem;
+}
+
+.install-card {
+  position: relative;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.install-card-badge {
+  position: absolute;
+  top: -0.6rem;
+  left: 1.25rem;
+  background: var(--gradient-forge);
+  color: #0f172a;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.6rem;
+  border-radius: 4px;
+  letter-spacing: 0.02em;
+}
+
+.install-card h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
+  font-size: 1.1rem;
+  margin-bottom: 0.4rem;
+  letter-spacing: -0.01em;
+}
+
+.install-card p {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+  flex-grow: 1;
+}
+
+.install-code {
+  background: var(--bg-code);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.install-code code {
+  font-family: inherit;
+  color: var(--text-secondary);
+}
+
+/* ===== CTA ===== */
+
+.cta {
+  padding: 5rem 0 6rem;
+  text-align: center;
+}
+
+/* ===== Footer ===== */
+
+.footer {
+  border-top: 1px solid var(--border-color);
+  padding: 2rem 0;
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: -0.02em;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.footer-links a {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: color 0.15s;
+}
+
+.footer-links a:hover {
+  color: var(--text-secondary);
+}
+
+.footer-license {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* ===== Responsive ===== */
+
+@media (max-width: 900px) {
+  .features-grid,
+  .install-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .demo-panels {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-toggle {
+    display: flex;
+  }
+
+  .nav-links {
+    position: fixed;
+    top: var(--nav-height);
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    background: rgba(15, 23, 42, 0.95);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    padding: 1.5rem;
+    gap: 1rem;
+    border-bottom: 1px solid var(--border-color);
+    transform: translateY(-100%);
+    opacity: 0;
+    pointer-events: none;
+    transition: transform 0.25s ease, opacity 0.25s ease;
+  }
+
+  .nav-toggle-input:checked ~ .nav-links {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(1) {
+    transform: translateY(6px) rotate(45deg);
+  }
+
+  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .nav-toggle-input:checked ~ .nav-toggle span:nth-child(3) {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+
+  .nav-links a {
+    font-size: 1rem;
+  }
+
+  .features-grid,
+  .install-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    padding-top: calc(var(--nav-height) + 3rem);
+    padding-bottom: 3rem;
+  }
+
+  .hero-subtitle br {
+    display: none;
+  }
+
+  .features, .demo, .install {
+    padding: 4rem 0;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .footer-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -44,27 +44,27 @@
 }
 
 [data-theme="dark"] {
-  --bg-body: #1a1a2e;
-  --bg-card: #28284a;
-  --bg-mint: #1c2e1a;
-  --bg-lavender: #281c3e;
-  --bg-peach: #2e281a;
-  --bg-ink: #111122;
-  --bg-code: #222240;
-  --bg-nav: rgba(26, 26, 46, 0.92);
-  --bg-nav-mobile: rgba(26, 26, 46, 0.97);
+  --bg-body: #1e1b16;
+  --bg-card: #2a2620;
+  --bg-mint: #1e3520;
+  --bg-lavender: #2e2248;
+  --bg-peach: #352a18;
+  --bg-ink: #141210;
+  --bg-code: #24201a;
+  --bg-nav: rgba(30, 27, 22, 0.92);
+  --bg-nav-mobile: rgba(30, 27, 22, 0.97);
 
   --text-strong: #f0ece6;
-  --text-body: #c8c4be;
-  --text-soft: #908c86;
-  --text-faint: #706c66;
-  --text-on-ink: #d0ccc6;
+  --text-body: #d0cbc4;
+  --text-soft: #a8a39c;
+  --text-faint: #807b74;
+  --text-on-ink: #d8d4ce;
 
-  --stroke: #706c66;
-  --stroke-soft: #3a3a4e;
+  --stroke: #8a8580;
+  --stroke-soft: #4a4640;
 
-  --shadow: 4px 4px 0 #444;
-  --shadow-sm: 3px 3px 0 #444;
+  --shadow: 4px 4px 0 #0a0906;
+  --shadow-sm: 3px 3px 0 #0a0906;
 
   --hl-key: #7dd3fc;
   --hl-str: #a5d6a7;
@@ -200,12 +200,12 @@ a { color: inherit; text-decoration: none; }
 .nav-logo {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-family: 'Gabarito', sans-serif;
-  font-weight: 900;
-  font-size: 1.25rem;
-  color: var(--text-strong);
 }
+
+/* Logo theme-responsive fills */
+.logo-wordmark { fill: var(--text-strong); }
+.logo-cutout { fill: var(--bg-body); }
+.logo-divider { stroke: var(--stroke-soft); stroke-width: 1; }
 
 .nav-links {
   display: flex;
@@ -542,10 +542,13 @@ a { color: inherit; text-decoration: none; }
 }
 
 .install-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   margin-top: 2.5rem;
+  max-width: 540px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .install-card {
@@ -597,9 +600,52 @@ a { color: inherit; text-decoration: none; }
   padding: 0.7rem 1rem;
   margin: 0;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 0.78rem;
-  line-height: 1.5;
+  font-size: 0.75rem;
+  line-height: 1.55;
   overflow-x: auto;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+/* Shell tabs */
+
+.shell-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: -2px;
+  position: relative;
+  z-index: 1;
+}
+
+.shell-tab {
+  font-family: 'Gabarito', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.35rem 0.85rem;
+  border: 2px solid var(--stroke);
+  background: var(--bg-code);
+  color: var(--text-faint);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+  border-bottom: none;
+}
+
+.shell-tab:first-child { border-radius: 8px 0 0 0; }
+.shell-tab:last-child { border-radius: 0 8px 0 0; }
+.shell-tab:not(:first-child) { border-left: none; }
+
+.shell-tab.active {
+  background: var(--bg-card);
+  color: var(--text-strong);
+}
+
+.shell-panel { display: none; }
+.shell-panel.active { display: block; }
+
+.shell-tabs + .shell-panel,
+.shell-tabs ~ .shell-panel {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .install-code code {

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="fav-title">
+  <title id="fav-title">Anvil</title>
+  <defs>
+    <linearGradient id="forge-sm" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#dc2626"/>
+      <stop offset="35%" stop-color="#f97316"/>
+      <stop offset="70%" stop-color="#fbbf24"/>
+      <stop offset="100%" stop-color="#fef3c7"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(32, 35)">
+    <path d="M-22 25 L-4 -25 Q0 -32 4 -25 L22 25 L14 25 L8 6 L-8 6 L-14 25 Z" fill="url(#forge-sm)"/>
+    <rect x="-10" y="0" width="20" height="6" rx="1" fill="#991b1b"/>
+    <path d="M-5 6 L0 -12 L5 6 Z" fill="#0f172a"/>
+  </g>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Anvil — Forge Your Perfect Workstation</title>
   <meta name="description" content="Declarative workstation configuration management. Define your dev environment in YAML, Anvil handles the rest.">
-  <meta name="theme-color" content="#0f172a">
+  <meta name="theme-color" content="#fff8f0">
   <meta property="og:title" content="Anvil — Declarative Workstation Configuration">
   <meta property="og:description" content="Define your development environment in YAML. Anvil installs packages, copies configs, runs commands, and validates health.">
   <meta property="og:type" content="website">
@@ -13,13 +13,19 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Gabarito:wght@400;500;600;700;800;900&family=Nunito:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
+  <script>
+    (function() {
+      var m = document.cookie.match(/anvil-theme=(\w+)/);
+      var t = m ? m[1] : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+      document.documentElement.setAttribute('data-theme', t);
+    })();
+  </script>
 </head>
 <body>
 
-  <!-- Navigation -->
-  <nav class="nav" id="nav">
+  <nav class="nav">
     <div class="nav-inner">
       <a href="/" class="nav-logo" aria-label="Anvil home">
         <svg viewBox="0 0 64 64" width="28" height="28" aria-hidden="true">
@@ -32,7 +38,6 @@
           <g transform="translate(32,35)">
             <path d="M-22 25 L-4-25 Q0-32 4-25 L22 25 L14 25 L8 6 L-8 6 L-14 25Z" fill="url(#nav-forge)"/>
             <rect x="-10" y="0" width="20" height="6" rx="1" fill="#991b1b"/>
-            <path d="M-5 6 L0-12 L5 6Z" fill="#0f172a"/>
           </g>
         </svg>
         <span>Anvil</span>
@@ -45,7 +50,16 @@
         <a href="#features">Features</a>
         <a href="#demo">Demo</a>
         <a href="#install">Install</a>
+        <a href="#support">Support</a>
         <a href="/docs/" class="nav-docs">Docs</a>
+        <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
+          <svg class="icon-sun" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M8 12a4 4 0 100-8 4 4 0 000 8zM8 0a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V.75A.75.75 0 018 0zm5.657 2.343a.75.75 0 010 1.06l-1.06 1.06a.75.75 0 11-1.06-1.06l1.06-1.06a.75.75 0 011.06 0zM16 8a.75.75 0 01-.75.75h-1.5a.75.75 0 010-1.5h1.5A.75.75 0 0116 8zm-2.343 5.657a.75.75 0 01-1.06 0l-1.06-1.06a.75.75 0 111.06-1.06l1.06 1.06a.75.75 0 010 1.06zM8 16a.75.75 0 01-.75-.75v-1.5a.75.75 0 011.5 0v1.5A.75.75 0 018 16zM2.343 13.657a.75.75 0 010-1.06l1.06-1.06a.75.75 0 111.06 1.06l-1.06 1.06a.75.75 0 01-1.06 0zM0 8a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5H.75A.75.75 0 010 8zm2.343-5.657a.75.75 0 011.06 0l1.06 1.06a.75.75 0 01-1.06 1.06L2.343 3.403a.75.75 0 010-1.06z"/>
+          </svg>
+          <svg class="icon-moon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M9.598 1.591a.75.75 0 01.785-.175 7 7 0 11-8.967 8.967.75.75 0 01.961-.96 5.5 5.5 0 007.046-7.046.75.75 0 01.175-.786z"/>
+          </svg>
+        </button>
         <a href="https://github.com/kafkade/anvil" target="_blank" rel="noopener" class="nav-github">
           <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
@@ -58,37 +72,29 @@
 
   <main>
 
-    <!-- Hero -->
     <section class="hero">
-      <div class="hero-glow" aria-hidden="true"></div>
       <div class="container">
         <p class="hero-badge">Open Source · Built with Rust · MIT / Apache-2.0</p>
 
         <div class="hero-logo" aria-hidden="true">
-          <svg viewBox="0 0 200 200" width="100" height="100">
+          <svg viewBox="0 0 200 200" width="96" height="96">
             <defs>
               <linearGradient id="hero-forge" x1="0%" y1="100%" x2="0%" y2="0%">
                 <stop offset="0%" stop-color="#dc2626"/><stop offset="35%" stop-color="#f97316"/>
                 <stop offset="70%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#fef3c7"/>
               </linearGradient>
-              <radialGradient id="hero-glow-g" cx="50%" cy="30%">
-                <stop offset="0%" stop-color="#fef3c7" stop-opacity="0.25"/>
-                <stop offset="100%" stop-color="#fef3c7" stop-opacity="0"/>
-              </radialGradient>
             </defs>
-            <circle cx="100" cy="90" r="75" fill="url(#hero-glow-g)"/>
             <g transform="translate(100,105)">
               <path d="M-56 65 L-10-65 Q0-82 10-65 L56 65 L34 65 L18 16 L-18 16 L-34 65Z" fill="url(#hero-forge)"/>
               <rect x="-24" y="0" width="48" height="16" rx="2" fill="#991b1b"/>
-              <path d="M-12 16 L0-32 L12 16Z" fill="#0f172a"/>
             </g>
           </svg>
         </div>
 
-        <h1>Forge Your Perfect<br><span class="gradient-text">Workstation</span></h1>
+        <h1>Forge Your Perfect<br><span class="accent">Workstation</span></h1>
         <p class="hero-subtitle">
-          Declarative configuration management for developer workstations.<br>
-          Define your environment in YAML — Anvil installs packages, copies configs,<br>
+          Declarative configuration management for developer workstations.
+          Define your environment in YAML — Anvil installs packages, copies configs,
           runs commands, and validates health.
         </p>
 
@@ -107,60 +113,49 @@
       </div>
     </section>
 
-    <!-- Features -->
     <section class="features" id="features">
       <div class="container">
-        <h2 class="section-title">Everything you need to<br><span class="gradient-text">manage your workstation</span></h2>
+        <h2 class="section-title">Everything you need to<br><span class="accent">manage your workstation</span></h2>
         <div class="features-grid">
-
           <div class="feature-card">
             <div class="feature-icon">📦</div>
             <h3>Package Management</h3>
             <p>Install software via winget with version pinning and custom overrides. Homebrew and APT support on the roadmap.</p>
           </div>
-
           <div class="feature-card">
             <div class="feature-icon">📁</div>
             <h3>File Synchronization</h3>
             <p>Deploy configuration files and dotfiles with automatic backup, hash verification, and template rendering.</p>
           </div>
-
           <div class="feature-card">
             <div class="feature-icon">🧬</div>
             <h3>Workload Inheritance</h3>
             <p>Compose configurations using DRY principles. Extend base workloads and override only what differs.</p>
           </div>
-
           <div class="feature-card">
             <div class="feature-icon">✅</div>
             <h3>Health Assertions</h3>
             <p>Declarative predicates validate your system state — check commands, files, directories, environment, and registry.</p>
           </div>
-
           <div class="feature-card">
             <div class="feature-icon">⌨️</div>
             <h3>Command Execution</h3>
             <p>Run pre- and post-install commands with conditions, timeouts, elevation control, and error handling.</p>
           </div>
-
           <div class="feature-card">
             <div class="feature-icon">📊</div>
             <h3>Multiple Formats</h3>
             <p>Output results as formatted tables, JSON, YAML, or HTML reports. Pipe into other tools or share with your team.</p>
           </div>
-
         </div>
       </div>
     </section>
 
-    <!-- Demo -->
     <section class="demo" id="demo">
       <div class="container">
-        <h2 class="section-title">Define Once,<br><span class="gradient-text">Deploy Everywhere</span></h2>
+        <h2 class="section-title">Define Once,<br><span class="accent">Deploy Everywhere</span></h2>
         <p class="section-subtitle">Write a workload once. Anvil handles installation, configuration, and validation.</p>
-
         <div class="demo-panels">
-
           <div class="demo-panel">
             <div class="demo-header">
               <span class="demo-dot" style="background:#ef4444"></span>
@@ -191,7 +186,6 @@
       <span class="hl-key">type</span><span class="hl-p">:</span> <span class="hl-str">command_exists</span>
       <span class="hl-key">command</span><span class="hl-p">:</span> <span class="hl-str">cargo</span></code></pre>
           </div>
-
           <div class="demo-panel">
             <div class="demo-header">
               <span class="demo-dot" style="background:#ef4444"></span>
@@ -216,25 +210,20 @@
 
   <span class="hl-ok">✓</span> <span class="hl-bold">Workload installed successfully</span></code></pre>
           </div>
-
         </div>
       </div>
     </section>
 
-    <!-- Install -->
     <section class="install" id="install">
       <div class="container">
-        <h2 class="section-title">Install in<br><span class="gradient-text">Seconds</span></h2>
-
+        <h2 class="section-title">Install in<br><span class="accent">Seconds</span></h2>
         <div class="install-grid">
-
           <div class="install-card">
             <div class="install-card-badge">Recommended</div>
             <h3>From crates.io</h3>
             <p>Install with Cargo — Rust 1.75+ required.</p>
             <pre class="install-code"><code>cargo install anvil-cli</code></pre>
           </div>
-
           <div class="install-card">
             <h3>Pre-built Binary</h3>
             <p>Download from GitHub Releases for your platform.</p>
@@ -245,7 +234,6 @@ releases/latest/download/
 anvil-windows-x64.zip"</span> `
   -OutFile anvil.zip</code></pre>
           </div>
-
           <div class="install-card">
             <h3>From Source</h3>
             <p>Clone and build the latest from main.</p>
@@ -254,15 +242,40 @@ anvil-windows-x64.zip"</span> `
 <span class="hl-cmd">cd</span> anvil
 cargo build --release</code></pre>
           </div>
-
         </div>
       </div>
     </section>
 
-    <!-- CTA -->
+    <section class="support" id="support">
+      <div class="container">
+        <h2 class="section-title">Support kafkade's<br><span class="accent">open-source work</span></h2>
+        <p class="section-subtitle">Anvil and all kafkade projects are free and open source. Your support funds development, infrastructure, and documentation.</p>
+        <div class="support-links">
+          <a href="https://github.com/sponsors/kafkade" class="support-link support-link--primary" target="_blank" rel="noopener">
+            <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true">
+              <path d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25z"/>
+            </svg>
+            GitHub Sponsors
+          </a>
+          <a href="https://ko-fi.com/kafkade" class="support-link support-link--primary" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+              <path d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.053 2.764 2.053 2.764s5.312.178 7.789.178c2.476 0 4.46-.448 5.666-1.725 1.205-1.276 1.664-2.964 1.664-2.964s2.025.088 3.195-.664c1.172-.752 1.981-1.88 2.27-3.278.29-1.397.13-2.338-1.778-2.338zm-5.46 5.136c-.263.547-.715.934-1.266 1.088-.551.154-1.189.08-1.734-.227-1.467-.823-.236-3.236.985-3.236.795 0 1.38.346 1.727.885.348.539.548 1.144.288 1.49z"/>
+            </svg>
+            Ko-fi
+          </a>
+          <a href="https://buymeacoffee.com/kafkade" class="support-link support-link--secondary" target="_blank" rel="noopener">
+            Buy Me a Coffee
+          </a>
+          <a href="https://patreon.com/kafkade" class="support-link support-link--secondary" target="_blank" rel="noopener">
+            Patreon
+          </a>
+        </div>
+      </div>
+    </section>
+
     <section class="cta">
       <div class="container">
-        <h2 class="section-title">Ready to forge<br><span class="gradient-text">your workstation?</span></h2>
+        <h2 class="section-title">Ready to forge<br><span class="accent">your workstation?</span></h2>
         <div class="hero-actions">
           <a href="/docs/user-guide.html" class="btn btn-primary">Get Started →</a>
           <a href="https://github.com/kafkade/anvil" target="_blank" rel="noopener" class="btn btn-secondary">Star on GitHub</a>
@@ -272,7 +285,6 @@ cargo build --release</code></pre>
 
   </main>
 
-  <!-- Footer -->
   <footer class="footer">
     <div class="container">
       <div class="footer-inner">
@@ -287,7 +299,6 @@ cargo build --release</code></pre>
             <g transform="translate(32,35)">
               <path d="M-22 25 L-4-25 Q0-32 4-25 L22 25 L14 25 L8 6 L-8 6 L-14 25Z" fill="url(#ft-forge)"/>
               <rect x="-10" y="0" width="20" height="6" rx="1" fill="#991b1b"/>
-              <path d="M-5 6 L0-12 L5 6Z" fill="#0f172a"/>
             </g>
           </svg>
           <span>Anvil</span>
@@ -298,11 +309,118 @@ cargo build --release</code></pre>
           <a href="/docs/changelog.html">Changelog</a>
           <a href="https://github.com/kafkade/anvil" target="_blank" rel="noopener">GitHub</a>
           <a href="https://crates.io/crates/anvil-cli" target="_blank" rel="noopener">crates.io</a>
+          <span class="footer-sep" aria-hidden="true">·</span>
+          <a href="https://github.com/sponsors/kafkade" target="_blank" rel="noopener">Sponsor</a>
+          <a href="https://ko-fi.com/kafkade" target="_blank" rel="noopener">Ko-fi</a>
         </div>
         <p class="footer-license">MIT OR Apache-2.0 · Made with ❤️ for developers</p>
       </div>
     </div>
   </footer>
+
+  <script>
+    // Theme toggle with cookie persistence
+    (function() {
+      var toggle = document.getElementById('theme-toggle');
+      toggle.addEventListener('click', function() {
+        var current = document.documentElement.getAttribute('data-theme');
+        if (current === 'matrix') return; // don't toggle during matrix mode
+        var next = current === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        document.cookie = 'anvil-theme=' + next + ';path=/;max-age=31536000;SameSite=Lax';
+      });
+
+      window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', function(e) {
+        if (!document.cookie.match(/anvil-theme=/)) {
+          document.documentElement.setAttribute('data-theme', e.matches ? 'light' : 'dark');
+        }
+      });
+    })();
+
+    // Konami Code → Matrix theme easter egg
+    (function() {
+      var SEQ = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
+      var pos = 0;
+      var active = false;
+
+      document.addEventListener('keydown', function(e) {
+        if (active) return;
+        if (e.key === SEQ[pos]) { pos++; if (pos === SEQ.length) { pos = 0; enterMatrix(); } }
+        else { pos = 0; }
+      });
+
+      function enterMatrix() {
+        active = true;
+        var prevTheme = document.documentElement.getAttribute('data-theme');
+
+        // Background canvas (behind content, not covering it)
+        var canvas = document.createElement('canvas');
+        canvas.id = 'matrix-canvas';
+        document.body.prepend(canvas);
+
+        // Dismiss button
+        var btn = document.createElement('button');
+        btn.className = 'matrix-dismiss';
+        btn.textContent = '[ ESC ] Exit Matrix';
+        document.body.appendChild(btn);
+
+        // Apply matrix theme
+        document.documentElement.setAttribute('data-theme', 'matrix');
+
+        var ctx = canvas.getContext('2d');
+        function resize() { canvas.width = window.innerWidth; canvas.height = window.innerHeight; }
+        resize();
+        window.addEventListener('resize', resize);
+
+        var chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ<>{}[]|/\\=+-*&^%$#@!';
+        var fontSize = 14;
+        var columns = Math.floor(canvas.width / fontSize);
+        var drops = [];
+        for (var i = 0; i < columns; i++) drops[i] = Math.random() * -40;
+
+        ctx.fillStyle = '#000800';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        var interval = setInterval(function() {
+          ctx.fillStyle = 'rgba(0, 6, 0, 0.06)';
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+          ctx.font = fontSize + 'px JetBrains Mono, Consolas, monospace';
+
+          for (var i = 0; i < drops.length; i++) {
+            var ch = chars[Math.floor(Math.random() * chars.length)];
+            ctx.fillStyle = (Math.random() > 0.95) ? '#aaffcc' : '#00ff41';
+            ctx.fillText(ch, i * fontSize, drops[i] * fontSize);
+            if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
+            drops[i] += 0.35 + Math.random() * 0.4;
+          }
+        }, 33);
+
+        var timer;
+
+        function dismiss() {
+          clearInterval(interval);
+          clearTimeout(timer);
+          window.removeEventListener('resize', resize);
+          document.removeEventListener('keydown', onKey);
+          canvas.remove();
+          btn.remove();
+          // Restore previous theme
+          var cookie = (document.cookie.match(/anvil-theme=(\w+)/) || [])[1];
+          document.documentElement.setAttribute('data-theme', cookie || prevTheme);
+          active = false;
+        }
+
+        function onKey(e) { if (e.key === 'Escape') dismiss(); }
+
+        setTimeout(function() {
+          btn.addEventListener('click', dismiss, { once: true });
+          document.addEventListener('keydown', onKey);
+        }, 400);
+
+        timer = setTimeout(dismiss, 60000);
+      }
+    })();
+  </script>
 
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anvil — Forge Your Perfect Workstation</title>
+  <meta name="description" content="Declarative workstation configuration management. Define your dev environment in YAML, Anvil handles the rest.">
+  <meta name="theme-color" content="#0f172a">
+  <meta property="og:title" content="Anvil — Declarative Workstation Configuration">
+  <meta property="og:description" content="Define your development environment in YAML. Anvil installs packages, copies configs, runs commands, and validates health.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://anvil.kafkade.com">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav" id="nav">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo" aria-label="Anvil home">
+        <svg viewBox="0 0 64 64" width="28" height="28" aria-hidden="true">
+          <defs>
+            <linearGradient id="nav-forge" x1="0%" y1="100%" x2="0%" y2="0%">
+              <stop offset="0%" stop-color="#dc2626"/><stop offset="35%" stop-color="#f97316"/>
+              <stop offset="70%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#fef3c7"/>
+            </linearGradient>
+          </defs>
+          <g transform="translate(32,35)">
+            <path d="M-22 25 L-4-25 Q0-32 4-25 L22 25 L14 25 L8 6 L-8 6 L-14 25Z" fill="url(#nav-forge)"/>
+            <rect x="-10" y="0" width="20" height="6" rx="1" fill="#991b1b"/>
+            <path d="M-5 6 L0-12 L5 6Z" fill="#0f172a"/>
+          </g>
+        </svg>
+        <span>Anvil</span>
+      </a>
+      <input type="checkbox" id="nav-toggle" class="nav-toggle-input" aria-label="Toggle navigation">
+      <label for="nav-toggle" class="nav-toggle" aria-label="Menu">
+        <span></span><span></span><span></span>
+      </label>
+      <div class="nav-links">
+        <a href="#features">Features</a>
+        <a href="#demo">Demo</a>
+        <a href="#install">Install</a>
+        <a href="/docs/" class="nav-docs">Docs</a>
+        <a href="https://github.com/kafkade/anvil" target="_blank" rel="noopener" class="nav-github">
+          <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+          </svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+
+    <!-- Hero -->
+    <section class="hero">
+      <div class="hero-glow" aria-hidden="true"></div>
+      <div class="container">
+        <p class="hero-badge">Open Source · Built with Rust · MIT / Apache-2.0</p>
+
+        <div class="hero-logo" aria-hidden="true">
+          <svg viewBox="0 0 200 200" width="100" height="100">
+            <defs>
+              <linearGradient id="hero-forge" x1="0%" y1="100%" x2="0%" y2="0%">
+                <stop offset="0%" stop-color="#dc2626"/><stop offset="35%" stop-color="#f97316"/>
+                <stop offset="70%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#fef3c7"/>
+              </linearGradient>
+              <radialGradient id="hero-glow-g" cx="50%" cy="30%">
+                <stop offset="0%" stop-color="#fef3c7" stop-opacity="0.25"/>
+                <stop offset="100%" stop-color="#fef3c7" stop-opacity="0"/>
+              </radialGradient>
+            </defs>
+            <circle cx="100" cy="90" r="75" fill="url(#hero-glow-g)"/>
+            <g transform="translate(100,105)">
+              <path d="M-56 65 L-10-65 Q0-82 10-65 L56 65 L34 65 L18 16 L-18 16 L-34 65Z" fill="url(#hero-forge)"/>
+              <rect x="-24" y="0" width="48" height="16" rx="2" fill="#991b1b"/>
+              <path d="M-12 16 L0-32 L12 16Z" fill="#0f172a"/>
+            </g>
+          </svg>
+        </div>
+
+        <h1>Forge Your Perfect<br><span class="gradient-text">Workstation</span></h1>
+        <p class="hero-subtitle">
+          Declarative configuration management for developer workstations.<br>
+          Define your environment in YAML — Anvil installs packages, copies configs,<br>
+          runs commands, and validates health.
+        </p>
+
+        <div class="hero-actions">
+          <a href="/docs/user-guide.html" class="btn btn-primary">Get Started →</a>
+          <a href="/docs/" class="btn btn-secondary">Documentation</a>
+        </div>
+
+        <div class="hero-install">
+          <span class="hero-install-prompt">$</span>
+          <code>cargo install anvil-cli</code>
+          <button class="hero-install-copy" aria-label="Copy install command" onclick="navigator.clipboard.writeText('cargo install anvil-cli')">
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25zM5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25z"/></svg>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="features" id="features">
+      <div class="container">
+        <h2 class="section-title">Everything you need to<br><span class="gradient-text">manage your workstation</span></h2>
+        <div class="features-grid">
+
+          <div class="feature-card">
+            <div class="feature-icon">📦</div>
+            <h3>Package Management</h3>
+            <p>Install software via winget with version pinning and custom overrides. Homebrew and APT support on the roadmap.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon">📁</div>
+            <h3>File Synchronization</h3>
+            <p>Deploy configuration files and dotfiles with automatic backup, hash verification, and template rendering.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon">🧬</div>
+            <h3>Workload Inheritance</h3>
+            <p>Compose configurations using DRY principles. Extend base workloads and override only what differs.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon">✅</div>
+            <h3>Health Assertions</h3>
+            <p>Declarative predicates validate your system state — check commands, files, directories, environment, and registry.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon">⌨️</div>
+            <h3>Command Execution</h3>
+            <p>Run pre- and post-install commands with conditions, timeouts, elevation control, and error handling.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon">📊</div>
+            <h3>Multiple Formats</h3>
+            <p>Output results as formatted tables, JSON, YAML, or HTML reports. Pipe into other tools or share with your team.</p>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- Demo -->
+    <section class="demo" id="demo">
+      <div class="container">
+        <h2 class="section-title">Define Once,<br><span class="gradient-text">Deploy Everywhere</span></h2>
+        <p class="section-subtitle">Write a workload once. Anvil handles installation, configuration, and validation.</p>
+
+        <div class="demo-panels">
+
+          <div class="demo-panel">
+            <div class="demo-header">
+              <span class="demo-dot" style="background:#ef4444"></span>
+              <span class="demo-dot" style="background:#f59e0b"></span>
+              <span class="demo-dot" style="background:#22c55e"></span>
+              <span class="demo-filename">workload.yaml</span>
+            </div>
+            <pre class="demo-code"><code><span class="hl-key">name</span><span class="hl-p">:</span> <span class="hl-str">rust-developer</span>
+<span class="hl-key">version</span><span class="hl-p">:</span> <span class="hl-str">"1.0.0"</span>
+<span class="hl-key">description</span><span class="hl-p">:</span> <span class="hl-str">"Complete Rust development environment"</span>
+
+<span class="hl-key">extends</span><span class="hl-p">:</span>
+  <span class="hl-p">-</span> <span class="hl-str">essentials</span>
+
+<span class="hl-key">packages</span><span class="hl-p">:</span>
+  <span class="hl-key">winget</span><span class="hl-p">:</span>
+    <span class="hl-p">-</span> <span class="hl-key">id</span><span class="hl-p">:</span> <span class="hl-str">Rustlang.Rustup</span>
+    <span class="hl-p">-</span> <span class="hl-key">id</span><span class="hl-p">:</span> <span class="hl-str">LLVM.LLVM</span>
+
+<span class="hl-key">files</span><span class="hl-p">:</span>
+  <span class="hl-p">-</span> <span class="hl-key">source</span><span class="hl-p">:</span> <span class="hl-str">config.toml</span>
+    <span class="hl-key">destination</span><span class="hl-p">:</span> <span class="hl-str">"~/.cargo/config.toml"</span>
+    <span class="hl-key">backup</span><span class="hl-p">:</span> <span class="hl-lit">true</span>
+
+<span class="hl-key">assertions</span><span class="hl-p">:</span>
+  <span class="hl-p">-</span> <span class="hl-key">name</span><span class="hl-p">:</span> <span class="hl-str">"Cargo is available"</span>
+    <span class="hl-key">check</span><span class="hl-p">:</span>
+      <span class="hl-key">type</span><span class="hl-p">:</span> <span class="hl-str">command_exists</span>
+      <span class="hl-key">command</span><span class="hl-p">:</span> <span class="hl-str">cargo</span></code></pre>
+          </div>
+
+          <div class="demo-panel">
+            <div class="demo-header">
+              <span class="demo-dot" style="background:#ef4444"></span>
+              <span class="demo-dot" style="background:#f59e0b"></span>
+              <span class="demo-dot" style="background:#22c55e"></span>
+              <span class="demo-filename">Terminal</span>
+            </div>
+            <pre class="demo-code"><code><span class="hl-prompt">$</span> <span class="hl-cmd">anvil install</span> <span class="hl-str">rust-developer</span>
+
+  <span class="hl-muted">▸ Resolving workload inheritance...</span>
+  <span class="hl-ok">✓</span> Merged: essentials → rust-developer
+
+  <span class="hl-muted">▸ Installing packages...</span>
+  <span class="hl-ok">✓</span> Rustlang.Rustup
+  <span class="hl-ok">✓</span> LLVM.LLVM
+
+  <span class="hl-muted">▸ Deploying configuration files...</span>
+  <span class="hl-ok">✓</span> ~/.cargo/config.toml
+
+  <span class="hl-muted">▸ Running assertions...</span>
+  <span class="hl-ok">✓</span> Cargo is available
+
+  <span class="hl-ok">✓</span> <span class="hl-bold">Workload installed successfully</span></code></pre>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- Install -->
+    <section class="install" id="install">
+      <div class="container">
+        <h2 class="section-title">Install in<br><span class="gradient-text">Seconds</span></h2>
+
+        <div class="install-grid">
+
+          <div class="install-card">
+            <div class="install-card-badge">Recommended</div>
+            <h3>From crates.io</h3>
+            <p>Install with Cargo — Rust 1.75+ required.</p>
+            <pre class="install-code"><code>cargo install anvil-cli</code></pre>
+          </div>
+
+          <div class="install-card">
+            <h3>Pre-built Binary</h3>
+            <p>Download from GitHub Releases for your platform.</p>
+            <pre class="install-code"><code><span class="hl-comment"># Windows (PowerShell)</span>
+Invoke-WebRequest -Uri <span class="hl-str">\
+  "https://github.com/kafkade/anvil/
+releases/latest/download/
+anvil-windows-x64.zip"</span> `
+  -OutFile anvil.zip</code></pre>
+          </div>
+
+          <div class="install-card">
+            <h3>From Source</h3>
+            <p>Clone and build the latest from main.</p>
+            <pre class="install-code"><code>git clone https://github.com/
+  kafkade/anvil.git
+<span class="hl-cmd">cd</span> anvil
+cargo build --release</code></pre>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="cta">
+      <div class="container">
+        <h2 class="section-title">Ready to forge<br><span class="gradient-text">your workstation?</span></h2>
+        <div class="hero-actions">
+          <a href="/docs/user-guide.html" class="btn btn-primary">Get Started →</a>
+          <a href="https://github.com/kafkade/anvil" target="_blank" rel="noopener" class="btn btn-secondary">Star on GitHub</a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-brand">
+          <svg viewBox="0 0 64 64" width="20" height="20" aria-hidden="true">
+            <defs>
+              <linearGradient id="ft-forge" x1="0%" y1="100%" x2="0%" y2="0%">
+                <stop offset="0%" stop-color="#dc2626"/><stop offset="35%" stop-color="#f97316"/>
+                <stop offset="70%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#fef3c7"/>
+              </linearGradient>
+            </defs>
+            <g transform="translate(32,35)">
+              <path d="M-22 25 L-4-25 Q0-32 4-25 L22 25 L14 25 L8 6 L-8 6 L-14 25Z" fill="url(#ft-forge)"/>
+              <rect x="-10" y="0" width="20" height="6" rx="1" fill="#991b1b"/>
+              <path d="M-5 6 L0-12 L5 6Z" fill="#0f172a"/>
+            </g>
+          </svg>
+          <span>Anvil</span>
+        </div>
+        <div class="footer-links">
+          <a href="/docs/">Docs</a>
+          <a href="/docs/user-guide.html">User Guide</a>
+          <a href="/docs/changelog.html">Changelog</a>
+          <a href="https://github.com/kafkade/anvil" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://crates.io/crates/anvil-cli" target="_blank" rel="noopener">crates.io</a>
+        </div>
+        <p class="footer-license">MIT OR Apache-2.0 · Made with ❤️ for developers</p>
+      </div>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -28,19 +28,27 @@
   <nav class="nav">
     <div class="nav-inner">
       <a href="/" class="nav-logo" aria-label="Anvil home">
-        <svg viewBox="0 0 64 64" width="28" height="28" aria-hidden="true">
+        <svg viewBox="0 0 360 100" height="30" role="img" aria-labelledby="nav-logo-title">
+          <title id="nav-logo-title">Anvil</title>
           <defs>
             <linearGradient id="nav-forge" x1="0%" y1="100%" x2="0%" y2="0%">
               <stop offset="0%" stop-color="#dc2626"/><stop offset="35%" stop-color="#f97316"/>
               <stop offset="70%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#fef3c7"/>
             </linearGradient>
+            <radialGradient id="glow-h" cx="50%" cy="30%">
+              <stop offset="0%" stop-color="#fef3c7" stop-opacity="0.15"/>
+              <stop offset="100%" stop-color="#fef3c7" stop-opacity="0"/>
+            </radialGradient>
           </defs>
-          <g transform="translate(32,35)">
-            <path d="M-22 25 L-4-25 Q0-32 4-25 L22 25 L14 25 L8 6 L-8 6 L-14 25Z" fill="url(#nav-forge)"/>
-            <rect x="-10" y="0" width="20" height="6" rx="1" fill="#991b1b"/>
+          <circle cx="50" cy="48" r="42" fill="url(#glow-h)"/>
+          <g transform="translate(50,52)">
+            <path d="M-32 38 L-6-38 Q0-48 6-38 L32 38 L20 38 L10 8 L-10 8 L-20 38Z" fill="url(#nav-forge)"/>
+            <rect x="-14" y="0" width="28" height="10" rx="1.5" fill="#991b1b"/>
+            <path class="logo-cutout" d="M-7 8 L0-18 L7 8Z"/>
           </g>
+          <line x1="100" y1="24" x2="100" y2="76" class="logo-divider"/>
+          <text class="logo-wordmark" x="118" y="62" font-family="'Helvetica Neue', Arial, sans-serif" font-size="36" font-weight="700" letter-spacing="6">ANVIL</text>
         </svg>
-        <span>Anvil</span>
       </a>
       <input type="checkbox" id="nav-toggle" class="nav-toggle-input" aria-label="Toggle navigation">
       <label for="nav-toggle" class="nav-toggle" aria-label="Menu">
@@ -77,17 +85,24 @@
         <p class="hero-badge">Open Source · Built with Rust · MIT / Apache-2.0</p>
 
         <div class="hero-logo" aria-hidden="true">
-          <svg viewBox="0 0 200 200" width="96" height="96">
+          <svg viewBox="0 0 200 200" width="148" height="148">
             <defs>
               <linearGradient id="hero-forge" x1="0%" y1="100%" x2="0%" y2="0%">
                 <stop offset="0%" stop-color="#dc2626"/><stop offset="35%" stop-color="#f97316"/>
                 <stop offset="70%" stop-color="#fbbf24"/><stop offset="100%" stop-color="#fef3c7"/>
               </linearGradient>
+              <radialGradient id="glow-v" cx="50%" cy="25%">
+                <stop offset="0%" stop-color="#fef3c7" stop-opacity="0.2"/>
+                <stop offset="100%" stop-color="#fef3c7" stop-opacity="0"/>
+              </radialGradient>
             </defs>
-            <g transform="translate(100,105)">
-              <path d="M-56 65 L-10-65 Q0-82 10-65 L56 65 L34 65 L18 16 L-18 16 L-34 65Z" fill="url(#hero-forge)"/>
-              <rect x="-24" y="0" width="48" height="16" rx="2" fill="#991b1b"/>
+            <circle cx="100" cy="72" r="60" fill="url(#glow-v)"/>
+            <g transform="translate(100,82)">
+              <path d="M-44 52 L-8-52 Q0-66 8-52 L44 52 L28 52 L14 12 L-14 12 L-28 52Z" fill="url(#hero-forge)"/>
+              <rect x="-20" y="0" width="40" height="13" rx="2" fill="#991b1b"/>
+              <path class="logo-cutout" d="M-9 12 L0-26 L9 12Z"/>
             </g>
+            <text class="logo-wordmark" x="100" y="162" text-anchor="middle" font-family="'Helvetica Neue', Arial, sans-serif" font-size="18" font-weight="600" letter-spacing="10">ANVIL</text>
           </svg>
         </div>
 
@@ -218,30 +233,46 @@
       <div class="container">
         <h2 class="section-title">Install in<br><span class="accent">Seconds</span></h2>
         <div class="install-grid">
+
           <div class="install-card">
             <div class="install-card-badge">Recommended</div>
             <h3>From crates.io</h3>
-            <p>Install with Cargo — Rust 1.75+ required.</p>
+            <p>Install with Cargo — Rust 1.75+ required. Works on all platforms.</p>
             <pre class="install-code"><code>cargo install anvil-cli</code></pre>
           </div>
+
           <div class="install-card">
             <h3>Pre-built Binary</h3>
             <p>Download from GitHub Releases for your platform.</p>
-            <pre class="install-code"><code><span class="hl-comment"># Windows (PowerShell)</span>
-Invoke-WebRequest -Uri <span class="hl-str">\
-  "https://github.com/kafkade/anvil/
-releases/latest/download/
-anvil-windows-x64.zip"</span> `
-  -OutFile anvil.zip</code></pre>
+            <div class="shell-tabs" data-shell-group="binary">
+              <button class="shell-tab active" data-shell="powershell">PowerShell</button>
+              <button class="shell-tab" data-shell="bash">Bash / Zsh</button>
+            </div>
+            <pre class="install-code shell-panel active" data-shell="powershell"><code><span class="hl-comment"># github.com/kafkade/anvil/releases</span>
+Expand-Archive anvil.zip C:\Tools\anvil
+$env:PATH += <span class="hl-str">";C:\Tools\anvil"</span></code></pre>
+            <pre class="install-code shell-panel" data-shell="bash"><code><span class="hl-comment"># github.com/kafkade/anvil/releases</span>
+tar xzf anvil-*-linux-gnu.tar.gz
+sudo mv anvil /usr/local/bin/</code></pre>
           </div>
+
           <div class="install-card">
             <h3>From Source</h3>
             <p>Clone and build the latest from main.</p>
-            <pre class="install-code"><code>git clone https://github.com/
-  kafkade/anvil.git
+            <div class="shell-tabs" data-shell-group="source">
+              <button class="shell-tab active" data-shell="powershell">PowerShell</button>
+              <button class="shell-tab" data-shell="bash">Bash / Zsh</button>
+            </div>
+            <pre class="install-code shell-panel active" data-shell="powershell"><code>git clone https://github.com/kafkade/anvil
 <span class="hl-cmd">cd</span> anvil
-cargo build --release</code></pre>
+cargo build --release
+<span class="hl-comment"># Binary: target\release\anvil.exe</span></code></pre>
+            <pre class="install-code shell-panel" data-shell="bash"><code>git clone https://github.com/kafkade/anvil
+<span class="hl-cmd">cd</span> anvil
+cargo build --release
+<span class="hl-comment"># Binary: target/release/anvil</span></code></pre>
           </div>
+
         </div>
       </div>
     </section>
@@ -319,6 +350,19 @@ cargo build --release</code></pre>
   </footer>
 
   <script>
+    // Shell tab switcher
+    document.querySelectorAll('.shell-tabs').forEach(function(tabs) {
+      tabs.addEventListener('click', function(e) {
+        var btn = e.target.closest('.shell-tab');
+        if (!btn) return;
+        var shell = btn.dataset.shell;
+        var card = tabs.closest('.install-card');
+
+        card.querySelectorAll('.shell-tab').forEach(function(t) { t.classList.toggle('active', t.dataset.shell === shell); });
+        card.querySelectorAll('.shell-panel').forEach(function(p) { p.classList.toggle('active', p.dataset.shell === shell); });
+      });
+    });
+
     // Theme toggle with cookie persistence
     (function() {
       var toggle = document.getElementById('theme-toggle');

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -201,13 +201,13 @@ impl SchemaValidator {
                 if scripts.get("health_check").is_some() {
                     result.add_error(
                         "scripts.health_check",
-                        "scripts.health_check has been removed in v1.0. Use declarative assertions instead. See https://anvil.kafkade.com/workload-authoring.html",
+                        "scripts.health_check has been removed in v1.0. Use declarative assertions instead. See https://anvil.kafkade.com/docs/workload-authoring.html",
                     );
                 }
                 if scripts.get("pre_install").is_some() || scripts.get("post_install").is_some() {
                     result.add_error(
                         "scripts",
-                        "scripts.pre_install and scripts.post_install have been removed in v1.0. Use the commands block instead. See https://anvil.kafkade.com/workload-authoring.html",
+                        "scripts.pre_install and scripts.post_install have been removed in v1.0. Use the commands block instead. See https://anvil.kafkade.com/docs/workload-authoring.html",
                     );
                 }
             }


### PR DESCRIPTION
## Description

Adds a promotional landing page for Anvil at nvil.kafkade.com, separate from the mdbook documentation which moves to anvil.kafkade.com/docs/. Both are built by a single self-contained script and deployed via Cloudflare Pages direct Git integration (no API tokens required).

### What's included

- **Promotional website** (site/): Dark-themed landing page with forge-gradient branding, featuring a hero section, feature grid, interactive code demo, and installation options. Responsive design with mobile hamburger nav.
- **Build script** (scripts/build-site.sh): Self-contained script that auto-installs mdbook if missing, copies the static site, builds mdbook docs, and combines into dist/.
- **URL migration**: book.toml updated so docs generate correct links under /docs/. Redirect rules (_redirects) map old root URLs to the new subpath. All hardcoded doc URLs updated across README, schema error messages, etc.
- **CI validation**: The existing Documentation job in CI now builds the full site to catch breakages before merge.

## Related Issues

<!-- No related issues -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)