### PR TITLE
feat: add winget packaging and automated publishing (#51)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,3 +131,14 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --no-verify
+
+  winget:
+    name: Publish to winget
+    needs: release
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: kafkade.anvil
+          installers-regex: 'anvil-.*-x86_64-pc-windows-msvc\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
   "site/",
   "scripts/",
   "examples/",
+  "packaging/",
   "book.toml",
   "rust-toolchain.toml",
   "CODE_OF_CONDUCT.md",

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,87 @@
+# Packaging
+
+Instructions for publishing Anvil to platform-specific package managers.
+
+## winget (Windows Package Manager)
+
+### First-time submission
+
+The `winget-releaser` automation requires at least one version to already exist in
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs). The first version must be submitted manually.
+
+**1. Get the SHA-256 hash from the release**
+
+```powershell
+# Download the .sha256 file from the GitHub release
+$tag = "v1.0.0"
+$asset = "anvil-${tag}-x86_64-pc-windows-msvc.zip"
+Invoke-WebRequest "https://github.com/kafkade/anvil/releases/download/${tag}/${asset}.sha256" -OutFile sha256.txt
+Get-Content sha256.txt
+```
+
+**2. Update the manifest**
+
+Edit `packaging/winget/kafkade.anvil.installer.yaml`:
+- Replace `REPLACE_WITH_ACTUAL_SHA256_FROM_RELEASE` with the actual hash
+- Verify the `InstallerUrl` matches the release URL
+- Update `PackageVersion` in all three files if different from `1.0.0`
+
+**3. Validate the manifest locally**
+
+```powershell
+winget validate packaging/winget/
+```
+
+**4. Test the install locally**
+
+```powershell
+winget install --manifest packaging/winget/
+anvil --version
+```
+
+**5. Submit to winget-pkgs**
+
+```powershell
+# Fork microsoft/winget-pkgs, then:
+# Copy manifests to: manifests/k/kafkade/anvil/1.0.0/
+# Create a PR following https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md
+
+# Or use wingetcreate CLI:
+wingetcreate submit packaging/winget/
+```
+
+**6. Verify after merge**
+
+```powershell
+winget search anvil
+winget install kafkade.anvil
+anvil --version
+```
+
+### Automated updates (subsequent releases)
+
+After the first version is accepted, the release workflow (`.github/workflows/release.yml`)
+automatically submits updated manifests to winget-pkgs on each tagged release using
+[winget-releaser](https://github.com/vedantmgoyal9/winget-releaser).
+
+**Required secret**: `WINGET_TOKEN` — a classic GitHub PAT with `public_repo` scope.
+Create one at https://github.com/settings/tokens and add it to the repo secrets.
+
+The automation:
+1. Triggers after the GitHub Release is created
+2. Matches the Windows `.zip` installer from the release assets
+3. Generates updated manifest files with the correct version and SHA-256
+4. Creates a PR to `microsoft/winget-pkgs` automatically
+
+### Manifest format
+
+The `packaging/winget/` directory contains a multi-file manifest:
+
+| File | Purpose |
+|------|---------|
+| `kafkade.anvil.yaml` | Version manifest (ties identifier to version) |
+| `kafkade.anvil.installer.yaml` | Installer details (URL, hash, architecture, type) |
+| `kafkade.anvil.locale.en-US.yaml` | Package metadata (description, tags, license) |
+
+The installer type is `zip` with `NestedInstallerType: portable` — winget extracts the zip
+and registers `anvil.exe` as a portable command.

--- a/packaging/winget/kafkade.anvil.installer.yaml
+++ b/packaging/winget/kafkade.anvil.installer.yaml
@@ -1,0 +1,16 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: kafkade.anvil
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: anvil.exe
+    PortableCommandAlias: anvil
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/kafkade/anvil/releases/download/v1.0.0/anvil-v1.0.0-x86_64-pc-windows-msvc.zip
+    InstallerSha256: REPLACE_WITH_ACTUAL_SHA256_FROM_RELEASE
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/packaging/winget/kafkade.anvil.locale.en-US.yaml
+++ b/packaging/winget/kafkade.anvil.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: kafkade.anvil
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: kafkade
+PublisherUrl: https://github.com/kafkade
+PublisherSupportUrl: https://github.com/kafkade/anvil/issues
+PackageName: Anvil
+PackageUrl: https://anvil.kafkade.com
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/kafkade/anvil/blob/main/LICENSE-MIT
+ShortDescription: Declarative workstation configuration management
+Description: |-
+  Anvil is a declarative configuration management tool for developer workstations.
+  Define your development environment in YAML, and Anvil will install packages,
+  copy configuration files, run setup commands, and verify system health.
+  Currently supports Windows (winget), with cross-platform support planned.
+Moniker: anvil
+Tags:
+  - automation
+  - cli
+  - configuration
+  - developer-tools
+  - devops
+  - winget
+  - workstation
+ReleaseNotesUrl: https://github.com/kafkade/anvil/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/packaging/winget/kafkade.anvil.yaml
+++ b/packaging/winget/kafkade.anvil.yaml
@@ -1,0 +1,8 @@
+# Created using winget CLI
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: kafkade.anvil
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Description

Adds winget packaging manifests and automated publishing to the release workflow so Anvil can be installed via `winget install kafkade.anvil` on Windows.

### What's included

- **winget manifests** (`packaging/winget/`): Multi-file manifest (version, installer, locale) for `kafkade.anvil` using `zip`/`portable` installer type with `anvil.exe` as the nested binary.
- **Release automation**: New `winget` job in `release.yml` using `vedantmgoyal9/winget-releaser` to auto-submit manifest PRs to `microsoft/winget-pkgs` on each tagged release.
- **Packaging playbook** (`packaging/README.md`): Step-by-step instructions for the one-time manual first submission, local validation with `winget validate`, and how the automation works for subsequent releases.
- **Crate exclusion**: `packaging/` added to `Cargo.toml` `exclude` list to keep the published crate lean.

## Related Issues

Closes #51

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)