### PR TITLE
feat: add source management CLI with remote git support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `anvil source` command family for managing workload sources from the CLI
+- `anvil source list` shows all configured sources with origin (default/local/remote) and workload counts
+- `anvil source add <path>` adds a local directory as a workload source
+- `anvil source add <git-url>` clones a git repository as a remote workload source with `--name`, `--ref`, and `--path` options
+- `anvil source remove <name>` removes a source (with `--delete` to clean up cloned files)
+- `anvil source status` shows sync status, current ref, dirty state, and last synced time for all sources
+- `anvil source sync [name]` pulls latest changes for remote sources (non-destructive — skips dirty working trees)
+- Remote source metadata persisted in `~/.anvil/sources.json`
+- Remote repositories cloned to `~/.anvil/sources/<name>/` using shallow clones for fast setup
+- Managed sources automatically integrated into workload discovery (after user paths, before defaults)
+- JSON and YAML output formats for `source list` and `source status`
+
 ## [1.1.0] - 2026-04-18
 
 ### Changed

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -485,3 +485,66 @@ impl std::fmt::Display for WorkloadTemplate {
         }
     }
 }
+
+/// Arguments for the `source` command
+#[derive(Args, Debug)]
+pub struct SourceArgs {
+    /// Source subcommand
+    #[command(subcommand)]
+    pub command: SourceCommand,
+}
+
+/// Source subcommands
+#[derive(Subcommand, Debug)]
+pub enum SourceCommand {
+    /// List all configured sources
+    List {
+        /// Output format
+        #[arg(short, long, value_enum, default_value = "table")]
+        output: OutputFormat,
+    },
+
+    /// Add a workload source (local path or git URL)
+    Add {
+        /// Local path or git repository URL
+        #[arg(value_name = "PATH_OR_URL")]
+        location: String,
+
+        /// Name for the source (auto-detected from URL or path if not specified)
+        #[arg(short, long)]
+        name: Option<String>,
+
+        /// Subdirectory within the source to search for workloads
+        #[arg(short, long, value_name = "DIR")]
+        path: Option<String>,
+
+        /// Git branch or tag to track (remote sources only)
+        #[arg(short = 'r', long = "ref", value_name = "REF")]
+        git_ref: Option<String>,
+    },
+
+    /// Remove a workload source
+    Remove {
+        /// Name of the source to remove
+        #[arg(value_name = "NAME")]
+        name: String,
+
+        /// Also delete cloned files for remote sources
+        #[arg(long)]
+        delete: bool,
+    },
+
+    /// Show sync status for all sources
+    Status {
+        /// Output format
+        #[arg(short, long, value_enum, default_value = "table")]
+        output: OutputFormat,
+    },
+
+    /// Sync remote sources (git pull)
+    Sync {
+        /// Name of a specific source to sync (syncs all if omitted)
+        #[arg(value_name = "NAME")]
+        name: Option<String>,
+    },
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -70,6 +70,9 @@ pub enum Commands {
 
     /// Manage global configuration
     Config(commands::ConfigArgs),
+
+    /// Manage workload sources (local paths and git repositories)
+    Source(commands::SourceArgs),
 }
 
 impl Cli {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,10 +5,12 @@
 pub mod global;
 pub mod inheritance;
 pub mod schema;
+pub mod sources;
 pub mod workload;
 
 pub use global::GlobalConfig;
 pub use inheritance::InheritanceGraph;
+pub use sources::SourcesConfig;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -56,6 +58,7 @@ impl ConfigManager {
     ///
     /// User-configured paths from GlobalConfig are prepended before defaults,
     /// giving them higher priority during workload discovery.
+    /// Managed sources from sources.json are added after user paths but before defaults.
     pub fn new() -> Self {
         let mut search_paths = Vec::new();
 
@@ -70,7 +73,16 @@ impl ConfigManager {
             }
         }
 
-        // 2. Default search paths (lower priority)
+        // 2. Managed sources from sources.json (after user paths, before defaults)
+        if let Ok(sources_config) = SourcesConfig::load() {
+            for source_path in sources_config.workload_paths() {
+                if !search_paths.contains(&source_path) {
+                    search_paths.push(source_path);
+                }
+            }
+        }
+
+        // 3. Default search paths (lower priority)
         for path in default_workload_paths() {
             if !search_paths.contains(&path) {
                 search_paths.push(path);

--- a/src/config/sources.rs
+++ b/src/config/sources.rs
@@ -1,0 +1,455 @@
+//! Source configuration management for Anvil
+//!
+//! This module manages workload sources — both local directories and remote git
+//! repositories. Source metadata is persisted in `~/.anvil/sources.json`.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Type of workload source
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceType {
+    /// A local filesystem directory
+    Local,
+    /// A remote git repository
+    Remote,
+}
+
+impl std::fmt::Display for SourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceType::Local => write!(f, "local"),
+            SourceType::Remote => write!(f, "remote"),
+        }
+    }
+}
+
+/// A workload source definition
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Source {
+    /// Unique name for this source
+    pub name: String,
+
+    /// Type of source (local or remote)
+    #[serde(rename = "type")]
+    pub source_type: SourceType,
+
+    /// Local filesystem path where workloads are found
+    ///
+    /// For local sources, this is the user-specified path.
+    /// For remote sources, this is the clone destination (e.g. `~/.anvil/sources/<name>/`).
+    pub local_path: PathBuf,
+
+    /// Git remote URL (only for remote sources)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// Git ref to track (branch name or tag) — only for remote sources
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_ref: Option<String>,
+
+    /// Subdirectory within the source to search for workloads
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workload_subdir: Option<String>,
+
+    /// Timestamp of last successful sync (only for remote sources)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_synced: Option<DateTime<Utc>>,
+}
+
+impl Source {
+    /// Create a new local source
+    pub fn new_local(name: String, local_path: PathBuf) -> Self {
+        Self {
+            name,
+            source_type: SourceType::Local,
+            local_path,
+            url: None,
+            git_ref: None,
+            workload_subdir: None,
+            last_synced: None,
+        }
+    }
+
+    /// Create a new remote (git) source
+    pub fn new_remote(
+        name: String,
+        url: String,
+        local_path: PathBuf,
+        git_ref: Option<String>,
+        workload_subdir: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            source_type: SourceType::Remote,
+            local_path,
+            url: Some(url),
+            git_ref,
+            workload_subdir,
+            last_synced: None,
+        }
+    }
+
+    /// Get the effective path where workloads should be discovered
+    pub fn workload_path(&self) -> PathBuf {
+        if let Some(ref subdir) = self.workload_subdir {
+            self.local_path.join(subdir)
+        } else {
+            self.local_path.clone()
+        }
+    }
+}
+
+/// Sources configuration — persisted at `~/.anvil/sources.json`
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SourcesConfig {
+    /// List of configured sources
+    pub sources: Vec<Source>,
+}
+
+impl SourcesConfig {
+    /// Get the path to the sources configuration file
+    pub fn sources_path() -> Result<PathBuf> {
+        let home = dirs::home_dir().context("Cannot find home directory")?;
+        Ok(home.join(".anvil").join("sources.json"))
+    }
+
+    /// Load sources configuration from file
+    ///
+    /// Returns default (empty) configuration if the file doesn't exist.
+    pub fn load() -> Result<Self> {
+        let path = Self::sources_path()?;
+
+        if path.exists() {
+            let content = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read sources file: {}", path.display()))?;
+            let config: SourcesConfig = serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse sources file: {}", path.display()))?;
+            Ok(config)
+        } else {
+            Ok(Self::default())
+        }
+    }
+
+    /// Save sources configuration to file
+    pub fn save(&self) -> Result<()> {
+        let path = Self::sources_path()?;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+
+        let content = serde_json::to_string_pretty(self)
+            .context("Failed to serialize sources configuration")?;
+
+        std::fs::write(&path, content)
+            .with_context(|| format!("Failed to write sources file: {}", path.display()))?;
+
+        Ok(())
+    }
+
+    /// Find a source by name
+    pub fn find_by_name(&self, name: &str) -> Option<&Source> {
+        self.sources.iter().find(|s| s.name == name)
+    }
+
+    /// Add a source, returning an error if a source with the same name exists
+    pub fn add(&mut self, source: Source) -> Result<()> {
+        if self.find_by_name(&source.name).is_some() {
+            anyhow::bail!("Source '{}' already exists", source.name);
+        }
+        self.sources.push(source);
+        Ok(())
+    }
+
+    /// Remove a source by name, returning the removed source if found
+    pub fn remove(&mut self, name: &str) -> Option<Source> {
+        if let Some(pos) = self.sources.iter().position(|s| s.name == name) {
+            Some(self.sources.remove(pos))
+        } else {
+            None
+        }
+    }
+
+    /// Get all remote sources
+    pub fn remote_sources(&self) -> Vec<&Source> {
+        self.sources
+            .iter()
+            .filter(|s| s.source_type == SourceType::Remote)
+            .collect()
+    }
+
+    /// Get workload search paths from all sources
+    pub fn workload_paths(&self) -> Vec<PathBuf> {
+        self.sources.iter().map(|s| s.workload_path()).collect()
+    }
+}
+
+/// Validate a source name (must be safe for use as a directory name)
+pub fn validate_source_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("Source name cannot be empty");
+    }
+
+    if name.len() > 64 {
+        anyhow::bail!("Source name cannot exceed 64 characters");
+    }
+
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+    {
+        anyhow::bail!(
+            "Source name '{}' contains invalid characters. \
+             Only alphanumeric characters, dots, underscores, and hyphens are allowed.",
+            name
+        );
+    }
+
+    if name.starts_with('.') || name.starts_with('-') {
+        anyhow::bail!("Source name cannot start with a dot or hyphen");
+    }
+
+    if name == "." || name == ".." {
+        anyhow::bail!("Source name cannot be '.' or '..'");
+    }
+
+    Ok(())
+}
+
+/// Detect whether a string looks like a git URL
+pub fn is_git_url(input: &str) -> bool {
+    input.starts_with("https://")
+        || input.starts_with("http://")
+        || input.starts_with("git@")
+        || input.starts_with("ssh://")
+        || input.ends_with(".git")
+}
+
+/// Extract a repository name from a git URL
+///
+/// Examples:
+/// - `https://github.com/org/repo.git` → `repo`
+/// - `git@github.com:org/repo.git` → `repo`
+/// - `https://github.com/org/repo` → `repo`
+pub fn repo_name_from_url(url: &str) -> Option<String> {
+    let cleaned = url.trim_end_matches('/').trim_end_matches(".git");
+
+    // Handle SSH URLs like git@github.com:org/repo
+    let path_part = if cleaned.contains(':') && cleaned.starts_with("git@") {
+        cleaned.rsplit(':').next()?
+    } else {
+        cleaned.rsplit('/').next()?
+    };
+
+    // Take the last component after any remaining slashes
+    let name = path_part.rsplit('/').next().unwrap_or(path_part);
+
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Get the directory where remote sources are cloned
+pub fn sources_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Cannot find home directory")?;
+    Ok(home.join(".anvil").join("sources"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_git_url() {
+        assert!(is_git_url("https://github.com/org/repo.git"));
+        assert!(is_git_url("https://github.com/org/repo"));
+        assert!(is_git_url("http://example.com/repo.git"));
+        assert!(is_git_url("git@github.com:org/repo.git"));
+        assert!(is_git_url("ssh://git@github.com/org/repo"));
+        assert!(is_git_url("my-repo.git"));
+
+        assert!(!is_git_url("/home/user/workloads"));
+        assert!(!is_git_url("C:\\Users\\user\\workloads"));
+        assert!(!is_git_url("./local-dir"));
+        assert!(!is_git_url("some-name"));
+    }
+
+    #[test]
+    fn test_repo_name_from_url() {
+        assert_eq!(
+            repo_name_from_url("https://github.com/org/repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            repo_name_from_url("https://github.com/org/repo"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            repo_name_from_url("git@github.com:org/repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            repo_name_from_url("https://github.com/org/my-workloads/"),
+            Some("my-workloads".to_string())
+        );
+        assert_eq!(
+            repo_name_from_url("ssh://git@github.com/org/repo"),
+            Some("repo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_validate_source_name() {
+        assert!(validate_source_name("my-source").is_ok());
+        assert!(validate_source_name("source_1").is_ok());
+        assert!(validate_source_name("org.repo").is_ok());
+        assert!(validate_source_name("MySource123").is_ok());
+
+        assert!(validate_source_name("").is_err());
+        assert!(validate_source_name("..").is_err());
+        assert!(validate_source_name(".hidden").is_err());
+        assert!(validate_source_name("-leading").is_err());
+        assert!(validate_source_name("path/traversal").is_err());
+        assert!(validate_source_name("has spaces").is_err());
+        assert!(validate_source_name(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn test_source_workload_path() {
+        let source = Source::new_local("test".to_string(), PathBuf::from("/some/path"));
+        assert_eq!(source.workload_path(), PathBuf::from("/some/path"));
+
+        let mut source = Source::new_remote(
+            "test".to_string(),
+            "https://example.com/repo.git".to_string(),
+            PathBuf::from("/clone/path"),
+            None,
+            Some("workloads".to_string()),
+        );
+        assert_eq!(
+            source.workload_path(),
+            PathBuf::from("/clone/path/workloads")
+        );
+
+        source.workload_subdir = None;
+        assert_eq!(source.workload_path(), PathBuf::from("/clone/path"));
+    }
+
+    #[test]
+    fn test_sources_config_add_remove() {
+        let mut config = SourcesConfig::default();
+
+        let source = Source::new_local("test".to_string(), PathBuf::from("/some/path"));
+        config.add(source).unwrap();
+
+        assert_eq!(config.sources.len(), 1);
+        assert!(config.find_by_name("test").is_some());
+        assert!(config.find_by_name("nonexistent").is_none());
+
+        // Duplicate add should fail
+        let dup = Source::new_local("test".to_string(), PathBuf::from("/other/path"));
+        assert!(config.add(dup).is_err());
+
+        // Remove
+        let removed = config.remove("test");
+        assert!(removed.is_some());
+        assert_eq!(config.sources.len(), 0);
+
+        // Remove nonexistent
+        let removed = config.remove("nonexistent");
+        assert!(removed.is_none());
+    }
+
+    #[test]
+    fn test_sources_config_remote_sources() {
+        let mut config = SourcesConfig::default();
+
+        config
+            .add(Source::new_local(
+                "local1".to_string(),
+                PathBuf::from("/local"),
+            ))
+            .unwrap();
+        config
+            .add(Source::new_remote(
+                "remote1".to_string(),
+                "https://example.com/repo.git".to_string(),
+                PathBuf::from("/clone"),
+                None,
+                None,
+            ))
+            .unwrap();
+
+        let remotes = config.remote_sources();
+        assert_eq!(remotes.len(), 1);
+        assert_eq!(remotes[0].name, "remote1");
+    }
+
+    #[test]
+    fn test_sources_config_workload_paths() {
+        let mut config = SourcesConfig::default();
+
+        config
+            .add(Source::new_local(
+                "local1".to_string(),
+                PathBuf::from("/local/path"),
+            ))
+            .unwrap();
+        config
+            .add(Source::new_remote(
+                "remote1".to_string(),
+                "https://example.com/repo.git".to_string(),
+                PathBuf::from("/clone/path"),
+                None,
+                Some("workloads".to_string()),
+            ))
+            .unwrap();
+
+        let paths = config.workload_paths();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], PathBuf::from("/local/path"));
+        assert_eq!(paths[1], PathBuf::from("/clone/path/workloads"));
+    }
+
+    #[test]
+    fn test_source_serialization_roundtrip() {
+        let mut config = SourcesConfig::default();
+        config
+            .add(Source::new_local(
+                "local1".to_string(),
+                PathBuf::from("/local/path"),
+            ))
+            .unwrap();
+        config
+            .add(Source::new_remote(
+                "remote1".to_string(),
+                "https://github.com/org/repo.git".to_string(),
+                PathBuf::from("/clone/path"),
+                Some("main".to_string()),
+                Some("workloads".to_string()),
+            ))
+            .unwrap();
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        let deserialized: SourcesConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.sources.len(), 2);
+        assert_eq!(deserialized.sources[0].name, "local1");
+        assert_eq!(deserialized.sources[0].source_type, SourceType::Local);
+        assert_eq!(deserialized.sources[1].name, "remote1");
+        assert_eq!(deserialized.sources[1].source_type, SourceType::Remote);
+        assert_eq!(
+            deserialized.sources[1].url,
+            Some("https://github.com/org/repo.git".to_string())
+        );
+        assert_eq!(deserialized.sources[1].git_ref, Some("main".to_string()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,9 @@ fn main() -> Result<()> {
         Commands::Config(args) => {
             operations::config::execute(args, &cli)?;
         }
+        Commands::Source(args) => {
+            operations::source::execute(args, &cli)?;
+        }
     }
 
     Ok(())

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -10,6 +10,7 @@ pub mod init;
 pub mod install;
 pub mod list;
 pub mod show;
+pub mod source;
 pub mod status;
 pub mod validate;
 

--- a/src/operations/source.rs
+++ b/src/operations/source.rs
@@ -1,0 +1,653 @@
+//! Source management operation module
+//!
+//! This module implements the `anvil source` command which provides
+//! management of workload sources — both local directories and remote
+//! git repositories.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use comfy_table::{presets::UTF8_FULL, Cell, Color, ContentArrangement, Table};
+
+use crate::cli::commands::{OutputFormat, SourceArgs, SourceCommand};
+use crate::cli::output::{print_error, print_info, print_success, print_warning};
+use crate::cli::Cli;
+use crate::config::default_workload_paths;
+use crate::config::sources::{
+    is_git_url, repo_name_from_url, sources_dir, validate_source_name, Source, SourceType,
+    SourcesConfig,
+};
+use crate::providers::git::GitProvider;
+
+/// Execute the source command
+pub fn execute(args: &SourceArgs, cli: &Cli) -> Result<()> {
+    match &args.command {
+        SourceCommand::List { output } => list_sources(*output, cli),
+        SourceCommand::Add {
+            location,
+            name,
+            path,
+            git_ref,
+        } => add_source(
+            location,
+            name.as_deref(),
+            path.as_deref(),
+            git_ref.as_deref(),
+            cli,
+        ),
+        SourceCommand::Remove { name, delete } => remove_source(name, *delete, cli),
+        SourceCommand::Status { output } => show_status(*output, cli),
+        SourceCommand::Sync { name } => sync_sources(name.as_deref(), cli),
+    }
+}
+
+/// List all configured sources including defaults, user-configured, and remote
+fn list_sources(output: OutputFormat, cli: &Cli) -> Result<()> {
+    let sources_config = SourcesConfig::load().unwrap_or_default();
+    let use_color = !cli.should_disable_color();
+
+    // Build the complete source list with origin labels
+    let mut entries: Vec<SourceListEntry> = Vec::new();
+
+    // 1. Managed sources from sources.json
+    for source in &sources_config.sources {
+        let workload_path = source.workload_path();
+        let workload_count = count_workloads(&workload_path);
+
+        entries.push(SourceListEntry {
+            name: source.name.clone(),
+            origin: source.source_type.to_string(),
+            path: source.workload_path().to_string_lossy().to_string(),
+            workloads: workload_count,
+            url: source.url.clone(),
+        });
+    }
+
+    // 2. Default paths
+    for path in default_workload_paths() {
+        // Skip if already covered by a managed source
+        let path_str = path.to_string_lossy().to_string();
+        if entries.iter().any(|e| e.path == path_str) {
+            continue;
+        }
+        let workload_count = count_workloads(&path);
+        entries.push(SourceListEntry {
+            name: "-".to_string(),
+            origin: "default".to_string(),
+            path: path_str,
+            workloads: workload_count,
+            url: None,
+        });
+    }
+
+    if entries.is_empty() && !cli.quiet {
+        print_info("No sources configured. Add one with 'anvil source add <path-or-url>'");
+        return Ok(());
+    }
+
+    match output {
+        OutputFormat::Table => print_source_table(&entries, use_color),
+        OutputFormat::Json => {
+            let json =
+                serde_json::to_string_pretty(&entries).context("Failed to serialize sources")?;
+            println!("{}", json);
+        }
+        OutputFormat::Yaml => {
+            let yaml = serde_yaml::to_string(&entries).context("Failed to serialize sources")?;
+            print!("{}", yaml);
+        }
+        OutputFormat::Html => {
+            print_source_table(&entries, false);
+        }
+    }
+
+    Ok(())
+}
+
+/// Add a new workload source (local path or git URL)
+fn add_source(
+    location: &str,
+    name: Option<&str>,
+    subdir: Option<&str>,
+    git_ref: Option<&str>,
+    _cli: &Cli,
+) -> Result<()> {
+    let mut sources_config = SourcesConfig::load().unwrap_or_default();
+
+    if is_git_url(location) {
+        add_remote_source(&mut sources_config, location, name, subdir, git_ref)?;
+    } else {
+        add_local_source(&mut sources_config, location, name, subdir)?;
+    }
+
+    sources_config
+        .save()
+        .context("Failed to save sources configuration")?;
+
+    Ok(())
+}
+
+/// Add a local directory as a source
+fn add_local_source(
+    config: &mut SourcesConfig,
+    path_str: &str,
+    name: Option<&str>,
+    subdir: Option<&str>,
+) -> Result<()> {
+    let path = PathBuf::from(path_str);
+    let canonical = std::fs::canonicalize(&path)
+        .with_context(|| format!("Path does not exist: {}", path.display()))?;
+
+    if !canonical.is_dir() {
+        anyhow::bail!("Path is not a directory: {}", canonical.display());
+    }
+
+    let source_name = match name {
+        Some(n) => n.to_string(),
+        None => canonical
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unnamed".to_string()),
+    };
+
+    validate_source_name(&source_name)?;
+
+    let mut source = Source::new_local(source_name.clone(), canonical);
+    source.workload_subdir = subdir.map(|s| s.to_string());
+
+    config
+        .add(source)
+        .with_context(|| format!("Failed to add source '{}'", source_name))?;
+
+    print_success(&format!("Added local source '{}'", source_name));
+
+    Ok(())
+}
+
+/// Add a remote git repository as a source
+fn add_remote_source(
+    config: &mut SourcesConfig,
+    url: &str,
+    name: Option<&str>,
+    subdir: Option<&str>,
+    git_ref: Option<&str>,
+) -> Result<()> {
+    if !GitProvider::is_available() {
+        anyhow::bail!(
+            "git is not installed or not in PATH. \
+             Install git to use remote sources."
+        );
+    }
+
+    let source_name = match name {
+        Some(n) => n.to_string(),
+        None => repo_name_from_url(url)
+            .context("Cannot determine source name from URL. Use --name to specify one.")?,
+    };
+
+    validate_source_name(&source_name)?;
+
+    // Determine clone destination
+    let sources_root = sources_dir()?;
+    let clone_path = sources_root.join(&source_name);
+
+    if clone_path.exists() {
+        anyhow::bail!(
+            "Destination already exists: {}. \
+             Use a different --name or remove it first.",
+            clone_path.display()
+        );
+    }
+
+    // Create parent directory
+    std::fs::create_dir_all(&sources_root).with_context(|| {
+        format!(
+            "Failed to create sources directory: {}",
+            sources_root.display()
+        )
+    })?;
+
+    print_info(&format!("Cloning {} into {}...", url, clone_path.display()));
+
+    GitProvider::clone(url, &clone_path, git_ref)
+        .with_context(|| format!("Failed to clone repository: {}", url))?;
+
+    let mut source = Source::new_remote(
+        source_name.clone(),
+        url.to_string(),
+        clone_path,
+        git_ref.map(|s| s.to_string()),
+        subdir.map(|s| s.to_string()),
+    );
+    source.last_synced = Some(Utc::now());
+
+    config
+        .add(source)
+        .with_context(|| format!("Failed to add source '{}'", source_name))?;
+
+    print_success(&format!("Added remote source '{}'", source_name));
+
+    Ok(())
+}
+
+/// Remove a workload source
+fn remove_source(name: &str, delete_files: bool, _cli: &Cli) -> Result<()> {
+    let mut sources_config = SourcesConfig::load().unwrap_or_default();
+
+    let removed = sources_config.remove(name);
+
+    match removed {
+        Some(source) => {
+            // Delete cloned files if requested and this is a remote source
+            if delete_files && source.source_type == SourceType::Remote {
+                if source.local_path.exists() {
+                    std::fs::remove_dir_all(&source.local_path).with_context(|| {
+                        format!(
+                            "Failed to delete source directory: {}",
+                            source.local_path.display()
+                        )
+                    })?;
+                    print_info(&format!(
+                        "Deleted cloned files at {}",
+                        source.local_path.display()
+                    ));
+                }
+            } else if source.source_type == SourceType::Remote && source.local_path.exists() {
+                print_info(&format!(
+                    "Cloned files remain at {}. Use --delete to remove them.",
+                    source.local_path.display()
+                ));
+            }
+
+            sources_config
+                .save()
+                .context("Failed to save sources configuration")?;
+            print_success(&format!("Removed source '{}'", name));
+        }
+        None => {
+            print_error(&format!("Source '{}' not found", name));
+            if !sources_config.sources.is_empty() {
+                println!("\nAvailable sources:");
+                for s in &sources_config.sources {
+                    println!("  - {} ({})", s.name, s.source_type);
+                }
+            }
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+/// Show sync status for all sources
+fn show_status(output: OutputFormat, cli: &Cli) -> Result<()> {
+    let sources_config = SourcesConfig::load().unwrap_or_default();
+    let use_color = !cli.should_disable_color();
+
+    if sources_config.sources.is_empty() {
+        print_info("No sources configured. Add one with 'anvil source add <path-or-url>'");
+        return Ok(());
+    }
+
+    let mut statuses: Vec<SourceStatusEntry> = Vec::new();
+
+    for source in &sources_config.sources {
+        let exists = source.local_path.exists() || source.workload_path().exists();
+        let workload_count = count_workloads(&source.workload_path());
+
+        let (current_ref, dirty) = if source.source_type == SourceType::Remote && exists {
+            let ref_str = GitProvider::current_ref(&source.local_path)
+                .unwrap_or_else(|_| "unknown".to_string());
+            let is_dirty = GitProvider::is_dirty(&source.local_path).unwrap_or(false);
+            (Some(ref_str), Some(is_dirty))
+        } else {
+            (None, None)
+        };
+
+        statuses.push(SourceStatusEntry {
+            name: source.name.clone(),
+            source_type: source.source_type.to_string(),
+            path: source.workload_path().to_string_lossy().to_string(),
+            exists,
+            workloads: workload_count,
+            current_ref,
+            dirty,
+            last_synced: source.last_synced.map(|t| t.to_rfc3339()),
+        });
+    }
+
+    match output {
+        OutputFormat::Table => print_status_table(&statuses, use_color),
+        OutputFormat::Json => {
+            let json =
+                serde_json::to_string_pretty(&statuses).context("Failed to serialize status")?;
+            println!("{}", json);
+        }
+        OutputFormat::Yaml => {
+            let yaml = serde_yaml::to_string(&statuses).context("Failed to serialize status")?;
+            print!("{}", yaml);
+        }
+        OutputFormat::Html => {
+            print_status_table(&statuses, false);
+        }
+    }
+
+    Ok(())
+}
+
+/// Sync remote sources
+fn sync_sources(name: Option<&str>, _cli: &Cli) -> Result<()> {
+    let mut sources_config = SourcesConfig::load().unwrap_or_default();
+
+    if !GitProvider::is_available() {
+        anyhow::bail!("git is not installed or not in PATH");
+    }
+
+    let sources_to_sync: Vec<usize> = if let Some(name) = name {
+        // Sync a specific source
+        let idx = sources_config
+            .sources
+            .iter()
+            .position(|s| s.name == name)
+            .with_context(|| format!("Source '{}' not found", name))?;
+
+        if sources_config.sources[idx].source_type != SourceType::Remote {
+            anyhow::bail!("Source '{}' is not a remote source", name);
+        }
+
+        vec![idx]
+    } else {
+        // Sync all remote sources
+        sources_config
+            .remote_sources()
+            .iter()
+            .filter_map(|s| {
+                sources_config
+                    .sources
+                    .iter()
+                    .position(|src| src.name == s.name)
+            })
+            .collect()
+    };
+
+    if sources_to_sync.is_empty() {
+        print_info("No remote sources to sync");
+        return Ok(());
+    }
+
+    let mut success_count = 0;
+    let mut fail_count = 0;
+
+    for idx in &sources_to_sync {
+        let source = &sources_config.sources[*idx];
+        let source_name = source.name.clone();
+        let repo_path = source.local_path.clone();
+        let git_ref = source.git_ref.clone();
+
+        print_info(&format!("Syncing '{}'...", source_name));
+
+        if !repo_path.exists() {
+            print_warning(&format!(
+                "Source '{}' directory not found: {}",
+                source_name,
+                repo_path.display()
+            ));
+            fail_count += 1;
+            continue;
+        }
+
+        match GitProvider::sync(&repo_path, git_ref.as_deref()) {
+            Ok(()) => {
+                sources_config.sources[*idx].last_synced = Some(Utc::now());
+                print_success(&format!("Synced '{}'", source_name));
+                success_count += 1;
+            }
+            Err(crate::providers::git::GitError::DirtyWorkingTree) => {
+                print_warning(&format!(
+                    "Skipping '{}': working tree has local modifications",
+                    source_name
+                ));
+                fail_count += 1;
+            }
+            Err(e) => {
+                print_error(&format!("Failed to sync '{}': {}", source_name, e));
+                fail_count += 1;
+            }
+        }
+    }
+
+    // Save updated timestamps
+    sources_config
+        .save()
+        .context("Failed to save sources configuration")?;
+
+    if fail_count > 0 {
+        println!("\n{} synced, {} failed", success_count, fail_count);
+    } else {
+        print_success(&format!(
+            "All {} source(s) synced successfully",
+            success_count
+        ));
+    }
+
+    Ok(())
+}
+
+/// Count workloads in a directory
+fn count_workloads(path: &std::path::Path) -> usize {
+    if !path.exists() {
+        return 0;
+    }
+
+    std::fs::read_dir(path)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.path().is_dir()
+                        && (e.path().join("workload.yaml").exists()
+                            || e.path().join("workload.yml").exists())
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Entry for the source list table
+#[derive(Debug, serde::Serialize)]
+struct SourceListEntry {
+    name: String,
+    origin: String,
+    path: String,
+    workloads: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+}
+
+/// Entry for the source status table
+#[derive(Debug, serde::Serialize)]
+struct SourceStatusEntry {
+    name: String,
+    #[serde(rename = "type")]
+    source_type: String,
+    path: String,
+    exists: bool,
+    workloads: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    current_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dirty: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_synced: Option<String>,
+}
+
+/// Print the source list as a formatted table
+fn print_source_table(entries: &[SourceListEntry], use_color: bool) {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    let headers = if use_color {
+        vec![
+            Cell::new("Name").fg(Color::Cyan),
+            Cell::new("Type").fg(Color::Cyan),
+            Cell::new("Path").fg(Color::Cyan),
+            Cell::new("Workloads").fg(Color::Cyan),
+        ]
+    } else {
+        vec![
+            Cell::new("Name"),
+            Cell::new("Type"),
+            Cell::new("Path"),
+            Cell::new("Workloads"),
+        ]
+    };
+    table.set_header(headers);
+
+    for entry in entries {
+        let type_cell = if use_color {
+            match entry.origin.as_str() {
+                "local" => Cell::new(&entry.origin).fg(Color::Green),
+                "remote" => Cell::new(&entry.origin).fg(Color::Blue),
+                "default" => Cell::new(&entry.origin).fg(Color::DarkGrey),
+                _ => Cell::new(&entry.origin),
+            }
+        } else {
+            Cell::new(&entry.origin)
+        };
+
+        let row = if use_color {
+            vec![
+                Cell::new(&entry.name).fg(Color::Green),
+                type_cell,
+                Cell::new(&entry.path),
+                Cell::new(entry.workloads.to_string()),
+            ]
+        } else {
+            vec![
+                Cell::new(&entry.name),
+                type_cell,
+                Cell::new(&entry.path),
+                Cell::new(entry.workloads.to_string()),
+            ]
+        };
+        table.add_row(row);
+    }
+
+    println!("{}", table);
+}
+
+/// Print the source status as a formatted table
+fn print_status_table(entries: &[SourceStatusEntry], use_color: bool) {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    let headers = if use_color {
+        vec![
+            Cell::new("Name").fg(Color::Cyan),
+            Cell::new("Type").fg(Color::Cyan),
+            Cell::new("Status").fg(Color::Cyan),
+            Cell::new("Ref").fg(Color::Cyan),
+            Cell::new("Workloads").fg(Color::Cyan),
+            Cell::new("Last Synced").fg(Color::Cyan),
+        ]
+    } else {
+        vec![
+            Cell::new("Name"),
+            Cell::new("Type"),
+            Cell::new("Status"),
+            Cell::new("Ref"),
+            Cell::new("Workloads"),
+            Cell::new("Last Synced"),
+        ]
+    };
+    table.set_header(headers);
+
+    for entry in entries {
+        let status = if !entry.exists {
+            "missing"
+        } else if entry.dirty == Some(true) {
+            "modified"
+        } else {
+            "ok"
+        };
+
+        let status_cell = if use_color {
+            match status {
+                "ok" => Cell::new("✓ ok").fg(Color::Green),
+                "modified" => Cell::new("⚠ modified").fg(Color::Yellow),
+                "missing" => Cell::new("✗ missing").fg(Color::Red),
+                _ => Cell::new(status),
+            }
+        } else {
+            Cell::new(status)
+        };
+
+        let ref_str = entry.current_ref.as_deref().unwrap_or("-");
+        let synced_str = entry.last_synced.as_deref().unwrap_or("-");
+
+        let row = if use_color {
+            vec![
+                Cell::new(&entry.name).fg(Color::Green),
+                Cell::new(&entry.source_type),
+                status_cell,
+                Cell::new(ref_str),
+                Cell::new(entry.workloads.to_string()),
+                Cell::new(synced_str),
+            ]
+        } else {
+            vec![
+                Cell::new(&entry.name),
+                Cell::new(&entry.source_type),
+                status_cell,
+                Cell::new(ref_str),
+                Cell::new(entry.workloads.to_string()),
+                Cell::new(synced_str),
+            ]
+        };
+        table.add_row(row);
+    }
+
+    println!("{}", table);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_count_workloads_empty_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        assert_eq!(count_workloads(temp.path()), 0);
+    }
+
+    #[test]
+    fn test_count_workloads_with_workloads() {
+        let temp = tempfile::TempDir::new().unwrap();
+
+        // Create a valid workload directory
+        let workload_dir = temp.path().join("test-workload");
+        std::fs::create_dir(&workload_dir).unwrap();
+        std::fs::write(
+            workload_dir.join("workload.yaml"),
+            "name: test\nversion: \"1.0.0\"\ndescription: test",
+        )
+        .unwrap();
+
+        // Create a non-workload directory
+        let other_dir = temp.path().join("not-a-workload");
+        std::fs::create_dir(&other_dir).unwrap();
+
+        assert_eq!(count_workloads(temp.path()), 1);
+    }
+
+    #[test]
+    fn test_count_workloads_nonexistent_dir() {
+        assert_eq!(
+            count_workloads(std::path::Path::new("/nonexistent/path")),
+            0
+        );
+    }
+}

--- a/src/providers/git.rs
+++ b/src/providers/git.rs
@@ -1,0 +1,214 @@
+//! Git provider for managing remote workload sources
+//!
+//! This module provides git operations (clone, pull, status) using
+//! `std::process::Command` to shell out to the `git` CLI.
+
+use std::path::Path;
+use std::process::Command;
+
+use thiserror::Error;
+
+/// Errors that can occur during git operations
+#[derive(Error, Debug)]
+pub enum GitError {
+    #[error("git is not installed or not in PATH")]
+    GitNotFound,
+
+    #[error("git clone failed: {0}")]
+    CloneFailed(String),
+
+    #[error("git fetch failed: {0}")]
+    FetchFailed(String),
+
+    #[error("git pull failed: {0}")]
+    PullFailed(String),
+
+    #[error("repository has local modifications")]
+    DirtyWorkingTree,
+
+    #[error("git command failed: {0}")]
+    CommandFailed(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Git operations provider
+pub struct GitProvider;
+
+impl GitProvider {
+    /// Check if git is available on the system
+    pub fn is_available() -> bool {
+        Command::new("git")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Clone a git repository
+    ///
+    /// Uses shallow clone (`--depth 1`) for faster initial setup.
+    /// If `git_ref` is provided, checks out that branch/tag after cloning.
+    pub fn clone(url: &str, dest: &Path, git_ref: Option<&str>) -> Result<(), GitError> {
+        if !Self::is_available() {
+            return Err(GitError::GitNotFound);
+        }
+
+        let mut cmd = Command::new("git");
+        cmd.arg("clone").arg("--depth").arg("1");
+
+        if let Some(ref_name) = git_ref {
+            cmd.arg("--branch").arg(ref_name);
+        }
+
+        cmd.arg(url).arg(dest);
+
+        let output = cmd.output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(GitError::CloneFailed(stderr));
+        }
+
+        Ok(())
+    }
+
+    /// Pull the latest changes for a repository
+    ///
+    /// For branches: runs `git pull`.
+    /// For tags/detached HEAD: runs `git fetch` + `git checkout <ref>`.
+    pub fn sync(repo_path: &Path, git_ref: Option<&str>) -> Result<(), GitError> {
+        if !Self::is_available() {
+            return Err(GitError::GitNotFound);
+        }
+
+        // Check for dirty working tree
+        if Self::is_dirty(repo_path)? {
+            return Err(GitError::DirtyWorkingTree);
+        }
+
+        // Fetch first
+        let fetch_output = Command::new("git")
+            .args(["fetch", "--depth", "1"])
+            .current_dir(repo_path)
+            .output()?;
+
+        if !fetch_output.status.success() {
+            let stderr = String::from_utf8_lossy(&fetch_output.stderr).to_string();
+            return Err(GitError::FetchFailed(stderr));
+        }
+
+        if let Some(ref_name) = git_ref {
+            // For a specific ref, fetch and checkout
+            let checkout_output = Command::new("git")
+                .args(["checkout", ref_name])
+                .current_dir(repo_path)
+                .output()?;
+
+            if !checkout_output.status.success() {
+                // Try as FETCH_HEAD for tags
+                let pull_output = Command::new("git")
+                    .args(["pull", "origin", ref_name])
+                    .current_dir(repo_path)
+                    .output()?;
+
+                if !pull_output.status.success() {
+                    let stderr = String::from_utf8_lossy(&pull_output.stderr).to_string();
+                    return Err(GitError::PullFailed(stderr));
+                }
+            }
+        } else {
+            // Default branch — just pull
+            let pull_output = Command::new("git")
+                .args(["pull"])
+                .current_dir(repo_path)
+                .output()?;
+
+            if !pull_output.status.success() {
+                let stderr = String::from_utf8_lossy(&pull_output.stderr).to_string();
+                return Err(GitError::PullFailed(stderr));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if the working tree has uncommitted changes
+    pub fn is_dirty(repo_path: &Path) -> Result<bool, GitError> {
+        let output = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(repo_path)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(GitError::CommandFailed(stderr));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(!stdout.trim().is_empty())
+    }
+
+    /// Get the current HEAD ref (branch name or commit hash)
+    pub fn current_ref(repo_path: &Path) -> Result<String, GitError> {
+        // Try symbolic-ref first (for branches)
+        let output = Command::new("git")
+            .args(["symbolic-ref", "--short", "HEAD"])
+            .current_dir(repo_path)
+            .output()?;
+
+        if output.status.success() {
+            let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            return Ok(branch);
+        }
+
+        // Fall back to rev-parse (for detached HEAD / tags)
+        let output = Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .current_dir(repo_path)
+            .output()?;
+
+        if output.status.success() {
+            let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Ok(hash)
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            Err(GitError::CommandFailed(stderr))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_git_is_available() {
+        // git should be available in the development environment
+        assert!(GitProvider::is_available());
+    }
+
+    #[test]
+    fn test_clone_invalid_url() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dest = temp.path().join("nonexistent-repo");
+        let result =
+            GitProvider::clone("https://example.invalid/nonexistent/repo.git", &dest, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_dirty_not_a_repo() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let result = GitProvider::is_dirty(temp.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_current_ref_not_a_repo() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let result = GitProvider::current_ref(temp.path());
+        assert!(result.is_err());
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -4,8 +4,10 @@
 //! - `winget`: Windows Package Manager for package installation
 //! - `filesystem`: File operations with backup and hashing
 //! - `script`: PowerShell script execution
+//! - `git`: Git operations for remote workload sources
 pub mod backup;
 pub mod filesystem;
+pub mod git;
 pub mod script;
 pub mod template;
 pub mod winget;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1040,3 +1040,110 @@ extends:
             .stdout(predicate::str::contains("child-workload"));
     }
 }
+
+mod source_command {
+    use super::*;
+
+    #[test]
+    fn source_list_succeeds() {
+        anvil().args(["source", "list"]).assert().success();
+    }
+
+    #[test]
+    fn source_list_json_output() {
+        anvil()
+            .args(["source", "list", "--output", "json"])
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn source_list_yaml_output() {
+        anvil()
+            .args(["source", "list", "--output", "yaml"])
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn source_status_succeeds() {
+        anvil().args(["source", "status"]).assert().success();
+    }
+
+    #[test]
+    fn source_status_json_output() {
+        anvil()
+            .args(["source", "status", "--output", "json"])
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn source_add_nonexistent_path_fails() {
+        anvil()
+            .args(["source", "add", "/nonexistent/path/that/does/not/exist"])
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn source_add_invalid_name_fails() {
+        let temp = TempDir::new().unwrap();
+        anvil()
+            .args([
+                "source",
+                "add",
+                temp.path().to_str().unwrap(),
+                "--name",
+                "../escape",
+            ])
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn source_remove_nonexistent_fails() {
+        anvil()
+            .args(["source", "remove", "nonexistent-source-name"])
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn source_sync_no_remote_sources() {
+        anvil().args(["source", "sync"]).assert().success();
+    }
+
+    #[test]
+    fn source_sync_nonexistent_name_fails() {
+        anvil()
+            .args(["source", "sync", "nonexistent-source-name"])
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn source_add_invalid_git_url_fails() {
+        anvil()
+            .args([
+                "source",
+                "add",
+                "https://example.invalid/nonexistent/repo.git",
+            ])
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn source_help_shows_subcommands() {
+        anvil()
+            .args(["source", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("list"))
+            .stdout(predicate::str::contains("add"))
+            .stdout(predicate::str::contains("remove"))
+            .stdout(predicate::str::contains("status"))
+            .stdout(predicate::str::contains("sync"));
+    }
+}


### PR DESCRIPTION
## Description

Add the `anvil source` command family for managing workload sources directly from the CLI, including support for remote git repositories.

### What's included

- **Source management CLI** (`anvil source list|add|remove|status|sync`) -- full subcommand suite for managing where Anvil discovers workloads
- **Local sources** -- add any local directory as a workload search path via `anvil source add <path>`
- **Remote git sources** -- clone git repos as workload sources via `anvil source add <git-url>`, with support for HTTPS/SSH URLs, branch/tag pinning (`--ref`), subdirectory scoping (`--path`), and custom naming (`--name`)
- **Sync workflow** -- `anvil source sync` pulls latest changes for remote sources; non-destructive (warns and skips dirty working trees)
- **Discovery integration** -- managed sources are automatically added to the workload search path (after user-configured paths, before defaults)
- **Source metadata** -- persisted in `~/.anvil/sources.json` as a single source of truth; remote repos cloned to `~/.anvil/sources/<name>/` using shallow clones
- **Git provider** -- new `providers::git` module using `std::process::Command` (no libgit2 dependency)
- **Safety** -- source names validated against strict charset (`[a-zA-Z0-9._-]`) to prevent path traversal

## Related Issues

Closes #54
Closes #55

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes (352 tests: 256 unit + 96 integration)
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)