### PR TITLE
chore: rename crate to anvil-dev and prepare for crates.io publishing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,6 +89,10 @@ Create `examples/<name>/workload.yaml` (plus optional `files/` and `scripts/`). 
 
 **Never execute Git commands that modify history or submit code.** This includes `git commit`, `git push`, `git rebase`, `git merge`, `git reset`, `git cherry-pick`, `git revert`, and `git tag`. Read-only commands like `git status`, `git diff`, `git log`, and `git branch` are fine. The maintainer must always review and commit changes themselves.
 
+## Cargo Publish Policy
+
+**Never execute `cargo publish`.** This includes `cargo publish`, `cargo publish --dry-run`, and any other command that interacts with the crates.io registry. Publishing is a privileged, irreversible operation that the maintainer must perform manually. You may run `cargo package --list` to inspect what would be included, but never publish or attempt to publish.
+
 ## Key References
 
 - `docs/src/specification.md` — Project spec, workload schema, and roadmap (v0.4–v1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Animated forge lettermark banner on `anvil --version` with molten gradient
 
 ### Changed
-- Crate renamed to `anvil-cli` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-cli`)
+- Crate renamed to `anvil-dev` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-dev`)
 - Tracing/log output now writes to stderr instead of stdout, preventing pollution of structured output (JSON, YAML)
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -509,7 +509,7 @@ After the workflow completes:
 gh release view vx.y.z
 
 # Verify crates.io publication
-cargo install anvil-cli  # should install the new version
+cargo install anvil-dev  # should install the new version
 anvil --version          # should show the new version
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing to Anvil! This document provides gui
 - [Testing](#testing)
 - [Submitting Changes](#submitting-changes)
 - [Creating Workloads](#creating-workloads)
+- [Releasing a New Version](#releasing-a-new-version)
 - [License](#license)
 
 ---
@@ -431,6 +432,99 @@ assertions:
     check:
       type: command_exists
       command: my-tool
+```
+
+---
+
+## Releasing a New Version
+
+Releases are automated — a single script bumps the version, stamps the changelog, commits, tags, and optionally pushes. CI then builds cross-platform binaries, creates a GitHub Release, and publishes to crates.io.
+
+### Prerequisites
+
+- You must be on the `main` branch with a clean working tree
+- `CHANGELOG.md` must have entries under `## [Unreleased]`
+- All tests and clippy checks must pass (the script verifies this)
+- The `CARGO_REGISTRY_TOKEN` secret must be configured in the repo (one-time setup)
+
+### Release Process
+
+**1. Run the release script**
+
+```powershell
+# Patch release (0.6.0 → 0.6.1)
+./scripts/release.ps1 patch
+
+# Minor release (0.6.0 → 0.7.0)
+./scripts/release.ps1 minor
+
+# Major release (0.6.0 → 1.0.0)
+./scripts/release.ps1 major
+
+# Preview what would happen without making changes
+./scripts/release.ps1 patch -DryRun
+
+# Release and push in one step
+./scripts/release.ps1 patch -Push
+```
+
+The script will:
+1. Read the current version from `Cargo.toml`
+2. Bump the specified semver component
+3. Verify the working tree is clean and on `main`
+4. Run `cargo test` and `cargo clippy` as preflight checks
+5. Update `Cargo.toml` with the new version
+6. Stamp `CHANGELOG.md` — rename `[Unreleased]` to `[x.y.z] - YYYY-MM-DD` and create a fresh `[Unreleased]` section
+7. Commit with message `chore: release vx.y.z`
+8. Create an annotated git tag `vx.y.z`
+
+**2. Push the tag**
+
+If you didn't use `-Push`, push manually:
+
+```powershell
+git push origin main --follow-tags
+```
+
+**3. CI takes over**
+
+Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
+
+1. **Builds** release binaries for 5 targets:
+   - `x86_64-pc-windows-msvc`
+   - `x86_64-unknown-linux-gnu`
+   - `aarch64-unknown-linux-gnu` (cross-compiled)
+   - `x86_64-apple-darwin`
+   - `aarch64-apple-darwin`
+2. **Packages** each binary (`.zip` for Windows, `.tar.gz` for Unix) with SHA-256 checksums
+3. **Creates a GitHub Release** with the changelog entry as release notes, and attaches all binaries
+4. **Publishes to crates.io** via `cargo publish --no-verify`
+
+### Post-Release Verification
+
+After the workflow completes:
+
+```powershell
+# Verify the GitHub release exists
+gh release view vx.y.z
+
+# Verify crates.io publication
+cargo install anvil-cli  # should install the new version
+anvil --version          # should show the new version
+```
+
+### Version Policy
+
+- Versions follow [Semantic Versioning](https://semver.org/)
+- Pre-1.0 releases (`0.x.y`) are marked as pre-releases on GitHub
+- Changelog follows [Keep a Changelog](https://keepachangelog.com/) format
+
+### Crate Packaging
+
+The `Cargo.toml` `exclude` list keeps the published crate lean — only source code, tests, licenses, README, and changelog are included. CI configs, docs, site assets, and scripts are excluded. To inspect what would be published:
+
+```powershell
+cargo package --list
 ```
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "anvil-cli"
+name = "anvil-dev"
 version = "0.6.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "anvil-cli"
+name = "anvil-dev"
 version = "0.6.0"
 edition = "2021"
 authors = ["Anvil Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,23 @@ authors = ["Anvil Contributors"]
 description = "Declarative workstation configuration management"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/kafkade/anvil"
-homepage = "https://github.com/kafkade/anvil"
+homepage = "https://anvil.kafkade.com"
 readme = "README.md"
 keywords = ["windows", "configuration", "winget", "devops", "automation"]
 categories = ["command-line-utilities", "config", "development-tools"]
 rust-version = "1.75"
+exclude = [
+  ".github/",
+  "docs/",
+  "site/",
+  "scripts/",
+  "examples/",
+  "book.toml",
+  "rust-toolchain.toml",
+  "CODE_OF_CONDUCT.md",
+  "CONTRIBUTING.md",
+  "SECURITY.md",
+]
 
 [dependencies]
 # CLI framework

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Anvil is a declarative configuration management tool for developer workstations.
 
 ```powershell
 # Prerequisites: Rust 1.75+
-cargo install anvil-cli
+cargo install anvil-dev
 ```
 
 **Option 2: Download from Releases**

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-platform release builds for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64)
 
 ### Changed
-- Crate renamed to `anvil-cli` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-cli`)
+- Crate renamed to `anvil-dev` for crates.io publishing (binary name stays `anvil`; install via `cargo install anvil-dev`)
 
 ### Deprecated
 - ~~`scripts.health_check` when used alongside `assertions`~~ — **removed in this release** (see Removed)

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -461,7 +461,7 @@ The script validates (clean tree, main branch, tests pass, clippy clean) before 
 
 1. Builds binaries for 5 platforms (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64)
 2. Creates a GitHub Release with changelog notes and SHA256 checksums
-3. Publishes to [crates.io](https://crates.io/crates/anvil-cli)
+3. Publishes to [crates.io](https://crates.io/crates/anvil-dev)
 
 ### Required secrets
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -23,7 +23,7 @@ that everything is healthy.
 
 ```sh
 # From crates.io (requires Rust 1.75+)
-cargo install anvil-cli
+cargo install anvil-dev
 ```
 
 Or download a pre-built binary from the

--- a/docs/src/specification.md
+++ b/docs/src/specification.md
@@ -1229,7 +1229,7 @@ Duplicate workload names produce a warning with the resolved path shown.
 
 **Goal:** Stable release with cross-platform CI and crates.io publishing.
 
-- Decide crate name (`anvil` is taken on crates.io — candidates: `anvil-cli`, `devsmith`, `forgekit`)
+- Decide crate name (`anvil` is taken on crates.io — candidates: `anvil-dev`, `devsmith`, `forgekit`)
 - ~~Cross-compilation CI for Windows, Linux, macOS~~ ✅ Implemented (matrix build in `ci.yml`)
 - ~~Shell completions~~ ✅ Implemented (bash, zsh, fish, powershell, elvish via `cli/completions.rs`)
 - Comprehensive documentation review

--- a/docs/src/user-guide.md
+++ b/docs/src/user-guide.md
@@ -40,7 +40,7 @@ Anvil is a declarative configuration management tool for developer workstations.
 
 ```powershell
 # Prerequisites: Rust 1.75+
-cargo install anvil-cli
+cargo install anvil-dev
 ```
 
 ### Download Pre-built Binary

--- a/site/index.html
+++ b/site/index.html
@@ -120,8 +120,8 @@
 
         <div class="hero-install">
           <span class="hero-install-prompt">$</span>
-          <code>cargo install anvil-cli</code>
-          <button class="hero-install-copy" aria-label="Copy install command" onclick="navigator.clipboard.writeText('cargo install anvil-cli')">
+          <code>cargo install anvil-dev</code>
+          <button class="hero-install-copy" aria-label="Copy install command" onclick="navigator.clipboard.writeText('cargo install anvil-dev')">
             <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25zM5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25z"/></svg>
           </button>
         </div>
@@ -238,7 +238,7 @@
             <div class="install-card-badge">Recommended</div>
             <h3>From crates.io</h3>
             <p>Install with Cargo — Rust 1.75+ required. Works on all platforms.</p>
-            <pre class="install-code"><code>cargo install anvil-cli</code></pre>
+            <pre class="install-code"><code>cargo install anvil-dev</code></pre>
           </div>
 
           <div class="install-card">
@@ -339,7 +339,7 @@ cargo build --release
           <a href="/docs/user-guide.html">User Guide</a>
           <a href="/docs/changelog.html">Changelog</a>
           <a href="https://github.com/kafkade/anvil" target="_blank" rel="noopener">GitHub</a>
-          <a href="https://crates.io/crates/anvil-cli" target="_blank" rel="noopener">crates.io</a>
+          <a href="https://crates.io/crates/anvil-dev" target="_blank" rel="noopener">crates.io</a>
           <span class="footer-sep" aria-hidden="true">·</span>
           <a href="https://github.com/sponsors/kafkade" target="_blank" rel="noopener">Sponsor</a>
           <a href="https://ko-fi.com/kafkade" target="_blank" rel="noopener">Ko-fi</a>


### PR DESCRIPTION
## Description

Prepares the crate for first publication to crates.io and adds release documentation.

### What's included

- **Crate rename**: `anvil-cli` → `anvil-dev` (the name `anvil-cli` was already taken on crates.io). The binary name remains `anvil`; users install via `cargo install anvil-dev`.
- **Homepage URL**: `Cargo.toml` `homepage` now points to `https://anvil.kafkade.com` instead of the GitHub repo.
- **Lean crate packaging**: Added `exclude` list to `Cargo.toml` so the published crate only contains source, tests, licenses, README, and changelog — no CI configs, docs, site assets, or scripts.
- **Cargo publish policy**: Added to `.github/copilot-instructions.md` — `cargo publish` must never be run by automation; only the maintainer publishes manually.
- **Release documentation**: New "Releasing a New Version" section in `CONTRIBUTING.md` covering the release script, CI automation, post-release verification, version policy, and crate packaging.
- **All references updated**: Every mention of `anvil-cli` across README, CHANGELOG, docs, and the promotional site updated to `anvil-dev`.

## Related Issues

Closes #41

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)