### PR TITLE
feat: default TUI browser with Flexoki theme and tabbed detail view

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,47 @@
+name: Security Audit
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  audit:
+    name: Cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run audit
+        run: cargo audit
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Security audit: vulnerable dependencies found (${new Date().toISOString().slice(0, 10)})`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security',
+              per_page: 10,
+            });
+            const alreadyOpen = existing.data.some(i => i.title.startsWith('Security audit:'));
+            if (!alreadyOpen) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `The weekly \`cargo audit\` found vulnerable dependencies.\n\nSee the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.\n\nPlease review and update affected crates.`,
+                labels: ['security', 'dependencies'],
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -13,8 +17,70 @@ env:
   CARGO_HTTP_CHECK_REVOKE: false
 
 jobs:
-  validate:
-    name: Validate (${{ matrix.os }})
+  # ── Change detection ──────────────────────────────────────────────────────────
+  # Determines which component groups were modified so downstream jobs can skip
+  # irrelevant work on PRs. Push-to-main/develop always runs everything.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'src/**'
+              - 'tests/**'
+              - 'examples/**'
+              - 'Cargo.*'
+              - '.cargo/**'
+              - '.github/workflows/**'
+            docs:
+              - '**/*.md'
+              - 'docs/**'
+              - 'book.toml'
+              - 'site/**'
+              - 'scripts/build-site.sh'
+              - '.github/mlc_config.json'
+              - '.github/workflows/**'
+
+  # ── Rust checks ───────────────────────────────────────────────────────────────
+
+  fmt:
+    name: Formatting
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test (${{ matrix.os }})
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -23,21 +89,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}
-          cache-all-crates: true
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run unit tests
         run: cargo test --bin anvil --all-features
@@ -45,10 +101,34 @@ jobs:
       - name: Run integration tests
         run: cargo test --test cli_tests --all-features
 
+  msrv:
+    name: MSRV (1.75)
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.75
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+      - run: cargo check --all-features
+
+  audit:
+    name: Security audit
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Build
+    needs: [fmt, clippy, test]
     runs-on: windows-latest
-    needs: validate
     steps:
       - uses: actions/checkout@v6
 
@@ -72,8 +152,12 @@ jobs:
           path: target/release/anvil.exe
           retention-days: 7
 
+  # ── Documentation ─────────────────────────────────────────────────────────────
+
   docs:
     name: Documentation
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -102,14 +186,17 @@ jobs:
           chmod +x scripts/build-site.sh
           bash scripts/build-site.sh
 
+  # ── Summary gate ──────────────────────────────────────────────────────────────
+  # Single required status check for branch protection. Downstream jobs may be
+  # skipped (path filters) — that is OK; only failures or cancellations block.
   ci-pass:
     name: CI Pass
-    needs: [validate, build, docs]
     if: always()
+    needs: [changes, fmt, clippy, test, msrv, audit, build, docs]
     runs-on: ubuntu-latest
     steps:
-      - name: Check results
-        run: |
-          if [ "${{ needs.validate.result }}" != "success" ]; then exit 1; fi
-          if [ "${{ needs.build.result }}" != "success" ]; then exit 1; fi
-          if [ "${{ needs.docs.result }}" != "success" ]; then exit 1; fi
+      - name: Fail if any dependency failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - name: All checks passed
+        run: echo "All CI checks passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      publish_crates:
+        description: "Publish to crates.io"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -46,14 +53,13 @@ jobs:
         if: matrix.cross
         run: cargo install cross --locked
 
-      - name: Build release binary
-        run: |
-          if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
-        shell: bash
+      - name: Build release binary (native)
+        if: "!matrix.cross"
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build release binary (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Package binary (unix)
         if: runner.os != 'Windows'
@@ -84,6 +90,7 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v6
 
@@ -103,34 +110,46 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           MAJOR="${VERSION%%.*}"
           if [ "$MAJOR" = "0" ]; then
-            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            echo "flag=" >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          body: ${{ steps.extract.outputs.release_notes }}
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
+          files: artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --notes "${{ steps.extract.outputs.release_notes }}" \
-            ${{ steps.prerelease.outputs.flag }} \
-            artifacts/*
 
   publish:
     name: Publish to crates.io
     needs: release
     runs-on: ubuntu-latest
+    environment: crates-io
     steps:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Verify version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+            exit 1
+          fi
+
+      - name: Dry run
+        run: cargo publish --dry-run
+
       - name: Publish crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --no-verify
+        run: cargo publish
 
   winget:
     name: Publish to winget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- TUI workload browser launches by default when running `anvil` without a subcommand
+- Workload detail view with tabbed sections (Overview, Packages, Files, Commands, Config, Assertions) and ←/→ navigation
+- Install and dry-run actions directly from the TUI browser (`i` / `d` keybindings)
+- Branded `anvil │ …` header bar with breadcrumb navigation across all TUI views
+- Reusable chrome widget library (header, badge, gauge, heatmap, health bar, error block)
+- Two-column CONTENTS grid in the browser preview pane showing package, file, font, feature, command, and assertion counts
+- Bordered panes with rounded corners and hairline section dividers in the browser view
+- `SOURCE` and metadata sections in the browser detail preview
+
+### Changed
+
+- Replaced amber/gold TUI theme with Flexoki dark palette (ember red accent, section-colored icons)
+- Detail view uses tabbed navigation instead of collapsible sections
+- Health view shows inline heatmap per section and summary strip with pass/fail badge
+- Install dashboard shows overall progress gauge with phase chips and split body layout
+- Status dashboard uses stat blocks with branded header and system info
+- Browser list items show right-aligned version and package count columns
+- Replaced emoji icons with single-width ASCII characters for consistent terminal alignment
+- Key hints bar updated to show all available actions (`↵ open`, `h health`, etc.)
+
+### Fixed
+
+- Double keystroke registration on Windows by filtering for `KeyEventKind::Press` events only
+- Stale Enter keypress from command launch no longer triggers immediate TUI exit (input buffer drain)
+- Workload install/dry-run from TUI now uses actual filesystem path instead of searching only `<cwd>/workloads/`
+- Replaced deprecated `atty` crate with `std::io::IsTerminal` for TTY detection
+
 ## [1.2.0] - 2026-05-09
 
 ### Added

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -200,7 +200,7 @@ pub struct HealthArgs {
 }
 
 /// Arguments for the `list` command
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Default)]
 pub struct ListArgs {
     /// Include built-in and custom workloads
     #[arg(short, long)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,7 +16,6 @@ use clap::{Parser, Subcommand};
 #[command(name = "anvil")]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
-#[command(arg_required_else_help = true)]
 pub struct Cli {
     /// Increase output verbosity (can be repeated: -v, -vv, -vvv)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
@@ -35,7 +34,7 @@ pub struct Cli {
     pub no_color: bool,
 
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Option<Commands>,
 }
 
 /// Available commands
@@ -112,14 +111,14 @@ mod tests {
             quiet: false,
             config: None,
             no_color: false,
-            command: Commands::List(commands::ListArgs {
+            command: Some(Commands::List(commands::ListArgs {
                 all: false,
                 long: false,
                 path: None,
                 all_paths: false,
                 output: None,
                 no_tui: false,
-            }),
+            })),
         };
         assert_eq!(cli.verbosity_level(), 3);
     }
@@ -131,14 +130,14 @@ mod tests {
             quiet: true,
             config: None,
             no_color: false,
-            command: Commands::List(commands::ListArgs {
+            command: Some(Commands::List(commands::ListArgs {
                 all: false,
                 long: false,
                 path: None,
                 all_paths: false,
                 output: None,
                 no_tui: false,
-            }),
+            })),
         };
         assert_eq!(cli.verbosity_level(), 0);
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -313,6 +313,17 @@ impl ConfigManager {
                 .map(|p| p.winget.as_ref().map(|w| w.len()).unwrap_or(0))
                 .unwrap_or(0),
             file_count: workload.files.as_ref().map(|f| f.len()).unwrap_or(0),
+            command_count: workload
+                .commands
+                .as_ref()
+                .map(|c| {
+                    c.pre_install.as_ref().map(|v| v.len()).unwrap_or(0)
+                        + c.post_install.as_ref().map(|v| v.len()).unwrap_or(0)
+                })
+                .unwrap_or(0),
+            font_count: workload.fonts.as_ref().map(|f| f.len()).unwrap_or(0),
+            feature_count: workload.features.as_ref().map(|f| f.len()).unwrap_or(0),
+            assertion_count: workload.assertions.as_ref().map(|a| a.len()).unwrap_or(0),
             path: path.to_path_buf(),
             shadowed_paths: Vec::new(),
         })
@@ -340,6 +351,14 @@ pub struct WorkloadInfo {
     pub package_count: usize,
     /// Number of files
     pub file_count: usize,
+    /// Number of commands (pre + post install)
+    pub command_count: usize,
+    /// Number of fonts
+    pub font_count: usize,
+    /// Number of features
+    pub feature_count: usize,
+    /// Number of assertions
+    pub assertion_count: usize,
     /// Path to the workload file
     #[serde(skip_serializing)]
     pub path: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod providers;
 mod state;
 mod tui;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -38,8 +38,17 @@ fn main() -> Result<()> {
         tracing::debug!("Verbosity level: {}", cli.verbose);
     }
 
+    // When no subcommand is given, always launch the TUI workload browser
+    let command = match cli.command {
+        Some(ref cmd) => cmd,
+        None => {
+            launch_default_tui()?;
+            return Ok(());
+        }
+    };
+
     // Execute the requested command
-    match &cli.command {
+    match command {
         Commands::Install(args) => {
             operations::install::execute(args, &cli)?;
         }
@@ -79,6 +88,348 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Launch the TUI workload browser as the default experience
+///
+/// Called when `anvil` is run without any subcommand. Launches the
+/// ratatui-based interactive browser directly, falling back to help
+/// text only when stdin is not a terminal (e.g. piped or in CI).
+///
+/// When the user selects a workload, transitions to a detail view
+/// with collapsible sections. Pressing Esc returns to the browser.
+/// Pressing 'i' or 'd' exits the TUI and runs install or dry-run.
+fn launch_default_tui() -> Result<()> {
+    use std::io::IsTerminal;
+
+    if !std::io::stdin().is_terminal() {
+        use clap::CommandFactory;
+        Cli::command().print_help()?;
+        println!();
+        return Ok(());
+    }
+
+    use colored::Colorize;
+    use tui::views::browser::BrowserOutcome;
+    use tui::views::detail::DetailOutcome;
+
+    let mut manager = config::ConfigManager::new();
+    let workloads = manager
+        .list_workloads()
+        .context("Failed to discover workloads")?;
+
+    if workloads.is_empty() {
+        println!("{} No workloads found.", "ℹ".blue());
+        println!(
+            "  {} Create a workload with '{}'",
+            "→".dimmed(),
+            "anvil init <name>".cyan()
+        );
+        return Ok(());
+    }
+
+    let entries: Vec<tui::views::browser::WorkloadEntry> = workloads
+        .iter()
+        .map(|w| tui::views::browser::WorkloadEntry {
+            name: w.name.clone(),
+            version: w.version.clone(),
+            description: w.description.clone(),
+            extends: w.extends.clone(),
+            package_count: w.package_count,
+            file_count: w.file_count,
+            command_count: w.command_count,
+            font_count: w.font_count,
+            feature_count: w.feature_count,
+            assertion_count: w.assertion_count,
+            source: "local".to_string(),
+            path: w.path.to_string_lossy().to_string(),
+        })
+        .collect();
+
+    let mut browser = tui::views::browser::WorkloadBrowser::new(entries);
+
+    loop {
+        // Run the TUI phase (browser, and optionally detail) inside a
+        // scoped block so the Tui is dropped before any install runs.
+        let action = (|| -> Result<TuiAction> {
+            let mut tui_instance = tui::Tui::new()?;
+            browser.reset();
+
+            loop {
+                match browser.run(&mut tui_instance)? {
+                    BrowserOutcome::Quit => return Ok(TuiAction::Quit),
+                    BrowserOutcome::Install(name, path) => {
+                        return Ok(TuiAction::Install {
+                            name,
+                            path,
+                            dry_run: false,
+                        });
+                    }
+                    BrowserOutcome::DryRun(name, path) => {
+                        return Ok(TuiAction::Install {
+                            name,
+                            path,
+                            dry_run: true,
+                        });
+                    }
+                    BrowserOutcome::Select(selected_name) => {
+                        let detail = load_workload_detail(&mut manager, &selected_name);
+                        let mut detail_view = tui::views::detail::DetailView::new(detail);
+                        match detail_view.run(&mut tui_instance)? {
+                            DetailOutcome::Back => {
+                                // Return to browser
+                                browser.reset();
+                                continue;
+                            }
+                            DetailOutcome::Quit => return Ok(TuiAction::Quit),
+                            DetailOutcome::Install(name, path) => {
+                                return Ok(TuiAction::Install {
+                                    name,
+                                    path,
+                                    dry_run: false,
+                                });
+                            }
+                            DetailOutcome::DryRun(name, path) => {
+                                return Ok(TuiAction::Install {
+                                    name,
+                                    path,
+                                    dry_run: true,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        })();
+
+        match action {
+            Ok(TuiAction::Quit) => break,
+            Ok(TuiAction::Install {
+                name,
+                path,
+                dry_run,
+            }) => {
+                run_install_from_tui(&name, &path, dry_run)?;
+                // After install completes, prompt before re-entering the TUI
+                println!();
+                println!("Press Enter to return to the workload browser...");
+                let _ = std::io::stdin().read_line(&mut String::new());
+            }
+            Err(_) => {
+                // TUI failed to start — fall back to help text
+                use clap::CommandFactory;
+                Cli::command().print_help()?;
+                println!();
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Internal action returned by the TUI phase
+enum TuiAction {
+    Quit,
+    Install {
+        name: String,
+        path: String,
+        dry_run: bool,
+    },
+}
+
+/// Run `operations::install::execute` from the TUI using the workload's
+/// resolved filesystem path (not just the name) so it works regardless of
+/// which search path the workload lives in.
+fn run_install_from_tui(workload_name: &str, workload_path: &str, dry_run: bool) -> Result<()> {
+    let args = cli::commands::InstallArgs {
+        workload: workload_path.to_string(),
+        dry_run,
+        force: false,
+        packages_only: false,
+        skip_packages: false,
+        skip_files: false,
+        no_backup: false,
+        upgrade: false,
+        retry_failed: false,
+        parallel: false,
+        jobs: 4,
+        timeout: 3600,
+        files_only: false,
+        force_files: false,
+        no_tui: false,
+    };
+
+    let cli_instance = Cli {
+        command: None,
+        verbose: 0,
+        quiet: false,
+        no_color: false,
+        config: None,
+    };
+
+    operations::install::execute(&args, &cli_instance)
+        .with_context(|| format!("Failed to install workload '{}'", workload_name))
+}
+
+/// Build a `WorkloadDetail` from the full workload definition.
+///
+/// Tries to load the workload YAML via `ConfigManager`. If loading fails
+/// (e.g. the workload was discovered but can't be parsed), returns a
+/// minimal detail populated from the name alone.
+fn load_workload_detail(
+    manager: &mut config::ConfigManager,
+    name: &str,
+) -> tui::views::detail::WorkloadDetail {
+    let found_path = manager.find_workload(name);
+    let path_str = found_path
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let result = match found_path {
+        Some(p) => manager.load_workload(&p),
+        None => {
+            return tui::views::detail::WorkloadDetail {
+                name: name.to_string(),
+                version: "?".to_string(),
+                description: "Workload not found".to_string(),
+                extends: Vec::new(),
+                packages: Vec::new(),
+                files: Vec::new(),
+                commands: Vec::new(),
+                assertions: Vec::new(),
+                fonts: Vec::new(),
+                features: Vec::new(),
+                environment: Vec::new(),
+                path: String::new(),
+            };
+        }
+    };
+
+    match result {
+        Ok(w) => {
+            let packages: Vec<String> = w
+                .packages
+                .as_ref()
+                .and_then(|p| p.winget.as_ref())
+                .map(|pkgs| pkgs.iter().map(|p| p.id.clone()).collect())
+                .unwrap_or_default();
+
+            let files: Vec<tui::views::detail::FileEntry> = w
+                .files
+                .as_ref()
+                .map(|fs| {
+                    fs.iter()
+                        .map(|f| tui::views::detail::FileEntry {
+                            source: f.source.clone(),
+                            destination: f.destination.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let commands: Vec<tui::views::detail::CommandEntry> = {
+                let mut cmds = Vec::new();
+                if let Some(ref cb) = w.commands {
+                    if let Some(ref pre) = cb.pre_install {
+                        for c in pre {
+                            cmds.push(tui::views::detail::CommandEntry {
+                                name: c.description.clone().unwrap_or_else(|| c.run.clone()),
+                                phase: "pre_install".to_string(),
+                            });
+                        }
+                    }
+                    if let Some(ref post) = cb.post_install {
+                        for c in post {
+                            cmds.push(tui::views::detail::CommandEntry {
+                                name: c.description.clone().unwrap_or_else(|| c.run.clone()),
+                                phase: "post_install".to_string(),
+                            });
+                        }
+                    }
+                }
+                cmds
+            };
+
+            let assertions: Vec<String> = w
+                .assertions
+                .as_ref()
+                .map(|a| a.iter().map(|a| a.name.clone()).collect())
+                .unwrap_or_default();
+
+            let fonts: Vec<String> = w
+                .fonts
+                .as_ref()
+                .map(|fs| {
+                    fs.iter()
+                        .map(|f| format!("{} v{}", f.name, f.version))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let features: Vec<String> = w
+                .features
+                .as_ref()
+                .map(|fs| {
+                    fs.iter()
+                        .map(|f| {
+                            format!(
+                                "{} ({})",
+                                f.name,
+                                f.description.as_deref().unwrap_or(&f.feature_type)
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let environment: Vec<String> = {
+                let mut env = Vec::new();
+                if let Some(ref e) = w.environment {
+                    if let Some(ref vars) = e.variables {
+                        for v in vars {
+                            env.push(format!("{}={}", v.name, v.value));
+                        }
+                    }
+                    if let Some(ref paths) = e.path_additions {
+                        for p in paths {
+                            env.push(format!("PATH += {}", p));
+                        }
+                    }
+                }
+                env
+            };
+
+            tui::views::detail::WorkloadDetail {
+                name: w.name,
+                version: w.version,
+                description: w.description,
+                extends: w.extends.unwrap_or_default(),
+                packages,
+                files,
+                commands,
+                assertions,
+                fonts,
+                features,
+                environment,
+                path: path_str.clone(),
+            }
+        }
+        Err(_) => tui::views::detail::WorkloadDetail {
+            name: name.to_string(),
+            version: "?".to_string(),
+            description: "Failed to load workload details".to_string(),
+            extends: Vec::new(),
+            packages: Vec::new(),
+            files: Vec::new(),
+            commands: Vec::new(),
+            assertions: Vec::new(),
+            fonts: Vec::new(),
+            features: Vec::new(),
+            environment: Vec::new(),
+            path: path_str,
+        },
+    }
 }
 
 /// Initialize the logging/tracing subsystem

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -65,11 +65,21 @@ pub fn execute(args: &ListArgs, cli: &Cli) -> Result<()> {
                 extends: w.extends.clone(),
                 package_count: w.package_count,
                 file_count: w.file_count,
+                command_count: w.command_count,
+                font_count: w.font_count,
+                feature_count: w.feature_count,
+                assertion_count: w.assertion_count,
                 source: "local".to_string(),
+                path: w.path.to_string_lossy().to_string(),
             })
             .collect();
-        if let Some(selected) = crate::tui::views::browser::run_browser(entries)? {
-            println!("{}", selected);
+        match crate::tui::views::browser::run_browser(entries)? {
+            crate::tui::views::browser::BrowserOutcome::Select(name)
+            | crate::tui::views::browser::BrowserOutcome::Install(name, _)
+            | crate::tui::views::browser::BrowserOutcome::DryRun(name, _) => {
+                println!("{}", name);
+            }
+            crate::tui::views::browser::BrowserOutcome::Quit => {}
         }
         return Ok(());
     }

--- a/src/operations/show.rs
+++ b/src/operations/show.rs
@@ -41,7 +41,11 @@ pub fn execute(args: &ShowArgs, cli: &Cli) -> Result<()> {
 
     // TUI mode: interactive detail view when default format and TTY
     if !args.no_tui && args.output == ConfigOutputFormat::Yaml && crate::tui::should_use_tui() {
-        let detail = build_workload_detail(&workload);
+        let workload_path = manager
+            .find_workload(&args.workload)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let detail = build_workload_detail(&workload, &workload_path);
         crate::tui::views::detail::run_detail_view(detail)?;
         return Ok(());
     }
@@ -390,7 +394,10 @@ fn show_inheritance_tree(
 }
 
 /// Build a WorkloadDetail from a Workload for TUI display
-fn build_workload_detail(workload: &Workload) -> crate::tui::views::detail::WorkloadDetail {
+fn build_workload_detail(
+    workload: &Workload,
+    workload_path: &str,
+) -> crate::tui::views::detail::WorkloadDetail {
     let extends = workload.extends.as_deref().unwrap_or(&[]).to_vec();
 
     let packages: Vec<String> = workload
@@ -444,6 +451,49 @@ fn build_workload_detail(workload: &Workload) -> crate::tui::views::detail::Work
         .map(|a| a.iter().map(|ass| ass.name.clone()).collect())
         .unwrap_or_default();
 
+    let fonts: Vec<String> = workload
+        .fonts
+        .as_ref()
+        .map(|fs| {
+            fs.iter()
+                .map(|f| format!("{} v{}", f.name, f.version))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let features: Vec<String> = workload
+        .features
+        .as_ref()
+        .map(|fs| {
+            fs.iter()
+                .map(|f| {
+                    format!(
+                        "{} ({})",
+                        f.name,
+                        f.description.as_deref().unwrap_or(&f.feature_type)
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let environment: Vec<String> = {
+        let mut env = Vec::new();
+        if let Some(ref e) = workload.environment {
+            if let Some(ref vars) = e.variables {
+                for v in vars {
+                    env.push(format!("{}={}", v.name, v.value));
+                }
+            }
+            if let Some(ref paths) = e.path_additions {
+                for p in paths {
+                    env.push(format!("PATH += {}", p));
+                }
+            }
+        }
+        env
+    };
+
     crate::tui::views::detail::WorkloadDetail {
         name: workload.name.clone(),
         version: workload.version.clone(),
@@ -453,6 +503,10 @@ fn build_workload_detail(workload: &Workload) -> crate::tui::views::detail::Work
         files,
         commands,
         assertions,
+        fonts,
+        features,
+        environment,
+        path: workload_path.to_string(),
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -14,7 +14,7 @@ use std::io::{self, Stdout};
 
 use anyhow::{Context, Result};
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     execute,
     terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -24,7 +24,8 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 ///
 /// Returns true when both stdout and stdin are TTYs.
 pub fn should_use_tui() -> bool {
-    atty::is(atty::Stream::Stdout) && atty::is(atty::Stream::Stdin)
+    use std::io::IsTerminal;
+    io::stdout().is_terminal() && io::stdin().is_terminal()
 }
 
 /// Terminal wrapper that manages setup/teardown of the raw terminal
@@ -51,6 +52,14 @@ impl Tui {
         let backend = CrosstermBackend::new(stdout);
         let terminal = Terminal::new(backend).context("Failed to create terminal")?;
 
+        // Drain any input events already in the console buffer (e.g., the
+        // Enter key the user pressed to launch the command). Without this,
+        // the first poll in the event loop would pick up stale keypresses
+        // and act on them immediately.
+        while event::poll(std::time::Duration::from_millis(50)).unwrap_or(false) {
+            let _ = event::read();
+        }
+
         Ok(Self {
             terminal,
             restored: false,
@@ -66,12 +75,21 @@ impl Tui {
         Ok(())
     }
 
-    /// Poll for a crossterm event with timeout
+    /// Poll for a crossterm key-press event with timeout
     ///
     /// Returns `None` if no event is available within the timeout.
+    /// Only returns `KeyEventKind::Press` events — release and repeat
+    /// events are silently consumed to prevent double-registration on
+    /// Windows, where every physical keypress produces both a press
+    /// and a release event.
     pub fn poll_event(&self, timeout: std::time::Duration) -> Result<Option<Event>> {
         if event::poll(timeout).context("Failed to poll for event")? {
             let evt = event::read().context("Failed to read event")?;
+            if let Event::Key(ref key) = evt {
+                if key.kind != KeyEventKind::Press {
+                    return Ok(None);
+                }
+            }
             Ok(Some(evt))
         } else {
             Ok(None)

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,6 +1,10 @@
 //! Color theme for the Anvil TUI
 //!
-//! Defines the forge-branded color palette used across all TUI views.
+//! Forge-branded palette built on the kafkade "Flexoki" design system
+//! (dark mode). Ember red is the single dominant accent; the remaining
+//! hues are used sparingly for status, section identity, and metadata.
+//!
+//! Source tokens: kafkade colors_and_type.css → [data-theme="dark"].
 
 use ratatui::style::{Color, Modifier, Style};
 
@@ -8,84 +12,238 @@ use ratatui::style::{Color, Modifier, Style};
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Theme {
-    /// Primary foreground
-    pub fg: Color,
-    /// Primary background
+    // ---- surfaces ----
+    /// Page background (terminal default — keeps user's transparency/theme)
     pub bg: Color,
-    /// Accent color (for highlights, borders)
-    pub accent: Color,
-    /// Success indicator
-    pub success: Color,
-    /// Warning indicator
-    pub warning: Color,
-    /// Error indicator
-    pub error: Color,
-    /// Muted/dimmed text
+    /// Secondary surface (header bars, footers)
+    pub bg_alt: Color,
+    /// Inset surface (code, inline highlight, gauge track)
+    pub bg_inset: Color,
+
+    // ---- text ----
+    /// Primary text
+    pub fg: Color,
+    /// Secondary / body text
+    pub ink2: Color,
+    /// Muted meta text (dates, captions, counts)
     pub muted: Color,
-    /// Border color
+    /// Faint text (disabled, pending, end-marks)
+    pub faint: Color,
+
+    // ---- structure ----
+    /// Structural border
     pub border: Color,
-    /// Running/active indicator
-    pub running: Color,
-    /// Title/header text
-    pub title: Color,
+    /// Hairline rule / row divider
+    pub hairline: Color,
+
+    // ---- accent ----
+    /// THE brand accent — ember red. Links, selection, active, primary.
+    pub accent: Color,
+    /// Text/ink on an accent fill
+    pub accent_ink: Color,
+
+    // ---- status / section hues (Flexoki 400-level for dark) ----
+    pub success: Color, // green   — pass / installed / stable
+    pub warning: Color, // yellow  — warn / partial / alpha
+    pub error: Color,   // red     — fail (== accent, intentional)
+    pub running: Color, // cyan    — in-progress / tags
+    pub info: Color,    // blue    — files / informational
+    pub special: Color, // orange  — commands / emphasis
+    pub alt: Color,     // purple  — fonts / secondary category
+    pub title: Color,   // warm-white titles
 }
 
 #[allow(dead_code)]
 impl Theme {
-    /// Dark theme — forge branding (molten gradient palette)
+    /// Dark theme — kafkade Flexoki dark + ember accent
     pub fn dark() -> Self {
         Self {
-            fg: Color::White,
+            // surfaces
             bg: Color::Reset,
-            accent: Color::Rgb(253, 224, 71), // amber/gold
-            success: Color::Green,
-            warning: Color::Yellow,
-            error: Color::Red,
-            muted: Color::DarkGray,
-            border: Color::DarkGray,
-            running: Color::Cyan,
-            title: Color::Rgb(254, 243, 199), // warm white
+            bg_alt: Color::Rgb(0x1C, 0x1B, 0x1A),
+            bg_inset: Color::Rgb(0x28, 0x27, 0x26),
+            // text
+            fg: Color::Rgb(0xCE, 0xCD, 0xC3),
+            ink2: Color::Rgb(0xB7, 0xB5, 0xAC),
+            muted: Color::Rgb(0x87, 0x85, 0x80),
+            faint: Color::Rgb(0x57, 0x56, 0x53),
+            // structure
+            border: Color::Rgb(0x40, 0x3E, 0x3C),
+            hairline: Color::Rgb(0x34, 0x33, 0x31),
+            // accent
+            accent: Color::Rgb(0xD1, 0x4D, 0x41),
+            accent_ink: Color::Rgb(0x10, 0x0F, 0x0F),
+            // status / section
+            success: Color::Rgb(0x87, 0x9A, 0x39),
+            warning: Color::Rgb(0xD0, 0xA2, 0x15),
+            error: Color::Rgb(0xD1, 0x4D, 0x41),
+            running: Color::Rgb(0x3A, 0xA9, 0x9F),
+            info: Color::Rgb(0x43, 0x85, 0xBE),
+            special: Color::Rgb(0xDA, 0x76, 0x35),
+            alt: Color::Rgb(0x8B, 0x7E, 0xC8),
+            title: Color::Rgb(0xCE, 0xCD, 0xC3),
         }
     }
 
-    /// Style for normal text
+    // ---------------------------------------------------------------
+    // Text styles
+    // ---------------------------------------------------------------
+
+    /// Normal body text
     pub fn normal(&self) -> Style {
         Style::default().fg(self.fg)
     }
 
-    /// Style for muted/dimmed text
+    /// Secondary body text
+    pub fn body(&self) -> Style {
+        Style::default().fg(self.ink2)
+    }
+
+    /// Muted / dimmed meta text
     pub fn dimmed(&self) -> Style {
         Style::default().fg(self.muted)
     }
 
-    /// Style for success text
+    /// Faint text (pending, disabled)
+    pub fn faint_style(&self) -> Style {
+        Style::default().fg(self.faint)
+    }
+
+    /// Success text (green)
     pub fn success_style(&self) -> Style {
         Style::default().fg(self.success)
     }
 
-    /// Style for error text
+    /// Error text (ember)
     pub fn error_style(&self) -> Style {
         Style::default().fg(self.error)
     }
 
-    /// Style for warning text
+    /// Warning text (yellow)
     pub fn warning_style(&self) -> Style {
         Style::default().fg(self.warning)
     }
 
-    /// Style for running/active text
+    /// Running / active text (cyan)
     pub fn running_style(&self) -> Style {
         Style::default().fg(self.running)
     }
 
-    /// Style for titles
+    /// Accent text (ember)
+    pub fn accent_style(&self) -> Style {
+        Style::default().fg(self.accent)
+    }
+
+    /// Bold accent — used for the `anvil` wordmark and active emphasis
+    pub fn brand_style(&self) -> Style {
+        Style::default()
+            .fg(self.accent)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Title text (bold)
     pub fn title_style(&self) -> Style {
         Style::default().fg(self.title).add_modifier(Modifier::BOLD)
     }
 
-    /// Style for borders
+    /// Uppercase section label (muted, used as group dividers)
+    pub fn label_style(&self) -> Style {
+        Style::default().fg(self.muted)
+    }
+
+    // ---------------------------------------------------------------
+    // Selection / highlight
+    // ---------------------------------------------------------------
+
+    /// Selected row — subtle ember wash + ember text (no full inversion).
+    /// Pair with a `▌` accent prefix Span for the left border effect.
+    pub fn selection(&self) -> Style {
+        Style::default()
+            .fg(self.accent)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Strong selection (full fill) — for list pickers where contrast matters.
+    pub fn selection_filled(&self) -> Style {
+        Style::default().bg(self.accent).fg(self.accent_ink)
+    }
+
+    // ---------------------------------------------------------------
+    // Borders
+    // ---------------------------------------------------------------
+
+    /// Resting border
     pub fn border_style(&self) -> Style {
         Style::default().fg(self.border)
+    }
+
+    /// Focused border (ember)
+    pub fn border_focused(&self) -> Style {
+        Style::default().fg(self.accent)
+    }
+
+    // ---------------------------------------------------------------
+    // Section identity colors (Detail / Browser breakdown)
+    // ---------------------------------------------------------------
+
+    /// Color for a workload section by kind. Keeps section identity
+    /// consistent across Browser breakdown, Detail tabs, and Health.
+    pub fn section_color(&self, kind: SectionKind) -> Color {
+        match kind {
+            SectionKind::Packages => self.running, // cyan
+            SectionKind::Files => self.info,       // blue
+            SectionKind::Commands => self.special, // orange
+            SectionKind::Fonts => self.alt,        // purple
+            SectionKind::Features => self.warning, // yellow
+            SectionKind::Environment => self.muted,
+            SectionKind::Assertions => self.success, // green
+            SectionKind::Inheritance => self.muted,
+        }
+    }
+}
+
+/// Identifies a workload section for consistent coloring & icons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum SectionKind {
+    Inheritance,
+    Packages,
+    Files,
+    Commands,
+    Fonts,
+    Features,
+    Environment,
+    Assertions,
+}
+
+#[allow(dead_code)]
+impl SectionKind {
+    /// A single-glyph icon for the section (terminal-safe).
+    pub fn icon(self) -> &'static str {
+        match self {
+            SectionKind::Inheritance => "~",
+            SectionKind::Packages => "#",
+            SectionKind::Files => "=",
+            SectionKind::Commands => ">",
+            SectionKind::Fonts => "A",
+            SectionKind::Features => "*",
+            SectionKind::Environment => "$",
+            SectionKind::Assertions => "+",
+        }
+    }
+
+    /// Human label.
+    pub fn label(self) -> &'static str {
+        match self {
+            SectionKind::Inheritance => "Inheritance",
+            SectionKind::Packages => "Packages",
+            SectionKind::Files => "Files",
+            SectionKind::Commands => "Commands",
+            SectionKind::Fonts => "Fonts",
+            SectionKind::Features => "Features",
+            SectionKind::Environment => "Environment",
+            SectionKind::Assertions => "Assertions",
+        }
     }
 }
 
@@ -100,11 +258,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_dark_theme_colors() {
+    fn test_dark_theme_accent_is_ember() {
         let theme = Theme::dark();
-        assert_eq!(theme.fg, Color::White);
-        assert_eq!(theme.success, Color::Green);
-        assert_eq!(theme.error, Color::Red);
+        assert_eq!(theme.accent, Color::Rgb(0xD1, 0x4D, 0x41));
+        assert_eq!(theme.error, theme.accent); // fail == accent, intentional
     }
 
     #[test]
@@ -112,5 +269,15 @@ mod tests {
         let theme = Theme::dark();
         assert_ne!(theme.success_style(), theme.error_style());
         assert_ne!(theme.dimmed(), theme.normal());
+        assert_ne!(theme.border_style(), theme.border_focused());
+    }
+
+    #[test]
+    fn test_section_colors_distinct() {
+        let theme = Theme::dark();
+        assert_ne!(
+            theme.section_color(SectionKind::Packages),
+            theme.section_color(SectionKind::Files)
+        );
     }
 }

--- a/src/tui/views/browser.rs
+++ b/src/tui/views/browser.rs
@@ -8,18 +8,20 @@ use std::time::Duration;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{
+        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+    },
     Frame,
 };
 
-use crate::tui::theme::Theme;
+use crate::tui::theme::{SectionKind, Theme};
+use crate::tui::widgets::chrome::render_header;
 use crate::tui::widgets::keyhints::{render_keyhints, KeyHint};
 use crate::tui::Tui;
 
 /// A single workload entry for the browser
-#[allow(dead_code)]
 pub struct WorkloadEntry {
     pub name: String,
     pub version: String,
@@ -27,7 +29,47 @@ pub struct WorkloadEntry {
     pub extends: Vec<String>,
     pub package_count: usize,
     pub file_count: usize,
+    pub command_count: usize,
+    pub font_count: usize,
+    pub feature_count: usize,
+    pub assertion_count: usize,
     pub source: String,
+    /// Filesystem path to the workload.yaml file
+    pub path: String,
+}
+
+/// The result of running the browser view
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BrowserOutcome {
+    /// User quit the browser (q / Ctrl+C)
+    Quit,
+    /// User selected a workload to view details
+    Select(String),
+    /// User requested install of a workload (name, path)
+    Install(String, String),
+    /// User requested dry-run of a workload (name, path)
+    DryRun(String, String),
+}
+
+/// Browser layout mode for the list + preview panes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserLayoutMode {
+    /// Auto-detect based on terminal width
+    Auto,
+    /// Force side-by-side (list left, details right)
+    Horizontal,
+    /// Force stacked (list top, details bottom)
+    Vertical,
+}
+
+impl BrowserLayoutMode {
+    fn next(self) -> Self {
+        match self {
+            Self::Auto => Self::Horizontal,
+            Self::Horizontal => Self::Vertical,
+            Self::Vertical => Self::Auto,
+        }
+    }
 }
 
 /// Interactive workload browser state
@@ -38,8 +80,9 @@ pub struct WorkloadBrowser {
     search_query: String,
     searching: bool,
     quit: bool,
-    confirmed: bool,
+    outcome: Option<BrowserOutcome>,
     theme: Theme,
+    layout_mode: BrowserLayoutMode,
 }
 
 impl WorkloadBrowser {
@@ -53,8 +96,9 @@ impl WorkloadBrowser {
             search_query: String::new(),
             searching: false,
             quit: false,
-            confirmed: false,
+            outcome: None,
             theme: Theme::dark(),
+            layout_mode: BrowserLayoutMode::Auto,
         }
     }
 
@@ -63,11 +107,13 @@ impl WorkloadBrowser {
         match key.code {
             // Ctrl+C always quits
             KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
+                self.outcome = Some(BrowserOutcome::Quit);
                 self.quit = true;
             }
 
             // q quits only when not searching
             KeyCode::Char('q') if key.modifiers == KeyModifiers::NONE && !self.searching => {
+                self.outcome = Some(BrowserOutcome::Quit);
                 self.quit = true;
             }
 
@@ -103,9 +149,31 @@ impl WorkloadBrowser {
                 if self.searching {
                     self.searching = false;
                 } else if !self.filtered.is_empty() {
-                    self.confirmed = true;
+                    let name = self.focused_name().unwrap();
+                    self.outcome = Some(BrowserOutcome::Select(name));
                     self.quit = true;
                 }
+            }
+
+            // Install focused workload
+            KeyCode::Char('i') if key.modifiers == KeyModifiers::NONE && !self.searching => {
+                if let Some((name, path)) = self.focused_name_and_path() {
+                    self.outcome = Some(BrowserOutcome::Install(name, path));
+                    self.quit = true;
+                }
+            }
+
+            // Dry-run focused workload
+            KeyCode::Char('d') if key.modifiers == KeyModifiers::NONE && !self.searching => {
+                if let Some((name, path)) = self.focused_name_and_path() {
+                    self.outcome = Some(BrowserOutcome::DryRun(name, path));
+                    self.quit = true;
+                }
+            }
+
+            // Toggle layout mode
+            KeyCode::Tab if !self.searching => {
+                self.layout_mode = self.layout_mode.next();
             }
 
             // Search input
@@ -148,9 +216,9 @@ impl WorkloadBrowser {
         self.quit
     }
 
-    /// Returns the name of the confirmed workload, if any
-    pub fn selected_name(&self) -> Option<String> {
-        if self.confirmed && !self.filtered.is_empty() {
+    /// Returns the name of the currently focused workload, if any
+    fn focused_name(&self) -> Option<String> {
+        if !self.filtered.is_empty() {
             let idx = self.filtered[self.selected];
             Some(self.workloads[idx].name.clone())
         } else {
@@ -158,64 +226,145 @@ impl WorkloadBrowser {
         }
     }
 
+    /// Returns the (name, path) of the currently focused workload, if any
+    fn focused_name_and_path(&self) -> Option<(String, String)> {
+        if !self.filtered.is_empty() {
+            let idx = self.filtered[self.selected];
+            let e = &self.workloads[idx];
+            Some((e.name.clone(), e.path.clone()))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the outcome after the browser exits
+    pub fn outcome(&self) -> BrowserOutcome {
+        self.outcome.clone().unwrap_or(BrowserOutcome::Quit)
+    }
+
     /// Render the browser view
     pub fn render(&self, frame: &mut Frame) {
         let area = frame.area();
 
         let outer = Layout::vertical([
-            Constraint::Length(3), // title
+            Constraint::Length(1), // branded header bar
             Constraint::Min(1),    // main content
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
-        self.render_title(frame, outer[0]);
+        render_header(
+            frame,
+            outer[0],
+            &self.theme,
+            &["Workload Browser"],
+            Some(Line::from(vec![Span::styled(
+                format!("{} workloads", self.workloads.len()),
+                self.theme.dimmed(),
+            )])),
+        );
         self.render_main(frame, outer[1]);
         self.render_keyhints(frame, outer[2]);
     }
 
-    /// Render the title bar
-    fn render_title(&self, frame: &mut Frame, area: Rect) {
-        let block = Block::default()
-            .title(Span::styled(
-                " Anvil — Workload Browser ",
-                self.theme.title_style(),
-            ))
-            .borders(Borders::ALL)
-            .border_style(self.theme.border_style());
-        frame.render_widget(block, area);
+    /// Minimum terminal width for side-by-side (horizontal) layout.
+    /// Below this, the list and detail panes stack vertically.
+    const MIN_HORIZONTAL_WIDTH: u16 = 100;
+
+    /// Whether the effective layout is horizontal for the given width
+    fn is_horizontal(&self, width: u16) -> bool {
+        match self.layout_mode {
+            BrowserLayoutMode::Auto => width >= Self::MIN_HORIZONTAL_WIDTH,
+            BrowserLayoutMode::Horizontal => true,
+            BrowserLayoutMode::Vertical => false,
+        }
     }
 
     /// Render the main two-pane area
     fn render_main(&self, frame: &mut Frame, area: Rect) {
-        let panes = Layout::horizontal([Constraint::Percentage(60), Constraint::Percentage(40)])
+        if self.is_horizontal(area.width) {
+            // Wide: side-by-side with a 1-col gap between panes
+            let panes = Layout::horizontal([
+                Constraint::Percentage(45),
+                Constraint::Length(1), // divider column
+                Constraint::Percentage(55),
+            ])
             .split(area);
 
-        self.render_list(frame, panes[0]);
-        self.render_preview(frame, panes[1]);
+            self.render_list(frame, panes[0]);
+
+            // Vertical divider line
+            let divider_lines: Vec<Line> = (0..panes[1].height)
+                .map(|_| Line::from(Span::styled("│", self.theme.border_style())))
+                .collect();
+            frame.render_widget(Paragraph::new(divider_lines), panes[1]);
+
+            self.render_preview(frame, panes[2]);
+        } else {
+            // Narrow: stacked with a 1-row divider
+            let panes = Layout::vertical([
+                Constraint::Percentage(50),
+                Constraint::Length(1), // divider row
+                Constraint::Percentage(50),
+            ])
+            .split(area);
+
+            self.render_list(frame, panes[0]);
+
+            // Horizontal divider
+            let divider_text = "─".repeat(panes[1].width as usize);
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    divider_text,
+                    self.theme.border_style(),
+                ))),
+                panes[1],
+            );
+
+            self.render_preview(frame, panes[2]);
+        }
     }
 
     /// Render the workload list (left pane)
     fn render_list(&self, frame: &mut Frame, area: Rect) {
-        let title = if self.searching {
-            format!(
-                "Workloads ({}) \u{1F50D} {}",
-                self.filtered.len(),
-                self.search_query
-            )
-        } else {
-            format!("Workloads ({})", self.filtered.len())
-        };
-
+        // Bordered block for the list pane
         let block = Block::default()
-            .title(Span::styled(title, self.theme.normal()))
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(self.theme.border_style());
-
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let visible_height = inner.height as usize;
+        // Split: search bar (1 line) + gap (1 line) + list items
+        let chunks = Layout::vertical([
+            Constraint::Length(1), // search bar
+            Constraint::Length(1), // padding below search
+            Constraint::Min(1),    // list items
+        ])
+        .split(inner);
+
+        // Search bar with bg_inset
+        let search_text = if self.searching {
+            format!("/ {}", self.search_query)
+        } else {
+            "/ Search workloads...".to_string()
+        };
+        let search_style = if self.searching {
+            self.theme.normal()
+        } else {
+            self.theme.faint_style()
+        };
+        let search_bar = Paragraph::new(Line::from(Span::styled(
+            format!(" {}", search_text),
+            search_style,
+        )))
+        .style(Style::default().bg(self.theme.bg_inset));
+        frame.render_widget(search_bar, chunks[0]);
+
+        // List items area
+        let list_area = chunks[2];
+        let visible_height = list_area.height as usize;
+        let list_width = list_area.width as usize;
 
         // Compute scroll so the selected item is always visible
         let scroll_offset = if self.selected >= visible_height {
@@ -232,20 +381,80 @@ impl WorkloadBrowser {
             .take(visible_height)
             .map(|(i, &idx)| {
                 let entry = &self.workloads[idx];
-                let style = if i == self.selected {
-                    Style::default()
-                        .bg(self.theme.accent)
-                        .fg(Color::Black)
-                        .add_modifier(Modifier::BOLD)
+
+                // Build right-side info: "V1.0.0  ☁ N pkg"
+                let version_text = format!("V{}", entry.version);
+                let remote_icon = if entry.source == "remote" { " ☁" } else { "" };
+                let pkg_text = format!("{} pkg", entry.package_count);
+                let right_text = format!("{}{}  {}", version_text, remote_icon, pkg_text);
+                let right_len = right_text.len();
+
+                // Name gets the remaining space (minus prefix + right + gap)
+                let prefix_len = 2; // "▌ " or "  "
+                let gap = 2;
+                let name_max = list_width.saturating_sub(prefix_len + right_len + gap);
+                let name_display = if entry.name.len() > name_max && name_max > 3 {
+                    format!("{}…", &entry.name[..name_max.saturating_sub(1)])
                 } else {
-                    self.theme.normal()
+                    entry.name.clone()
                 };
-                Line::styled(format!("  {}", entry.name), style)
+                let name_pad = name_max.saturating_sub(name_display.len());
+
+                if i == self.selected {
+                    Line::from(vec![
+                        Span::styled("▌", Style::default().fg(self.theme.accent)),
+                        Span::styled(
+                            format!(" {}{}", name_display, " ".repeat(name_pad)),
+                            self.theme.selection().bg(self.theme.bg_inset),
+                        ),
+                        Span::styled(
+                            format!("  {}", version_text),
+                            Style::default()
+                                .fg(self.theme.muted)
+                                .bg(self.theme.bg_inset)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        if !remote_icon.is_empty() {
+                            Span::styled(
+                                " ☁",
+                                Style::default().fg(self.theme.info).bg(self.theme.bg_inset),
+                            )
+                        } else {
+                            Span::styled("", Style::default().bg(self.theme.bg_inset))
+                        },
+                        Span::styled(
+                            format!("  {}", pkg_text),
+                            Style::default()
+                                .fg(self.theme.muted)
+                                .bg(self.theme.bg_inset),
+                        ),
+                    ])
+                } else {
+                    Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(
+                            format!("{}{}", name_display, " ".repeat(name_pad)),
+                            self.theme.normal(),
+                        ),
+                        Span::styled(
+                            format!("  {}", version_text),
+                            Style::default()
+                                .fg(self.theme.faint)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        if entry.source == "remote" {
+                            Span::styled(" ☁", Style::default().fg(self.theme.info))
+                        } else {
+                            Span::raw("")
+                        },
+                        Span::styled(format!("  {}", pkg_text), self.theme.faint_style()),
+                    ])
+                }
             })
             .collect();
 
         let paragraph = Paragraph::new(lines);
-        frame.render_widget(paragraph, inner);
+        frame.render_widget(paragraph, list_area);
 
         // Scrollbar
         let total = self.filtered.len();
@@ -253,17 +462,17 @@ impl WorkloadBrowser {
             let max_scroll = total.saturating_sub(visible_height);
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
             let mut scrollbar_state = ScrollbarState::new(max_scroll).position(scroll_offset);
-            frame.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+            frame.render_stateful_widget(scrollbar, list_area, &mut scrollbar_state);
         }
     }
 
     /// Render the detail preview (right pane)
     fn render_preview(&self, frame: &mut Frame, area: Rect) {
+        // Bordered block for the preview pane
         let block = Block::default()
-            .title(Span::styled("Details", self.theme.normal()))
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(self.theme.border_style());
-
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
@@ -277,47 +486,189 @@ impl WorkloadBrowser {
         let entry = &self.workloads[idx];
 
         let mut lines: Vec<Line> = Vec::new();
-        lines.push(Line::raw(""));
-        lines.push(Line::from(vec![Span::styled(
-            format!("  {}", entry.name),
-            self.theme.title_style(),
-        )]));
-        lines.push(Line::raw(""));
-        lines.push(Line::from(vec![
-            Span::styled("  Version: ", self.theme.dimmed()),
-            Span::styled(&entry.version, self.theme.normal()),
-        ]));
-        lines.push(Line::raw(""));
-        lines.push(Line::from(vec![
-            Span::styled("  Description: ", self.theme.dimmed()),
-            Span::styled(&entry.description, self.theme.normal()),
-        ]));
+
+        // Top padding
         lines.push(Line::raw(""));
 
-        if !entry.extends.is_empty() {
-            lines.push(Line::from(vec![
-                Span::styled("  Extends: ", self.theme.dimmed()),
-                Span::styled(entry.extends.join(", "), self.theme.normal()),
-            ]));
+        // Name + version badge + source badge
+        let source_label = entry.source.to_uppercase();
+        let source_color = if entry.source == "remote" {
+            self.theme.info
+        } else {
+            self.theme.success
+        };
+        lines.push(Line::from(vec![
+            Span::styled(&entry.name, self.theme.title_style()),
+            Span::styled(
+                format!("  V{}", entry.version),
+                Style::default()
+                    .fg(self.theme.faint)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  {} ", source_label),
+                Style::default()
+                    .fg(source_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+
+        // Description (wrapped across lines)
+        if !entry.description.is_empty() {
             lines.push(Line::raw(""));
+            let max_width = inner.width.saturating_sub(2) as usize;
+            let desc = &entry.description;
+            if max_width == 0 || desc.len() <= max_width {
+                lines.push(Line::from(Span::styled(desc.as_str(), self.theme.body())));
+            } else {
+                let mut remaining = desc.as_str();
+                while !remaining.is_empty() {
+                    if remaining.len() <= max_width {
+                        lines.push(Line::from(Span::styled(remaining, self.theme.body())));
+                        break;
+                    }
+                    let split_at = remaining[..max_width].rfind(' ').unwrap_or(max_width);
+                    lines.push(Line::from(Span::styled(
+                        &remaining[..split_at],
+                        self.theme.body(),
+                    )));
+                    remaining = remaining[split_at..].trim_start();
+                }
+            }
         }
 
-        lines.push(Line::from(vec![
-            Span::styled("  Packages: ", self.theme.dimmed()),
-            Span::styled(entry.package_count.to_string(), self.theme.normal()),
-        ]));
-        lines.push(Line::from(vec![
-            Span::styled("  Files: ", self.theme.dimmed()),
-            Span::styled(entry.file_count.to_string(), self.theme.normal()),
-        ]));
+        // Hairline divider helper
+        let divider_width = inner.width.saturating_sub(2) as usize;
+        let hairline = Line::from(Span::styled(
+            "─".repeat(divider_width),
+            Style::default().fg(self.theme.hairline),
+        ));
+
+        // ── SOURCE ──
+        lines.push(Line::raw(""));
+        lines.push(hairline.clone());
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled("SOURCE", self.theme.label_style())));
+        lines.push(Line::raw(""));
+        let source_icon = if entry.source == "remote" {
+            "☁"
+        } else {
+            "📁"
+        };
+        let source_style = if entry.source == "remote" {
+            self.theme.running_style()
+        } else {
+            self.theme.success_style()
+        };
+        lines.push(Line::from(vec![Span::styled(
+            format!("{} {}", source_icon, entry.source),
+            source_style,
+        )]));
+        lines.push(Line::from(Span::styled(
+            &entry.path,
+            self.theme.running_style(),
+        )));
+
+        // ── CONTENTS ──
+        lines.push(Line::raw(""));
+        lines.push(hairline.clone());
+        lines.push(Line::raw(""));
+        lines.push(Line::from(Span::styled(
+            "CONTENTS",
+            self.theme.label_style(),
+        )));
+        lines.push(Line::raw(""));
+
+        // Row 1: Packages + Fonts
+        let row1 = self.contents_row(
+            SectionKind::Packages,
+            entry.package_count,
+            SectionKind::Fonts,
+            entry.font_count,
+        );
+        lines.push(row1);
+
+        // Row 2: Files + Features
+        let row2 = self.contents_row(
+            SectionKind::Files,
+            entry.file_count,
+            SectionKind::Features,
+            entry.feature_count,
+        );
+        lines.push(row2);
+
+        // Row 3: Commands + Assertions
+        let row3 = self.contents_row(
+            SectionKind::Commands,
+            entry.command_count,
+            SectionKind::Assertions,
+            entry.assertion_count,
+        );
+        lines.push(row3);
+
+        // ── META ──
+        lines.push(Line::raw(""));
+        lines.push(hairline);
         lines.push(Line::raw(""));
         lines.push(Line::from(vec![
-            Span::styled("  Source: ", self.theme.dimmed()),
-            Span::styled(&entry.source, self.theme.normal()),
+            Span::styled("Last installed  ", self.theme.label_style()),
+            Span::styled("Extends  ", self.theme.label_style()),
+        ]));
+        let extends_text = if entry.extends.is_empty() {
+            "None".to_string()
+        } else {
+            entry.extends.join(", ")
+        };
+        lines.push(Line::from(vec![
+            Span::styled("—               ", self.theme.faint_style()),
+            Span::styled(extends_text, self.theme.normal()),
         ]));
 
+        // Render with left padding inside the block
+        let padded = Rect {
+            x: inner.x + 1,
+            y: inner.y,
+            width: inner.width.saturating_sub(2),
+            height: inner.height,
+        };
         let paragraph = Paragraph::new(lines);
-        frame.render_widget(paragraph, inner);
+        frame.render_widget(paragraph, padded);
+    }
+
+    /// Build a 2-column contents row with equal-width columns.
+    /// Each column: `icon label       count` (fixed 20 chars).
+    fn contents_row(
+        &self,
+        left_kind: SectionKind,
+        left_count: usize,
+        right_kind: SectionKind,
+        right_count: usize,
+    ) -> Line<'_> {
+        // Fixed column width: 1 icon + 1 space + 11 label + 1 space + 4 count = 18
+        // Then 4-char gap between columns
+        let col_label_w = 11;
+        let col_count_w = 4;
+
+        let left_label = format!("{:width$}", left_kind.label(), width = col_label_w);
+        let left_ct = format!("{:>width$}", left_count, width = col_count_w);
+        let right_label = format!("{:width$}", right_kind.label(), width = col_label_w);
+        let right_ct = format!("{:>width$}", right_count, width = col_count_w);
+
+        Line::from(vec![
+            Span::styled(
+                left_kind.icon(),
+                Style::default().fg(self.theme.section_color(left_kind)),
+            ),
+            Span::styled(format!(" {}", left_label), self.theme.normal()),
+            Span::styled(left_ct, self.theme.normal()),
+            Span::raw("    "),
+            Span::styled(
+                right_kind.icon(),
+                Style::default().fg(self.theme.section_color(right_kind)),
+            ),
+            Span::styled(format!(" {}", right_label), self.theme.normal()),
+            Span::styled(right_ct, self.theme.normal()),
+        ])
     }
 
     /// Render the bottom key hints bar
@@ -340,7 +691,7 @@ impl WorkloadBrowser {
         } else {
             vec![
                 KeyHint {
-                    key: "↑/↓",
+                    key: "↕",
                     desc: "navigate",
                 },
                 KeyHint {
@@ -348,8 +699,20 @@ impl WorkloadBrowser {
                     desc: "search",
                 },
                 KeyHint {
-                    key: "Enter",
-                    desc: "select",
+                    key: "↵",
+                    desc: "open",
+                },
+                KeyHint {
+                    key: "i",
+                    desc: "install",
+                },
+                KeyHint {
+                    key: "d",
+                    desc: "dry-run",
+                },
+                KeyHint {
+                    key: "h",
+                    desc: "health",
                 },
                 KeyHint {
                     key: "q",
@@ -360,31 +723,44 @@ impl WorkloadBrowser {
 
         render_keyhints(frame, area, &hints, &self.theme);
     }
+    /// Reset the browser state so it can be re-entered after returning
+    /// from a detail view or install action. Layout preference is preserved.
+    pub fn reset(&mut self) {
+        self.quit = false;
+        self.outcome = None;
+    }
+
+    /// Run the browser event loop using an existing TUI session.
+    ///
+    /// Returns the outcome indicating what the user chose.
+    pub fn run(&mut self, tui: &mut Tui) -> anyhow::Result<BrowserOutcome> {
+        let tick_rate = Duration::from_millis(100);
+
+        loop {
+            tui.draw(|f| self.render(f))?;
+
+            if let Some(Event::Key(key)) = tui.poll_event(tick_rate)? {
+                self.handle_key(key);
+
+                if self.should_quit() {
+                    break;
+                }
+            }
+        }
+
+        Ok(self.outcome())
+    }
 }
 
 /// Run the interactive workload browser
 ///
-/// Returns `Some(name)` if the user selected a workload, `None` if they quit.
-pub fn run_browser(workloads: Vec<WorkloadEntry>) -> anyhow::Result<Option<String>> {
+/// Returns the outcome indicating what the user chose.
+pub fn run_browser(workloads: Vec<WorkloadEntry>) -> anyhow::Result<BrowserOutcome> {
     let mut tui = Tui::new()?;
     let mut browser = WorkloadBrowser::new(workloads);
-
-    let tick_rate = Duration::from_millis(100);
-
-    loop {
-        tui.draw(|f| browser.render(f))?;
-
-        if let Some(Event::Key(key)) = tui.poll_event(tick_rate)? {
-            browser.handle_key(key);
-
-            if browser.should_quit() {
-                break;
-            }
-        }
-    }
-
+    let result = browser.run(&mut tui)?;
     tui.restore()?;
-    Ok(browser.selected_name())
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -401,7 +777,12 @@ mod tests {
                 extends: vec![],
                 package_count: 12,
                 file_count: 3,
+                command_count: 1,
+                font_count: 2,
+                feature_count: 1,
+                assertion_count: 8,
                 source: "default".to_string(),
+                path: "/workloads/essentials/workload.yaml".to_string(),
             },
             WorkloadEntry {
                 name: "rust-developer".to_string(),
@@ -410,7 +791,12 @@ mod tests {
                 extends: vec!["essentials".to_string()],
                 package_count: 5,
                 file_count: 1,
+                command_count: 0,
+                font_count: 0,
+                feature_count: 0,
+                assertion_count: 3,
                 source: "local".to_string(),
+                path: "/workloads/rust-developer/workload.yaml".to_string(),
             },
             WorkloadEntry {
                 name: "node-developer".to_string(),
@@ -419,7 +805,12 @@ mod tests {
                 extends: vec!["essentials".to_string()],
                 package_count: 8,
                 file_count: 2,
+                command_count: 2,
+                font_count: 0,
+                feature_count: 0,
+                assertion_count: 5,
                 source: "remote".to_string(),
+                path: "/workloads/node-developer/workload.yaml".to_string(),
             },
         ]
     }
@@ -430,9 +821,10 @@ mod tests {
         assert_eq!(browser.selected, 0);
         assert!(!browser.searching);
         assert!(!browser.should_quit());
-        assert!(!browser.confirmed);
+        assert_eq!(browser.outcome(), BrowserOutcome::Quit);
         assert_eq!(browser.filtered.len(), 3);
         assert!(browser.search_query.is_empty());
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Auto);
     }
 
     #[test]
@@ -514,9 +906,11 @@ mod tests {
 
         // Press Enter to confirm
         browser.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert!(browser.confirmed);
         assert!(browser.should_quit());
-        assert_eq!(browser.selected_name(), Some("rust-developer".to_string()));
+        assert_eq!(
+            browser.outcome(),
+            BrowserOutcome::Select("rust-developer".to_string())
+        );
     }
 
     #[test]
@@ -525,8 +919,7 @@ mod tests {
 
         browser.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert!(browser.should_quit());
-        assert!(!browser.confirmed);
-        assert_eq!(browser.selected_name(), None);
+        assert_eq!(browser.outcome(), BrowserOutcome::Quit);
     }
 
     #[test]
@@ -544,11 +937,23 @@ mod tests {
     fn test_browser_render_in_test_backend() {
         use ratatui::{backend::TestBackend, Terminal};
 
-        let backend = TestBackend::new(100, 30);
+        let backend = TestBackend::new(120, 30);
         let mut terminal = Terminal::new(backend).unwrap();
         let browser = WorkloadBrowser::new(sample_workloads());
 
-        // Should render without panicking
+        // Wide terminal: should render horizontal layout without panicking
+        terminal.draw(|f| browser.render(f)).unwrap();
+    }
+
+    #[test]
+    fn test_browser_render_narrow_terminal() {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let backend = TestBackend::new(60, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let browser = WorkloadBrowser::new(sample_workloads());
+
+        // Narrow terminal: should render vertical (stacked) layout without panicking
         terminal.draw(|f| browser.render(f)).unwrap();
     }
 
@@ -561,7 +966,7 @@ mod tests {
         let browser = WorkloadBrowser::new(vec![]);
 
         terminal.draw(|f| browser.render(f)).unwrap();
-        assert_eq!(browser.selected_name(), None);
+        assert_eq!(browser.outcome(), BrowserOutcome::Quit);
     }
 
     #[test]
@@ -575,5 +980,139 @@ mod tests {
         assert_eq!(browser.search_query, "zz");
         assert!(browser.filtered.is_empty());
         assert_eq!(browser.selected, 0);
+    }
+
+    #[test]
+    fn test_browser_install_key() {
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+
+        // Navigate to second item and press 'i'
+        browser.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        browser.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        assert!(browser.should_quit());
+        assert_eq!(
+            browser.outcome(),
+            BrowserOutcome::Install(
+                "rust-developer".to_string(),
+                "/workloads/rust-developer/workload.yaml".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn test_browser_dryrun_key() {
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+
+        // Press 'd' on first item
+        browser.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(browser.should_quit());
+        assert_eq!(
+            browser.outcome(),
+            BrowserOutcome::DryRun(
+                "essentials".to_string(),
+                "/workloads/essentials/workload.yaml".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn test_browser_install_ignored_during_search() {
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+
+        // Enter search mode
+        browser.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
+        assert!(browser.searching);
+
+        // 'i' and 'd' should be search input, not actions
+        browser.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        assert!(!browser.should_quit());
+        assert_eq!(browser.search_query, "i");
+
+        browser.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(!browser.should_quit());
+        assert_eq!(browser.search_query, "id");
+    }
+
+    #[test]
+    fn test_browser_install_empty_list_does_nothing() {
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+
+        // Filter to empty
+        browser.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
+        browser.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+        browser.handle_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+        browser.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(browser.filtered.is_empty());
+
+        // 'i' does nothing when list is empty
+        browser.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        assert!(!browser.should_quit());
+    }
+
+    #[test]
+    fn test_browser_layout_toggle() {
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Auto);
+
+        // Tab cycles: Auto -> Horizontal -> Vertical -> Auto
+        browser.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Horizontal);
+
+        browser.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Vertical);
+
+        browser.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Auto);
+    }
+
+    #[test]
+    fn test_browser_layout_toggle_ignored_during_search() {
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+
+        browser.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
+        assert!(browser.searching);
+
+        browser.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Auto);
+    }
+
+    #[test]
+    fn test_browser_layout_preserved_across_reset() {
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+
+        browser.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Horizontal);
+
+        browser.reset();
+        assert_eq!(browser.layout_mode, BrowserLayoutMode::Horizontal);
+    }
+
+    #[test]
+    fn test_browser_is_horizontal() {
+        let browser = WorkloadBrowser::new(sample_workloads());
+
+        // Auto mode
+        assert!(browser.is_horizontal(120));
+        assert!(!browser.is_horizontal(80));
+
+        // Forced modes
+        let mut b2 = WorkloadBrowser::new(sample_workloads());
+        b2.layout_mode = BrowserLayoutMode::Horizontal;
+        assert!(b2.is_horizontal(50)); // forced horizontal even on narrow
+
+        b2.layout_mode = BrowserLayoutMode::Vertical;
+        assert!(!b2.is_horizontal(200)); // forced vertical even on wide
+    }
+
+    #[test]
+    fn test_browser_render_forced_vertical_on_wide() {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut browser = WorkloadBrowser::new(sample_workloads());
+        browser.layout_mode = BrowserLayoutMode::Vertical;
+
+        terminal.draw(|f| browser.render(f)).unwrap();
     }
 }

--- a/src/tui/views/detail.rs
+++ b/src/tui/views/detail.rs
@@ -1,40 +1,40 @@
 //! Interactive workload detail view
 //!
 //! This view renders a full-screen TUI showing workload metadata
-//! with collapsible sections for packages, files, commands, etc.
+//! with tabbed sections for packages, files, commands, etc.
 
-use std::collections::HashSet;
 use std::time::Duration;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{
+        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+        Tabs,
+    },
     Frame,
 };
 
-use crate::tui::theme::Theme;
+use crate::tui::theme::{SectionKind, Theme};
+use crate::tui::widgets::chrome::render_header;
 use crate::tui::widgets::keyhints::{render_keyhints, KeyHint};
 use crate::tui::Tui;
 
 /// A file entry in the workload
-#[allow(dead_code)]
 pub struct FileEntry {
     pub source: String,
     pub destination: String,
 }
 
 /// A command/script entry in the workload
-#[allow(dead_code)]
 pub struct CommandEntry {
     pub name: String,
     pub phase: String,
 }
 
 /// All metadata for a single workload
-#[allow(dead_code)]
 pub struct WorkloadDetail {
     pub name: String,
     pub version: String,
@@ -44,32 +44,58 @@ pub struct WorkloadDetail {
     pub files: Vec<FileEntry>,
     pub commands: Vec<CommandEntry>,
     pub assertions: Vec<String>,
+    pub fonts: Vec<String>,
+    pub features: Vec<String>,
+    pub environment: Vec<String>,
+    /// Filesystem path to the workload.yaml file
+    pub path: String,
 }
 
-/// Number of collapsible sections
-const SECTION_COUNT: usize = 5;
+/// Number of tabs in the detail view
+const TAB_COUNT: usize = 6;
+
+/// Tab indices
+const TAB_OVERVIEW: usize = 0;
+const TAB_PACKAGES: usize = 1;
+const TAB_FILES: usize = 2;
+const TAB_COMMANDS: usize = 3;
+const TAB_CONFIG: usize = 4;
+const TAB_ASSERTIONS: usize = 5;
+
+/// The result of running the detail view
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DetailOutcome {
+    /// User went back to browser (Esc / Backspace)
+    Back,
+    /// User quit the app (q / Ctrl+C)
+    Quit,
+    /// User requested install of this workload (name, path)
+    Install(String, String),
+    /// User requested dry-run of this workload (name, path)
+    DryRun(String, String),
+}
 
 /// Interactive detail view state
-#[allow(dead_code)]
 pub struct DetailView {
     detail: WorkloadDetail,
+    active_tab: usize,
     selected: usize,
-    collapsed: HashSet<usize>,
     scroll_offset: usize,
     quit: bool,
+    outcome: Option<DetailOutcome>,
     theme: Theme,
 }
 
-#[allow(dead_code)]
 impl DetailView {
     /// Create a new detail view for the given workload
     pub fn new(detail: WorkloadDetail) -> Self {
         Self {
             detail,
+            active_tab: TAB_OVERVIEW,
             selected: 0,
-            collapsed: HashSet::new(),
             scroll_offset: 0,
             quit: false,
+            outcome: None,
             theme: Theme::dark(),
         }
     }
@@ -78,29 +104,55 @@ impl DetailView {
     pub fn handle_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Char('q') if key.modifiers == KeyModifiers::NONE => {
+                self.outcome = Some(DetailOutcome::Quit);
                 self.quit = true;
             }
             KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
+                self.outcome = Some(DetailOutcome::Quit);
                 self.quit = true;
             }
+            KeyCode::Esc | KeyCode::Backspace => {
+                self.outcome = Some(DetailOutcome::Back);
+                self.quit = true;
+            }
+            // Tab navigation with ←/→
+            KeyCode::Left | KeyCode::Char('h') => {
+                if self.active_tab > 0 {
+                    self.active_tab -= 1;
+                    self.selected = 0;
+                    self.scroll_offset = 0;
+                }
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                if self.active_tab < TAB_COUNT - 1 {
+                    self.active_tab += 1;
+                    self.selected = 0;
+                    self.scroll_offset = 0;
+                }
+            }
+            // Content scrolling with ↑/↓
             KeyCode::Up | KeyCode::Char('k') => {
                 self.selected = self.selected.saturating_sub(1);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                let max = self.total_lines().saturating_sub(1);
+                let max = self.tab_content_lines().saturating_sub(1);
                 if self.selected < max {
                     self.selected += 1;
                 }
             }
-            KeyCode::Enter => {
-                // Determine which section header the cursor is on and toggle it
-                if let Some(section_idx) = self.line_to_section(self.selected) {
-                    if self.collapsed.contains(&section_idx) {
-                        self.collapsed.remove(&section_idx);
-                    } else {
-                        self.collapsed.insert(section_idx);
-                    }
-                }
+            KeyCode::Char('i') if key.modifiers == KeyModifiers::NONE => {
+                self.outcome = Some(DetailOutcome::Install(
+                    self.detail.name.clone(),
+                    self.detail.path.clone(),
+                ));
+                self.quit = true;
+            }
+            KeyCode::Char('d') if key.modifiers == KeyModifiers::NONE => {
+                self.outcome = Some(DetailOutcome::DryRun(
+                    self.detail.name.clone(),
+                    self.detail.path.clone(),
+                ));
+                self.quit = true;
             }
             _ => {}
         }
@@ -111,142 +163,252 @@ impl DetailView {
         self.quit
     }
 
-    /// Total number of navigable lines in the content area
-    pub fn total_lines(&self) -> usize {
-        self.build_lines(None).len()
+    /// Returns the outcome after the view exits
+    pub fn outcome(&self) -> DetailOutcome {
+        self.outcome.clone().unwrap_or(DetailOutcome::Back)
     }
 
-    /// Map a line index to a section index if it's a section header
-    fn line_to_section(&self, line_idx: usize) -> Option<usize> {
-        let mut current = 0;
-        for section in 0..SECTION_COUNT {
-            if current == line_idx {
-                return Some(section);
-            }
-            current += 1; // header line
-            if !self.collapsed.contains(&section) {
-                current += self.section_item_count(section);
-            }
-        }
-        None
+    /// Number of content lines in the current tab
+    pub fn tab_content_lines(&self) -> usize {
+        self.build_tab_lines(None).len()
     }
 
-    /// Number of child items in a section
-    fn section_item_count(&self, section: usize) -> usize {
-        match section {
-            0 => {
-                if self.detail.extends.is_empty() {
-                    1 // "None"
-                } else {
-                    self.detail.extends.len()
-                }
-            }
-            1 => self.detail.packages.len(),
-            2 => self.detail.files.len(),
-            3 => self.detail.commands.len(),
-            4 => self.detail.assertions.len(),
-            _ => 0,
+    /// Tab titles with counts
+    fn tab_titles(&self) -> Vec<String> {
+        vec![
+            "Overview".to_string(),
+            format!("Packages ({})", self.detail.packages.len()),
+            format!("Files ({})", self.detail.files.len()),
+            format!("Commands ({})", self.detail.commands.len()),
+            "Config".to_string(),
+            format!("Assertions ({})", self.detail.assertions.len()),
+        ]
+    }
+
+    /// Build content lines for the active tab
+    fn build_tab_lines(&self, highlight_style: Option<Style>) -> Vec<Line<'_>> {
+        match self.active_tab {
+            TAB_OVERVIEW => self.build_overview_lines(highlight_style),
+            TAB_PACKAGES => self.build_list_lines(&self.detail.packages, highlight_style),
+            TAB_FILES => self.build_files_lines(highlight_style),
+            TAB_COMMANDS => self.build_commands_lines(highlight_style),
+            TAB_CONFIG => self.build_config_lines(highlight_style),
+            TAB_ASSERTIONS => self.build_list_lines(&self.detail.assertions, highlight_style),
+            _ => vec![],
         }
     }
 
-    /// Build the content lines, optionally highlighting the selected line.
-    /// When `highlight_style` is `None`, lines are built without selection styling
-    /// (used for counting). When `Some`, the selected line gets that style.
-    fn build_lines(&self, highlight_style: Option<Style>) -> Vec<Line<'_>> {
-        let mut lines: Vec<Line> = Vec::new();
-        let mut line_idx: usize = 0;
+    fn build_overview_lines(&self, _hl: Option<Style>) -> Vec<Line<'_>> {
+        let mut lines = vec![
+            Line::raw(""),
+            Line::from(vec![
+                Span::styled("  Description: ", self.theme.dimmed()),
+                Span::styled(&self.detail.description, self.theme.body()),
+            ]),
+            Line::raw(""),
+            Line::from(vec![
+                Span::styled("  Version:     ", self.theme.dimmed()),
+                Span::styled(&self.detail.version, self.theme.normal()),
+            ]),
+            Line::raw(""),
+        ];
 
-        for section in 0..SECTION_COUNT {
-            let (label, _count) = self.section_header_info(section);
-            let is_collapsed = self.collapsed.contains(&section);
-            let arrow = if is_collapsed { "▸" } else { "▾" };
-            let header_text = format!("  {} {}", arrow, label);
+        if !self.detail.extends.is_empty() {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    SectionKind::Inheritance.icon(),
+                    Style::default().fg(self.theme.section_color(SectionKind::Inheritance)),
+                ),
+                Span::styled("  Extends: ", self.theme.dimmed()),
+                Span::styled(self.detail.extends.join(", "), self.theme.normal()),
+            ]));
+            lines.push(Line::raw(""));
+        }
 
-            let header_style =
-                if let Some(hl) = highlight_style.filter(|_| line_idx == self.selected) {
-                    hl
-                } else {
-                    self.theme.title_style()
-                };
-            lines.push(Line::from(Span::styled(header_text, header_style)));
-            line_idx += 1;
+        // Content breakdown
+        let sections = [
+            (SectionKind::Packages, self.detail.packages.len()),
+            (SectionKind::Files, self.detail.files.len()),
+            (SectionKind::Commands, self.detail.commands.len()),
+            (SectionKind::Fonts, self.detail.fonts.len()),
+            (SectionKind::Features, self.detail.features.len()),
+            (SectionKind::Environment, self.detail.environment.len()),
+            (SectionKind::Assertions, self.detail.assertions.len()),
+        ];
 
-            if !is_collapsed {
-                let items = self.section_items(section);
-                if items.is_empty() && section != 0 {
-                    // No items — nothing to show
-                } else {
-                    for item_text in &items {
-                        let item_style = if let Some(hl) =
-                            highlight_style.filter(|_| line_idx == self.selected)
-                        {
-                            hl
-                        } else {
-                            self.theme.normal()
-                        };
-                        lines.push(Line::from(Span::styled(
-                            format!("    {}", item_text),
-                            item_style,
-                        )));
-                        line_idx += 1;
-                    }
-                }
+        for (kind, count) in &sections {
+            if *count > 0 {
+                lines.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(
+                        kind.icon(),
+                        Style::default().fg(self.theme.section_color(*kind)),
+                    ),
+                    Span::styled(
+                        format!("  {:12} {}", kind.label(), count),
+                        self.theme.normal(),
+                    ),
+                ]));
             }
         }
 
         lines
     }
 
-    /// Section header label and item count
-    fn section_header_info(&self, section: usize) -> (String, usize) {
-        match section {
-            0 => ("Inheritance".to_string(), self.detail.extends.len()),
-            1 => {
-                let n = self.detail.packages.len();
-                (format!("Packages ({})", n), n)
-            }
-            2 => {
-                let n = self.detail.files.len();
-                (format!("Files ({})", n), n)
-            }
-            3 => {
-                let n = self.detail.commands.len();
-                (format!("Commands ({})", n), n)
-            }
-            4 => {
-                let n = self.detail.assertions.len();
-                (format!("Assertions ({})", n), n)
-            }
-            _ => ("Unknown".to_string(), 0),
+    fn build_list_lines<'a>(
+        &'a self,
+        items: &'a [String],
+        highlight_style: Option<Style>,
+    ) -> Vec<Line<'a>> {
+        if items.is_empty() {
+            return vec![Line::styled("  No items", self.theme.dimmed())];
         }
+        items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                let style = if let Some(hl) = highlight_style.filter(|_| i == self.selected) {
+                    hl
+                } else {
+                    self.theme.normal()
+                };
+                Line::from(vec![
+                    if Some(i) == Some(self.selected) && highlight_style.is_some() {
+                        Span::styled("▌", Style::default().fg(self.theme.accent))
+                    } else {
+                        Span::raw(" ")
+                    },
+                    Span::styled(format!(" {}", item), style),
+                ])
+            })
+            .collect()
     }
 
-    /// Item strings for a section
-    fn section_items(&self, section: usize) -> Vec<String> {
-        match section {
-            0 => {
-                if self.detail.extends.is_empty() {
-                    vec!["None".to_string()]
-                } else {
-                    self.detail.extends.clone()
-                }
-            }
-            1 => self.detail.packages.clone(),
-            2 => self
-                .detail
-                .files
-                .iter()
-                .map(|f| format!("{} → {}", f.source, f.destination))
-                .collect(),
-            3 => self
-                .detail
-                .commands
-                .iter()
-                .map(|c| format!("[{}] {}", c.phase, c.name))
-                .collect(),
-            4 => self.detail.assertions.clone(),
-            _ => Vec::new(),
+    fn build_files_lines(&self, highlight_style: Option<Style>) -> Vec<Line<'_>> {
+        if self.detail.files.is_empty() {
+            return vec![Line::styled("  No files", self.theme.dimmed())];
         }
+        self.detail
+            .files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let style = if let Some(hl) = highlight_style.filter(|_| i == self.selected) {
+                    hl
+                } else {
+                    self.theme.normal()
+                };
+                Line::from(vec![
+                    if Some(i) == Some(self.selected) && highlight_style.is_some() {
+                        Span::styled("▌", Style::default().fg(self.theme.accent))
+                    } else {
+                        Span::raw(" ")
+                    },
+                    Span::styled(format!(" {} → {}", f.source, f.destination), style),
+                ])
+            })
+            .collect()
+    }
+
+    fn build_commands_lines(&self, highlight_style: Option<Style>) -> Vec<Line<'_>> {
+        if self.detail.commands.is_empty() {
+            return vec![Line::styled("  No commands", self.theme.dimmed())];
+        }
+        self.detail
+            .commands
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                let style = if let Some(hl) = highlight_style.filter(|_| i == self.selected) {
+                    hl
+                } else {
+                    self.theme.normal()
+                };
+                Line::from(vec![
+                    if Some(i) == Some(self.selected) && highlight_style.is_some() {
+                        Span::styled("▌", Style::default().fg(self.theme.accent))
+                    } else {
+                        Span::raw(" ")
+                    },
+                    Span::styled(format!(" [{}] {}", c.phase, c.name), style),
+                ])
+            })
+            .collect()
+    }
+
+    fn build_config_lines(&self, _hl: Option<Style>) -> Vec<Line<'_>> {
+        let mut lines = Vec::new();
+
+        // Fonts section
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                SectionKind::Fonts.icon(),
+                Style::default().fg(self.theme.section_color(SectionKind::Fonts)),
+            ),
+            Span::styled(
+                format!("  Fonts ({})", self.detail.fonts.len()),
+                self.theme.title_style(),
+            ),
+        ]));
+        for font in &self.detail.fonts {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(font.as_str(), self.theme.normal()),
+            ]));
+        }
+        if self.detail.fonts.is_empty() {
+            lines.push(Line::styled("    None", self.theme.dimmed()));
+        }
+        lines.push(Line::raw(""));
+
+        // Features section
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                SectionKind::Features.icon(),
+                Style::default().fg(self.theme.section_color(SectionKind::Features)),
+            ),
+            Span::styled(
+                format!("  Features ({})", self.detail.features.len()),
+                self.theme.title_style(),
+            ),
+        ]));
+        for feat in &self.detail.features {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(feat.as_str(), self.theme.normal()),
+            ]));
+        }
+        if self.detail.features.is_empty() {
+            lines.push(Line::styled("    None", self.theme.dimmed()));
+        }
+        lines.push(Line::raw(""));
+
+        // Environment section
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                SectionKind::Environment.icon(),
+                Style::default().fg(self.theme.section_color(SectionKind::Environment)),
+            ),
+            Span::styled(
+                format!("  Environment ({})", self.detail.environment.len()),
+                self.theme.title_style(),
+            ),
+        ]));
+        for env in &self.detail.environment {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(env.as_str(), self.theme.normal()),
+            ]));
+        }
+        if self.detail.environment.is_empty() {
+            lines.push(Line::styled("    None", self.theme.dimmed()));
+        }
+
+        lines
     }
 
     /// Render the full view
@@ -254,57 +416,74 @@ impl DetailView {
         let area = frame.area();
 
         let chunks = Layout::vertical([
-            Constraint::Length(5), // header
+            Constraint::Length(1), // branded header
+            Constraint::Length(1), // tabs
+            Constraint::Length(2), // description + path strip
             Constraint::Min(3),    // main content
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
-        self.render_header(frame, chunks[0]);
-        self.render_main(frame, chunks[1]);
-        self.render_keyhints(frame, chunks[2]);
+        self.render_branded_header(frame, chunks[0]);
+        self.render_tabs(frame, chunks[1]);
+        self.render_info_strip(frame, chunks[2]);
+        self.render_main(frame, chunks[3]);
+        self.render_keyhints(frame, chunks[4]);
     }
 
-    /// Render the header block with workload name, version, description
-    fn render_header(&self, frame: &mut Frame, area: Rect) {
-        let title = format!(" Anvil — Workload: {} ", self.detail.name);
-        let block = Block::default()
-            .title(Span::styled(title, self.theme.title_style()))
-            .borders(Borders::ALL)
-            .border_style(self.theme.border_style());
-
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-
-        let lines = vec![
-            Line::from(Span::styled(
-                &self.detail.name,
-                Style::default()
-                    .fg(self.theme.fg)
-                    .add_modifier(Modifier::BOLD),
-            )),
-            Line::from(Span::styled(
+    /// Render the branded header bar with breadcrumb
+    fn render_branded_header(&self, frame: &mut Frame, area: Rect) {
+        render_header(
+            frame,
+            area,
+            &self.theme,
+            &["Workloads", &self.detail.name],
+            Some(Line::from(vec![Span::styled(
                 format!("v{}", self.detail.version),
                 self.theme.dimmed(),
-            )),
-            Line::from(Span::styled(&self.detail.description, self.theme.normal())),
-        ];
-
-        let paragraph = Paragraph::new(lines);
-        frame.render_widget(paragraph, inner);
+            )])),
+        );
     }
 
-    /// Render the main content area with collapsible sections
+    /// Render the tabs bar
+    fn render_tabs(&self, frame: &mut Frame, area: Rect) {
+        let titles = self.tab_titles();
+        let tabs = Tabs::new(titles)
+            .select(self.active_tab)
+            .style(self.theme.dimmed())
+            .highlight_style(self.theme.brand_style())
+            .divider(Span::styled("·", self.theme.faint_style()));
+        frame.render_widget(tabs, area);
+    }
+
+    /// Render the description + path info strip
+    fn render_info_strip(&self, frame: &mut Frame, area: Rect) {
+        let lines = vec![
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled(&self.detail.description, self.theme.body()),
+            ]),
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled(&self.detail.path, self.theme.running_style()),
+            ]),
+        ];
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, area);
+    }
+
+    /// Render the main content area for the active tab
     fn render_main(&self, frame: &mut Frame, area: Rect) {
         let block = Block::default()
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(self.theme.border_style());
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        let highlight = Style::default().bg(self.theme.accent).fg(Color::Black);
-        let lines = self.build_lines(Some(highlight));
+        let highlight = self.theme.selection().bg(self.theme.bg_inset);
+        let lines = self.build_tab_lines(Some(highlight));
 
         let visible_height = inner.height as usize;
         let total = lines.len();
@@ -341,12 +520,24 @@ impl DetailView {
     fn render_keyhints(&self, frame: &mut Frame, area: Rect) {
         let hints = vec![
             KeyHint {
-                key: "↑/↓",
-                desc: "navigate",
+                key: "←/→",
+                desc: "tabs",
             },
             KeyHint {
-                key: "Enter",
-                desc: "toggle",
+                key: "↑/↓",
+                desc: "scroll",
+            },
+            KeyHint {
+                key: "i",
+                desc: "install",
+            },
+            KeyHint {
+                key: "d",
+                desc: "dry-run",
+            },
+            KeyHint {
+                key: "Esc",
+                desc: "back",
             },
             KeyHint {
                 key: "q",
@@ -356,30 +547,34 @@ impl DetailView {
 
         render_keyhints(frame, area, &hints, &self.theme);
     }
+
+    /// Run the detail view event loop using an existing TUI session.
+    pub fn run(&mut self, tui: &mut Tui) -> anyhow::Result<DetailOutcome> {
+        let tick_rate = Duration::from_millis(100);
+
+        loop {
+            tui.draw(|f| self.render(f))?;
+
+            if let Some(Event::Key(key)) = tui.poll_event(tick_rate)? {
+                self.handle_key(key);
+
+                if self.should_quit() {
+                    break;
+                }
+            }
+        }
+
+        Ok(self.outcome())
+    }
 }
 
 /// Run the interactive detail view event loop
-#[allow(dead_code)]
-pub fn run_detail_view(detail: WorkloadDetail) -> anyhow::Result<()> {
+pub fn run_detail_view(detail: WorkloadDetail) -> anyhow::Result<DetailOutcome> {
     let mut tui = Tui::new()?;
     let mut view = DetailView::new(detail);
-
-    let tick_rate = Duration::from_millis(100);
-
-    loop {
-        tui.draw(|f| view.render(f))?;
-
-        if let Some(Event::Key(key)) = tui.poll_event(tick_rate)? {
-            view.handle_key(key);
-
-            if view.should_quit() {
-                break;
-            }
-        }
-    }
-
+    let outcome = view.run(&mut tui)?;
     tui.restore()?;
-    Ok(())
+    Ok(outcome)
 }
 
 #[cfg(test)]
@@ -402,6 +597,10 @@ mod tests {
                 phase: "post_install".to_string(),
             }],
             assertions: vec!["git is installed".to_string()],
+            fonts: vec!["Cascadia Code NF v2407.24".to_string()],
+            features: vec!["Windows Sudo (registry_toggle)".to_string()],
+            environment: vec!["GIT_EDITOR=code --wait".to_string()],
+            path: "/workloads/test-workload/workload.yaml".to_string(),
         }
     }
 
@@ -409,15 +608,15 @@ mod tests {
     fn test_detail_initial_state() {
         let view = DetailView::new(sample_detail());
         assert_eq!(view.selected, 0);
-        assert!(view.collapsed.is_empty());
+        assert_eq!(view.active_tab, TAB_OVERVIEW);
         assert!(!view.should_quit());
-        assert!(view.total_lines() > 0);
+        assert!(view.tab_content_lines() > 0);
     }
 
     #[test]
     fn test_detail_navigation() {
         let mut view = DetailView::new(sample_detail());
-        let max = view.total_lines().saturating_sub(1);
+        let max = view.tab_content_lines().saturating_sub(1);
 
         // Move down
         view.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
@@ -447,23 +646,36 @@ mod tests {
     }
 
     #[test]
-    fn test_detail_toggle_section() {
+    fn test_detail_tab_switching() {
         let mut view = DetailView::new(sample_detail());
-        let initial_lines = view.total_lines();
+        assert_eq!(view.active_tab, TAB_OVERVIEW);
 
-        // Selected line 0 is the first section header (Inheritance)
-        assert_eq!(view.selected, 0);
-        assert!(!view.collapsed.contains(&0));
+        // Move right to Packages tab
+        view.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        assert_eq!(view.active_tab, TAB_PACKAGES);
+        assert_eq!(view.selected, 0); // reset on tab change
 
-        // Toggle collapse
-        view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert!(view.collapsed.contains(&0));
-        assert!(view.total_lines() < initial_lines);
+        // Move right to Files tab
+        view.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        assert_eq!(view.active_tab, TAB_FILES);
 
-        // Toggle expand
-        view.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert!(!view.collapsed.contains(&0));
-        assert_eq!(view.total_lines(), initial_lines);
+        // Move left back to Packages
+        view.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+        assert_eq!(view.active_tab, TAB_PACKAGES);
+
+        // Move left back to Overview
+        view.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+        assert_eq!(view.active_tab, TAB_OVERVIEW);
+
+        // Can't go below 0
+        view.handle_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+        assert_eq!(view.active_tab, TAB_OVERVIEW);
+
+        // Navigate to last tab
+        for _ in 0..TAB_COUNT + 2 {
+            view.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        }
+        assert_eq!(view.active_tab, TAB_COUNT - 1);
     }
 
     #[test]
@@ -474,11 +686,55 @@ mod tests {
         assert!(!view.should_quit());
         view.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert!(view.should_quit());
+        assert_eq!(view.outcome(), DetailOutcome::Quit);
 
         // Ctrl+C also quits
         let mut view2 = DetailView::new(sample_detail());
         assert!(!view2.should_quit());
         view2.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert!(view2.should_quit());
+        assert_eq!(view2.outcome(), DetailOutcome::Quit);
+
+        // Esc goes back
+        let mut view3 = DetailView::new(sample_detail());
+        assert!(!view3.should_quit());
+        view3.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(view3.should_quit());
+        assert_eq!(view3.outcome(), DetailOutcome::Back);
+
+        // Backspace also goes back
+        let mut view4 = DetailView::new(sample_detail());
+        view4.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+        assert_eq!(view4.outcome(), DetailOutcome::Back);
+    }
+
+    #[test]
+    fn test_detail_install_key() {
+        let mut view = DetailView::new(sample_detail());
+
+        view.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        assert!(view.should_quit());
+        assert_eq!(
+            view.outcome(),
+            DetailOutcome::Install(
+                "test-workload".to_string(),
+                "/workloads/test-workload/workload.yaml".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn test_detail_dryrun_key() {
+        let mut view = DetailView::new(sample_detail());
+
+        view.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(view.should_quit());
+        assert_eq!(
+            view.outcome(),
+            DetailOutcome::DryRun(
+                "test-workload".to_string(),
+                "/workloads/test-workload/workload.yaml".to_string(),
+            )
+        );
     }
 }

--- a/src/tui/views/health.rs
+++ b/src/tui/views/health.rs
@@ -9,13 +9,16 @@ use std::time::Duration;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{
+        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+    },
     Frame,
 };
 
 use crate::tui::theme::Theme;
+use crate::tui::widgets::chrome::{badge, render_header};
 use crate::tui::widgets::keyhints::{render_keyhints, KeyHint};
 use crate::tui::Tui;
 
@@ -140,18 +143,46 @@ impl HealthViewer {
         let area = frame.area();
 
         let chunks = Layout::vertical([
-            Constraint::Length(3), // summary bar
+            Constraint::Length(1), // branded header
+            Constraint::Length(1), // summary strip
             Constraint::Min(3),    // main content
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
-        self.render_summary(frame, chunks[0]);
-        self.render_main(frame, chunks[1]);
-        self.render_keyhints(frame, chunks[2]);
+        self.render_branded_header(frame, chunks[0]);
+        self.render_summary(frame, chunks[1]);
+        self.render_main(frame, chunks[2]);
+        self.render_keyhints(frame, chunks[3]);
     }
 
-    /// Render the summary bar
+    /// Render the branded header bar
+    fn render_branded_header(&self, frame: &mut Frame, area: Rect) {
+        let (_, _pass, fail, _, _) = self.count_statuses();
+        let issues_text = format!("{} ISSUES", fail);
+        let result_badge = if fail == 0 {
+            badge("ALL PASS", self.theme.success)
+        } else {
+            badge(&issues_text, self.theme.error)
+        };
+
+        render_header(
+            frame,
+            area,
+            &self.theme,
+            &["Health", &self.report.workload_name],
+            Some(Line::from(vec![
+                Span::styled(
+                    format!("{:.1}s", self.report.duration.as_secs_f64()),
+                    self.theme.dimmed(),
+                ),
+                Span::raw(" "),
+                result_badge,
+            ])),
+        );
+    }
+
+    /// Render the summary strip
     fn render_summary(&self, frame: &mut Frame, area: Rect) {
         let (total, pass, fail, skip, warn) = self.count_statuses();
         let pass_rate = if total > 0 {
@@ -160,18 +191,8 @@ impl HealthViewer {
             0.0
         };
 
-        let title = format!(" Anvil — Health Report: {} ", self.report.workload_name);
-
-        let block = Block::default()
-            .title(Span::styled(title, self.theme.title_style()))
-            .borders(Borders::ALL)
-            .border_style(self.theme.border_style());
-
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-
         let summary_line = Line::from(vec![
-            Span::raw("  "),
+            Span::raw(" "),
             Span::styled(format!("{total} checks"), self.theme.normal()),
             Span::raw("  "),
             Span::styled(format!("{pass} pass"), self.theme.success_style()),
@@ -183,7 +204,7 @@ impl HealthViewer {
             Span::styled(format!("{warn} warn"), self.theme.warning_style()),
             Span::raw("  "),
             Span::styled(
-                format!("{pass_rate:.0}% pass rate"),
+                format!("{pass_rate:.0}%"),
                 if pass_rate >= 100.0 {
                     self.theme.success_style()
                 } else if pass_rate >= 50.0 {
@@ -192,21 +213,17 @@ impl HealthViewer {
                     self.theme.error_style()
                 },
             ),
-            Span::raw("  "),
-            Span::styled(
-                format!("{:.1}s", self.report.duration.as_secs_f64()),
-                self.theme.dimmed(),
-            ),
         ]);
 
         let paragraph = Paragraph::new(summary_line);
-        frame.render_widget(paragraph, inner);
+        frame.render_widget(paragraph, area);
     }
 
     /// Render the main content area with sections and items
     fn render_main(&self, frame: &mut Frame, area: Rect) {
         let block = Block::default()
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(self.theme.border_style());
 
         let inner = block.inner(area);
@@ -214,25 +231,71 @@ impl HealthViewer {
 
         let mut lines: Vec<Line> = Vec::new();
         let mut flat_index: usize = 0;
-        let highlight_style = Style::default().bg(self.theme.accent).fg(Color::Black);
 
         for (si, section) in self.report.sections.iter().enumerate() {
             let is_collapsed = self.section_collapsed.contains(&si);
             let (section_pass, section_total) = self.section_counts(section);
             let is_selected = flat_index == self.selected;
 
-            // Section header
+            // Build heatmap data for this section
+            let heatmap_results: Vec<bool> = section
+                .items
+                .iter()
+                .map(|i| i.status == HealthStatus::Pass)
+                .collect();
+
+            // Section header with heatmap
             let arrow = if is_collapsed { "▸" } else { "▾" };
-            let header_text = format!(
-                "  {} {} ({}/{})",
-                arrow, section.name, section_pass, section_total
-            );
-            let header_style = if is_selected {
-                highlight_style.add_modifier(Modifier::BOLD)
+            let count_style = if section_pass == section_total {
+                self.theme.success_style()
             } else {
-                self.theme.normal().add_modifier(Modifier::BOLD)
+                self.theme.error_style()
             };
-            lines.push(Line::styled(header_text, header_style));
+
+            if is_selected {
+                let mut spans = vec![
+                    Span::styled("▌", Style::default().fg(self.theme.accent)),
+                    Span::styled(
+                        format!(" {} {} ", arrow, section.name),
+                        self.theme.selection().bg(self.theme.bg_inset),
+                    ),
+                ];
+                // Inline heatmap
+                for &pass in heatmap_results.iter().take(20) {
+                    let c = if pass {
+                        self.theme.success
+                    } else {
+                        self.theme.error
+                    };
+                    spans.push(Span::styled("▮", Style::default().fg(c)));
+                }
+                spans.push(Span::styled(
+                    format!(" {}/{}", section_pass, section_total),
+                    count_style,
+                ));
+                lines.push(Line::from(spans));
+            } else {
+                let mut spans = vec![
+                    Span::raw("  "),
+                    Span::styled(
+                        format!("{} {} ", arrow, section.name),
+                        self.theme.normal().add_modifier(Modifier::BOLD),
+                    ),
+                ];
+                for &pass in heatmap_results.iter().take(20) {
+                    let c = if pass {
+                        self.theme.success
+                    } else {
+                        self.theme.error
+                    };
+                    spans.push(Span::styled("▮", Style::default().fg(c)));
+                }
+                spans.push(Span::styled(
+                    format!(" {}/{}", section_pass, section_total),
+                    count_style,
+                ));
+                lines.push(Line::from(spans));
+            }
             flat_index += 1;
 
             // Items (if section not collapsed)
@@ -252,30 +315,50 @@ impl HealthViewer {
                         HealthStatus::Warn => ("⚠", self.theme.warning_style()),
                     };
 
-                    let item_style = if is_item_selected {
-                        highlight_style
+                    if is_item_selected {
+                        let mut spans = vec![
+                            Span::styled("  ▌", Style::default().fg(self.theme.accent)),
+                            Span::styled(format!(" {} ", icon), icon_style.bg(self.theme.bg_inset)),
+                            Span::styled(
+                                item.name.clone(),
+                                self.theme.selection().bg(self.theme.bg_inset),
+                            ),
+                        ];
+                        // Right-aligned error text for failed items
+                        if item.status == HealthStatus::Fail {
+                            if let Some(detail) = &item.detail {
+                                let affordance = if is_expanded { " ▾" } else { " ▸" };
+                                spans.push(Span::styled(
+                                    format!("  {}{}", detail, affordance),
+                                    self.theme.error_style(),
+                                ));
+                            }
+                        }
+                        lines.push(Line::from(spans));
                     } else {
-                        Style::default()
-                    };
-
-                    let item_icon_style = if is_item_selected {
-                        highlight_style
-                    } else {
-                        icon_style
-                    };
-
-                    lines.push(Line::from(vec![
-                        Span::raw("    "),
-                        Span::styled(icon, item_icon_style),
-                        Span::styled(format!(" {}", item.name), item_style),
-                    ]));
+                        let mut spans = vec![
+                            Span::raw("    "),
+                            Span::styled(format!("{} ", icon), icon_style),
+                            Span::styled(&item.name, self.theme.normal()),
+                        ];
+                        if item.status == HealthStatus::Fail {
+                            if let Some(detail) = &item.detail {
+                                let affordance = if is_expanded { " ▾" } else { " ▸" };
+                                spans.push(Span::styled(
+                                    format!("  {}{}", detail, affordance),
+                                    self.theme.error_style(),
+                                ));
+                            }
+                        }
+                        lines.push(Line::from(spans));
+                    }
 
                     // Show detail if expanded
                     if is_expanded {
                         if let Some(detail) = &item.detail {
                             lines.push(Line::from(vec![
                                 Span::raw("      "),
-                                Span::styled(detail, self.theme.dimmed()),
+                                Span::styled(detail.as_str(), self.theme.error_style()),
                             ]));
                         }
                     }

--- a/src/tui/views/install.rs
+++ b/src/tui/views/install.rs
@@ -11,12 +11,15 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::Modifier,
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{
+        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
+    },
     Frame,
 };
 
 use crate::tui::events::{InstallEvent, InstallPhase, ItemResult};
 use crate::tui::theme::Theme;
+use crate::tui::widgets::chrome::{gauge, render_header};
 use crate::tui::widgets::keyhints::{render_keyhints, KeyHint};
 use crate::tui::widgets::status::{status_line, ItemStatus};
 use crate::tui::Tui;
@@ -180,23 +183,124 @@ impl InstallDashboard {
     pub fn render(&self, frame: &mut Frame) {
         let area = frame.area();
 
-        // Main layout: content + key hints bar
         let chunks = Layout::vertical([
-            Constraint::Min(3),    // main content
+            Constraint::Length(1), // branded header
+            Constraint::Length(1), // overall gauge
+            Constraint::Length(1), // phase chips
+            Constraint::Min(3),    // main content (split body)
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
-        self.render_main(frame, chunks[0]);
-        self.render_keyhints(frame, chunks[1]);
+        self.render_branded_header(frame, chunks[0]);
+        self.render_gauge(frame, chunks[1]);
+        self.render_phase_chips(frame, chunks[2]);
+        self.render_main(frame, chunks[3]);
+        self.render_keyhints(frame, chunks[4]);
+    }
+
+    /// Render the branded header bar
+    fn render_branded_header(&self, frame: &mut Frame, area: Rect) {
+        let status_text = if self.done { "Complete" } else { "Installing" };
+
+        render_header(
+            frame,
+            area,
+            &self.theme,
+            &["Install", &self.workload_name],
+            Some(Line::from(vec![
+                Span::styled(
+                    status_text,
+                    if self.done {
+                        self.theme.success_style()
+                    } else {
+                        self.theme.running_style()
+                    },
+                ),
+                if let Some(dur) = self.total_duration {
+                    Span::styled(
+                        format!("  {}", crate::cli::progress::format_duration(dur)),
+                        self.theme.dimmed(),
+                    )
+                } else {
+                    Span::raw("")
+                },
+            ])),
+        );
+    }
+
+    /// Render the overall progress gauge
+    fn render_gauge(&self, frame: &mut Frame, area: Rect) {
+        let (completed, total) = self.overall_progress();
+        let ratio = if total > 0 {
+            completed as f64 / total as f64
+        } else {
+            0.0
+        };
+        frame.render_widget(
+            gauge(
+                &self.theme,
+                ratio,
+                self.theme.accent,
+                Some(format!("{completed} / {total} items")),
+            ),
+            area,
+        );
+    }
+
+    /// Render phase indicator chips
+    fn render_phase_chips(&self, frame: &mut Frame, area: Rect) {
+        let all_phases = [
+            InstallPhase::PreCommands,
+            InstallPhase::Packages,
+            InstallPhase::Fonts,
+            InstallPhase::Features,
+            InstallPhase::Terminal,
+            InstallPhase::Files,
+            InstallPhase::PostCommands,
+        ];
+
+        let mut spans: Vec<Span> = vec![Span::raw(" ")];
+        for phase in &all_phases {
+            let state = self.phases.iter().find(|p| p.phase == *phase);
+            let (icon, style) = match state.map(|p| p.status) {
+                Some(ItemStatus::Success) => ("✓", self.theme.success_style()),
+                Some(ItemStatus::Running) => ("⠋", self.theme.running_style()),
+                _ => ("·", self.theme.faint_style()),
+            };
+            spans.push(Span::styled(format!(" {} {} ", icon, phase.label()), style));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    /// Compute overall completed/total across all phases
+    fn overall_progress(&self) -> (usize, usize) {
+        let completed: usize = self.phases.iter().map(|p| p.completed).sum();
+        let total: usize = self.phases.iter().map(|p| p.total).sum();
+        (completed, total)
     }
 
     /// Render the main content area
     fn render_main(&self, frame: &mut Frame, area: Rect) {
-        let title = format!(" Anvil — Installing {} ", self.workload_name);
+        if self.verbose && !self.logs.is_empty() {
+            // Split body: items (62%) + log (38%)
+            let body = Layout::horizontal([Constraint::Percentage(62), Constraint::Percentage(38)])
+                .split(area);
+
+            self.render_items(frame, body[0]);
+            self.render_log(frame, body[1]);
+        } else {
+            self.render_items(frame, area);
+        }
+    }
+
+    /// Render the items pane
+    fn render_items(&self, frame: &mut Frame, area: Rect) {
+        let title = format!(" Installing {} ", self.workload_name);
         let block = Block::default()
             .title(Span::styled(title, self.theme.title_style()))
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(self.theme.border_style());
 
         let inner = block.inner(area);
@@ -282,35 +386,7 @@ impl InstallDashboard {
                 }
             }
 
-            // Show future phases as pending
-            let active_phases: Vec<InstallPhase> = self.phases.iter().map(|p| p.phase).collect();
-            let all_phases = [
-                InstallPhase::PreCommands,
-                InstallPhase::Packages,
-                InstallPhase::Fonts,
-                InstallPhase::Features,
-                InstallPhase::Terminal,
-                InstallPhase::Files,
-                InstallPhase::PostCommands,
-            ];
-            for phase in &all_phases {
-                if !active_phases.contains(phase) {
-                    lines.push(Line::styled(
-                        format!("  Phase: {}  pending", phase.label()),
-                        self.theme.dimmed(),
-                    ));
-                }
-            }
-
-            // Verbose log section
-            if self.verbose && !self.logs.is_empty() {
-                lines.push(Line::raw(""));
-                lines.push(Line::styled("  ─── Log ───", self.theme.dimmed()));
-                let log_start = self.logs.len().saturating_sub(10);
-                for log in &self.logs[log_start..] {
-                    lines.push(Line::styled(format!("  {}", log), self.theme.dimmed()));
-                }
-            }
+            // Future phases no longer shown inline — phase chips handle this
         }
 
         // Apply scroll offset
@@ -332,6 +408,37 @@ impl InstallDashboard {
             let mut scrollbar_state = ScrollbarState::new(max_scroll).position(scroll);
             frame.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
         }
+    }
+
+    /// Render the log pane (right side when verbose)
+    fn render_log(&self, frame: &mut Frame, area: Rect) {
+        let block = Block::default()
+            .title(Span::styled(" Log ", self.theme.dimmed()))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(self.theme.border_style());
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let visible_height = inner.height as usize;
+        let log_start = self.logs.len().saturating_sub(visible_height);
+        let lines: Vec<Line> = self.logs[log_start..]
+            .iter()
+            .map(|log| {
+                let style = if log.starts_with('$') || log.starts_with('>') {
+                    self.theme.faint_style()
+                } else if log.starts_with('✓') {
+                    self.theme.success_style()
+                } else {
+                    self.theme.dimmed()
+                };
+                Line::styled(format!(" {}", log), style)
+            })
+            .collect();
+
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, inner);
     }
 
     /// Render the key hints bar

--- a/src/tui/views/status.rs
+++ b/src/tui/views/status.rs
@@ -9,13 +9,14 @@ use std::time::Duration;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, BorderType, Borders, Paragraph},
     Frame,
 };
 
 use crate::tui::theme::Theme;
+use crate::tui::widgets::chrome::render_header;
 use crate::tui::widgets::keyhints::{render_keyhints, KeyHint};
 use crate::tui::Tui;
 
@@ -106,67 +107,104 @@ impl StatusDashboard {
         let area = frame.area();
 
         let chunks = Layout::vertical([
-            Constraint::Length(5), // system info
-            Constraint::Length(3), // source summary
+            Constraint::Length(1), // branded header
+            Constraint::Length(3), // stat blocks
             Constraint::Min(3),    // workload list
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
-        self.render_system_info(frame, chunks[0]);
-        self.render_source_summary(frame, chunks[1]);
+        self.render_branded_header(frame, chunks[0]);
+        self.render_stat_blocks(frame, chunks[1]);
         self.render_workload_list(frame, chunks[2]);
         self.render_keyhints(frame, chunks[3]);
     }
 
-    /// Render the system info block
-    fn render_system_info(&self, frame: &mut Frame, area: Rect) {
-        let block = Block::default()
-            .title(Span::styled(
-                " Anvil \u{2014} Status Dashboard ",
-                self.theme.title_style(),
-            ))
-            .borders(Borders::ALL)
-            .border_style(self.theme.border_style());
-
+    /// Render the branded header bar
+    fn render_branded_header(&self, frame: &mut Frame, area: Rect) {
         let winget_span = if self.info.system_info.winget_available {
-            Span::styled("available", self.theme.success_style())
+            Span::styled("winget ✓", self.theme.success_style())
         } else {
-            Span::styled("not available", self.theme.error_style())
+            Span::styled("winget ✗", self.theme.error_style())
         };
 
-        let lines = vec![
-            Line::from(vec![Span::raw(format!(
-                "  Anvil Version: {}",
-                self.info.system_info.anvil_version
-            ))]),
-            Line::from(vec![Span::raw(format!(
-                "  OS: {}",
-                self.info.system_info.os
-            ))]),
-            Line::from(vec![Span::raw("  Winget: "), winget_span]),
-        ];
-
-        let paragraph = Paragraph::new(lines).block(block);
-        frame.render_widget(paragraph, area);
+        render_header(
+            frame,
+            area,
+            &self.theme,
+            &["Status"],
+            Some(Line::from(vec![
+                Span::styled(
+                    format!("v{}", self.info.system_info.anvil_version),
+                    self.theme.dimmed(),
+                ),
+                Span::styled(" · ", self.theme.faint_style()),
+                Span::styled(&self.info.system_info.os, self.theme.dimmed()),
+                Span::styled(" · ", self.theme.faint_style()),
+                winget_span,
+            ])),
+        );
     }
 
-    /// Render the source summary block
-    fn render_source_summary(&self, frame: &mut Frame, area: Rect) {
-        let block = Block::default()
-            .title(Span::styled(" Sources ", self.theme.title_style()))
+    /// Render stat summary blocks
+    fn render_stat_blocks(&self, frame: &mut Frame, area: Rect) {
+        let stats_cols = Layout::horizontal([
+            Constraint::Ratio(1, 3),
+            Constraint::Ratio(1, 3),
+            Constraint::Ratio(1, 3),
+        ])
+        .split(area);
+
+        // Workloads stat
+        let wl_block = Block::default()
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(self.theme.border_style());
+        let wl_inner = wl_block.inner(stats_cols[0]);
+        frame.render_widget(wl_block, stats_cols[0]);
+        let wl_lines = vec![Line::from(vec![
+            Span::styled(" WORKLOADS ", self.theme.label_style()),
+            Span::styled(
+                format!("{}", self.info.source_summary.total_workloads),
+                self.theme.title_style(),
+            ),
+        ])];
+        frame.render_widget(Paragraph::new(wl_lines), wl_inner);
 
-        let summary = format!(
-            "  Local: {}  Remote: {}  Total: {}",
-            self.info.source_summary.local_count,
-            self.info.source_summary.remote_count,
-            self.info.source_summary.total_workloads,
-        );
+        // Sources stat
+        let src_block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(self.theme.border_style());
+        let src_inner = src_block.inner(stats_cols[1]);
+        frame.render_widget(src_block, stats_cols[1]);
+        let src_lines = vec![Line::from(vec![
+            Span::styled(" SOURCES ", self.theme.label_style()),
+            Span::styled(
+                format!(
+                    "{} local · {} remote",
+                    self.info.source_summary.local_count, self.info.source_summary.remote_count
+                ),
+                self.theme.normal(),
+            ),
+        ])];
+        frame.render_widget(Paragraph::new(src_lines), src_inner);
 
-        let paragraph = Paragraph::new(Line::raw(summary)).block(block);
-        frame.render_widget(paragraph, area);
+        // Installed stat
+        let inst_block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(self.theme.border_style());
+        let inst_inner = inst_block.inner(stats_cols[2]);
+        frame.render_widget(inst_block, stats_cols[2]);
+        let inst_lines = vec![Line::from(vec![
+            Span::styled(" INSTALLED ", self.theme.label_style()),
+            Span::styled(
+                format!("{}", self.info.installed_workloads.len()),
+                self.theme.title_style(),
+            ),
+        ])];
+        frame.render_widget(Paragraph::new(inst_lines), inst_inner);
     }
 
     /// Render the installed workloads list
@@ -176,6 +214,7 @@ impl StatusDashboard {
         let block = Block::default()
             .title(Span::styled(title, self.theme.title_style()))
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(self.theme.border_style());
 
         let inner = block.inner(area);
@@ -199,17 +238,33 @@ impl StatusDashboard {
             .skip(self.scroll_offset)
             .take(visible_height)
             .map(|(i, w)| {
-                let text = format!("  {}  v{}  installed {}", w.name, w.version, w.installed_at);
                 if i == self.selected {
-                    Line::styled(
-                        text,
-                        Style::default()
-                            .bg(self.theme.accent)
-                            .fg(Color::Black)
-                            .add_modifier(Modifier::BOLD),
-                    )
+                    Line::from(vec![
+                        Span::styled("▌", Style::default().fg(self.theme.accent)),
+                        Span::styled(
+                            format!(" {}", w.name),
+                            self.theme.selection().bg(self.theme.bg_inset),
+                        ),
+                        Span::styled(
+                            format!("  v{}", w.version),
+                            Style::default()
+                                .fg(self.theme.muted)
+                                .bg(self.theme.bg_inset),
+                        ),
+                        Span::styled(
+                            format!("  {}", w.installed_at),
+                            Style::default()
+                                .fg(self.theme.faint)
+                                .bg(self.theme.bg_inset),
+                        ),
+                    ])
                 } else {
-                    Line::raw(text)
+                    Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(&w.name, self.theme.normal()),
+                        Span::styled(format!("  v{}", w.version), self.theme.dimmed()),
+                        Span::styled(format!("  {}", w.installed_at), self.theme.faint_style()),
+                    ])
                 }
             })
             .collect();

--- a/src/tui/widgets/chrome.rs
+++ b/src/tui/widgets/chrome.rs
@@ -1,0 +1,272 @@
+//! Reusable Anvil TUI widgets
+//!
+//! Small composable helpers shared across views: the branded header bar,
+//! status badges, gauges, heatmap strips, and the expandable error block.
+
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Gauge, Paragraph, Wrap},
+    Frame,
+};
+
+use ratatui::layout::Alignment;
+
+use crate::tui::theme::Theme;
+
+/// The `anvil` wordmark, followed by a breadcrumb trail.
+///
+/// Renders a single styled line:  `anvil │ Workloads › essentials`
+/// The last crumb is bold/primary; earlier crumbs are muted.
+pub fn header_line<'a>(theme: &Theme, crumbs: &'a [&'a str]) -> Line<'a> {
+    let mut spans: Vec<Span> = vec![
+        Span::styled("anvil", theme.brand_style()),
+        Span::styled(" │ ", Style::default().fg(theme.border)),
+    ];
+
+    for (i, crumb) in crumbs.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" › ", theme.faint_style()));
+        }
+        let last = i == crumbs.len() - 1;
+        let style = if last {
+            theme.normal().add_modifier(Modifier::BOLD)
+        } else {
+            theme.dimmed()
+        };
+        spans.push(Span::styled(*crumb, style));
+    }
+
+    Line::from(spans)
+}
+
+/// Render the header bar into `area` (typically Constraint::Length(1) inside
+/// a bg_alt block). `right` lines are drawn right-aligned on the same row.
+pub fn render_header(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    crumbs: &[&str],
+    right: Option<Line>,
+) {
+    // bg_alt fill
+    let bar = Block::default().style(Style::default().bg(theme.bg_alt));
+    frame.render_widget(bar, area);
+
+    let inner = Rect {
+        x: area.x + 1,
+        y: area.y,
+        width: area.width.saturating_sub(2),
+        height: area.height,
+    };
+
+    frame.render_widget(Paragraph::new(header_line(theme, crumbs)), inner);
+
+    if let Some(right_line) = right {
+        frame.render_widget(
+            Paragraph::new(right_line).alignment(Alignment::Right),
+            inner,
+        );
+    }
+}
+
+/// A small uppercase pill badge, e.g. `[local]`, `OK`, `3 ISSUES`.
+pub fn badge<'a>(text: &'a str, fg: ratatui::style::Color) -> Span<'a> {
+    Span::styled(
+        format!(" {text} "),
+        Style::default().fg(fg).add_modifier(Modifier::BOLD),
+    )
+}
+
+/// Build a Gauge widget styled to the theme.
+///
+/// `ratio` in 0.0..=1.0. `color` is the fill (accent / success / running).
+pub fn gauge<'a>(
+    theme: &Theme,
+    ratio: f64,
+    color: ratatui::style::Color,
+    label: Option<String>,
+) -> Gauge<'a> {
+    let mut g = Gauge::default()
+        .gauge_style(Style::default().fg(color).bg(theme.bg_inset))
+        .ratio(ratio.clamp(0.0, 1.0))
+        .use_unicode(true);
+    if let Some(l) = label {
+        g = g.label(Span::styled(
+            l,
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+        ));
+    }
+    g
+}
+
+/// A heatmap strip: one colored cell per check result.
+/// Renders into `area` as a row of `▮` blocks (green = pass, ember = fail).
+///
+/// `results`: true = pass, false = fail. Cells beyond `area.width` are dropped.
+#[allow(dead_code)]
+pub fn render_heatmap(frame: &mut Frame, area: Rect, theme: &Theme, results: &[bool]) {
+    let cells: Vec<Span> = results
+        .iter()
+        .take(area.width as usize)
+        .map(|&pass| {
+            let c = if pass { theme.success } else { theme.error };
+            Span::styled("▮", Style::default().fg(c))
+        })
+        .collect();
+    frame.render_widget(Paragraph::new(Line::from(cells)), area);
+}
+
+/// A mini sparkline-style health bar: 8 cells filled proportional to `health`
+/// (0..=100). Used in Status / Browser rows. Returns a Line of styled Spans.
+#[allow(dead_code)]
+pub fn health_bar<'a>(theme: &Theme, health: u8) -> Line<'a> {
+    let filled = ((health as usize * 8) / 100).min(8);
+    let color = if health >= 90 {
+        theme.success
+    } else if health >= 70 {
+        theme.warning
+    } else {
+        theme.error
+    };
+    let mut spans: Vec<Span> = Vec::with_capacity(9);
+    for i in 0..8 {
+        let style = if i < filled {
+            Style::default().fg(color)
+        } else {
+            Style::default().fg(theme.bg_inset)
+        };
+        spans.push(Span::styled("▮", style));
+    }
+    spans.push(Span::styled(
+        format!(" {health}%"),
+        Style::default().fg(color),
+    ));
+    Line::from(spans)
+}
+
+/// Render an expandable error block beneath a failed health item.
+///
+/// When collapsed, the caller renders the (possibly truncated) message
+/// inline & right-aligned. When `expanded`, call this to draw the full
+/// wrapped message in a tinted, bordered block.
+#[allow(dead_code)]
+pub fn render_error_block(frame: &mut Frame, area: Rect, theme: &Theme, message: &str) {
+    let block = Block::bordered()
+        .border_style(Style::default().fg(theme.error))
+        .style(Style::default().bg(theme.bg_inset));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let para = Paragraph::new(Span::styled(message, theme.error_style())).wrap(Wrap { trim: true });
+    frame.render_widget(para, inner);
+}
+
+/// Truncate a string to `max` display columns, appending `…` if cut.
+/// (Column-accurate enough for ASCII / typical winget IDs.)
+#[allow(dead_code)]
+pub fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let keep = max.saturating_sub(1);
+        format!("{}…", s.chars().take(keep).collect::<String>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    #[test]
+    fn test_header_line_single_crumb() {
+        let theme = Theme::dark();
+        let line = header_line(&theme, &["Workloads"]);
+        assert!(!line.spans.is_empty());
+    }
+
+    #[test]
+    fn test_header_line_multiple_crumbs() {
+        let theme = Theme::dark();
+        let line = header_line(&theme, &["Workloads", "essentials"]);
+        // Should have: anvil, separator, crumb1, separator, crumb2
+        assert!(line.spans.len() >= 5);
+    }
+
+    #[test]
+    fn test_badge_styling() {
+        let b = badge("OK", ratatui::style::Color::Green);
+        assert!(b.content.contains("OK"));
+    }
+
+    #[test]
+    fn test_gauge_clamping() {
+        let theme = Theme::dark();
+        let g = gauge(&theme, 1.5, theme.accent, Some("over".to_string()));
+        // Should not panic — ratio is clamped
+        let _ = g;
+    }
+
+    #[test]
+    fn test_health_bar_values() {
+        let theme = Theme::dark();
+        let bar_100 = health_bar(&theme, 100);
+        assert!(!bar_100.spans.is_empty());
+        let bar_0 = health_bar(&theme, 0);
+        assert!(!bar_0.spans.is_empty());
+    }
+
+    #[test]
+    fn test_truncate_short() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_exact() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_long() {
+        assert_eq!(truncate("hello world", 6), "hello…");
+    }
+
+    #[test]
+    fn test_render_header_no_panic() {
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::dark();
+        terminal
+            .draw(|f| {
+                render_header(f, f.area(), &theme, &["Workloads"], None);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_heatmap_no_panic() {
+        let backend = TestBackend::new(20, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::dark();
+        let results = vec![true, true, false, true, false];
+        terminal
+            .draw(|f| {
+                render_heatmap(f, f.area(), &theme, &results);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_render_error_block_no_panic() {
+        let backend = TestBackend::new(40, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::dark();
+        terminal
+            .draw(|f| {
+                render_error_block(f, f.area(), &theme, "Something went wrong");
+            })
+            .unwrap();
+    }
+}

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -1,5 +1,6 @@
 //! Shared TUI widgets
 
+pub mod chrome;
 pub mod keyhints;
 pub mod progress;
 pub mod status;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1078,12 +1078,12 @@ mod global_flags {
     }
 
     #[test]
-    fn no_args_shows_help() {
-        // With arg_required_else_help, no args should show help
+    fn no_args_shows_workload_browser() {
+        // With no subcommand in a non-TTY test context, falls back to help
         anvil()
             .assert()
-            .failure()
-            .stderr(predicate::str::contains("Usage").or(predicate::str::contains("Commands")));
+            .success()
+            .stdout(predicate::str::contains("Usage").or(predicate::str::contains("Commands")));
     }
 }
 


### PR DESCRIPTION
## Description

Launch the TUI workload browser by default when running `anvil` with no subcommand, apply the Flexoki dark theme across all TUI views, and add tabbed detail navigation with install/dry-run actions.

### What's included

- **Default TUI browser** — running `anvil` without a subcommand now opens the interactive workload browser. Falls back to `--help` when stdin is not a TTY.
- **Flexoki dark theme** — replaces the amber/gold palette with a Flexoki dark base and ember red (#D14D41) accent. Adds section-colored icons, hairline dividers, and a `SectionKind` enum for consistent hue assignment.
- **Chrome widget library** — new `widgets/chrome.rs` with reusable `render_header`, `badge`, `gauge`, `heatmap`, `health_bar`, and `error_block` widgets used across all views.
- **Browser redesign** — bordered panes with rounded corners, vertical/horizontal divider, search bar with bg_inset, right-aligned version/package columns, two-column CONTENTS grid, SOURCE section, and metadata row.
- **Tabbed detail view** — replaces collapsible sections with 6 tabs (Overview, Packages, Files, Commands, Config, Assertions) navigated via ←/→ arrows.
- **Install/dry-run from TUI** — press `i` or `d` in the browser or detail view to install or dry-run the focused workload. Uses actual filesystem path for correct resolution across all configured sources.
- **Windows input fixes** — filters `KeyEventKind::Press` to prevent double keystrokes, drains stale input buffer on startup to prevent phantom Enter.
- **View updates** — health (inline heatmap, pass/fail badge), install (progress gauge, phase chips), and status (stat blocks, system info) views all updated with themed rendering.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)