### PR TITLE
feat: redesign TUI views with inline health check and install history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Two-column CONTENTS grid in the browser preview pane showing package, file, font, feature, command, and assertion counts
 - Bordered panes with rounded corners and hairline section dividers in the browser view
 - `SOURCE` and metadata sections in the browser detail preview
+- Health check action from the browser (`h` keybinding) with live progress and log output
+- Health view runs inline within the TUI session — `Esc` returns to browser, `q` quits the app
+- Install history view with columnar table, detail pane, re-install action, and log viewer
+- Columnar table layout for Packages, Files, Commands, and Assertions tabs in the detail view
+- Inline progress gauge with animated spinner in the install dashboard phase headers
+- `HealthEvent` / `HealthPhase` event types for channel-based health check progress
 
 ### Changed
 
 - Replaced amber/gold TUI theme with Flexoki dark palette (ember red accent, section-colored icons)
 - Detail view uses tabbed navigation instead of collapsible sections
-- Health view shows inline heatmap per section and summary strip with pass/fail badge
-- Install dashboard shows overall progress gauge with phase chips and split body layout
+- Detail view shows column headers (PACKAGE ID / VERSION / SOURCE) for table-style tabs
+- Detail view description, path, and tabs rendered as separate padded sections with hairline dividers
+- Health view shows inline gauge bar with pass/fail summary, `N ISSUES` badge, and section heatmaps
+- Health view expanded errors render in a word-wrapped `bg_inset` background box
+- Install dashboard renders inline ASCII gauge bar instead of widget-based gauge
+- Install dashboard shows phase chips with animated spinner on active phase
+- Install dashboard log pane uses `LOG` uppercase header with auto-scrolling timestamped entries
 - Status dashboard uses stat blocks with branded header and system info
 - Browser list items show right-aligned version and package count columns
 - Replaced emoji icons with single-width ASCII characters for consistent terminal alignment
-- Key hints bar updated to show all available actions (`↵ open`, `h health`, etc.)
+- Key hints bar updated across all views with consistent symbols (`↕`, `↵`, `↑↓`, `←→`)
 
 ### Fixed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,22 @@ fn launch_default_tui() -> Result<()> {
                             dry_run: true,
                         });
                     }
+                    BrowserOutcome::Health(name, path) => {
+                        let health_outcome = operations::health::execute_health_inline(
+                            &mut tui_instance,
+                            &path,
+                            &name,
+                        )?;
+                        match health_outcome {
+                            tui::views::health::HealthOutcome::Back => {
+                                browser.reset();
+                                continue;
+                            }
+                            tui::views::health::HealthOutcome::Quit => {
+                                return Ok(TuiAction::Quit);
+                            }
+                        }
+                    }
                     BrowserOutcome::Select(selected_name) => {
                         let detail = load_workload_detail(&mut manager, &selected_name);
                         let mut detail_view = tui::views::detail::DetailView::new(detail);

--- a/src/operations/health.rs
+++ b/src/operations/health.rs
@@ -124,7 +124,7 @@ pub fn execute(args: &HealthArgs, cli: &Cli) -> Result<()> {
         && crate::tui::should_use_tui()
     {
         let report = build_tui_health_report(&workload.name, &checks);
-        crate::tui::views::health::run_health_viewer(report)?;
+        let _outcome = crate::tui::views::health::run_health_viewer(report)?;
         return Ok(());
     }
 
@@ -818,4 +818,332 @@ fn build_tui_health_report(
         sections,
         duration: std::time::Duration::ZERO,
     }
+}
+
+/// Execute health check with live TUI progress view.
+///
+/// Runs the health checks in a background thread, sending events to the TUI
+/// viewer in real-time, then transitions to the results view.
+#[allow(dead_code)]
+pub fn execute_with_tui(workload_path: &str, workload_name: &str) -> Result<()> {
+    use crate::tui::events::{HealthEvent, HealthPhase};
+    use std::sync::mpsc;
+    use std::time::Instant;
+
+    let (event_tx, event_rx) = mpsc::channel::<HealthEvent>();
+    let (report_tx, report_rx) = mpsc::channel::<crate::tui::views::health::HealthReport>();
+
+    let path_owned = workload_path.to_string();
+    let name_owned = workload_name.to_string();
+
+    // Run health checks in a background thread
+    std::thread::spawn(move || {
+        let start = Instant::now();
+        let mut config_manager = ConfigManager::new();
+
+        let workload = match config_manager.load_resolved(&path_owned) {
+            Ok(w) => w,
+            Err(e) => {
+                let _ = event_tx.send(HealthEvent::Log {
+                    message: format!("Error loading workload: {}", e),
+                });
+                let _ = event_tx.send(HealthEvent::Done {
+                    duration: start.elapsed(),
+                });
+                return;
+            }
+        };
+
+        let mut all_checks: Vec<CheckResult> = Vec::new();
+
+        // Package checks
+        let packages = workload
+            .packages
+            .as_ref()
+            .map(|p| p.winget.as_deref().unwrap_or(&[]).len())
+            .unwrap_or(0);
+        if packages > 0 {
+            let _ = event_tx.send(HealthEvent::PhaseStart {
+                phase: HealthPhase::Packages,
+                total: packages,
+            });
+        }
+
+        match check_packages(&workload, 0, true) {
+            Ok((checks, _, _)) => {
+                for check in &checks {
+                    let passed = check.status == CheckStatus::Ok;
+                    let _ = event_tx.send(HealthEvent::ItemComplete {
+                        phase: HealthPhase::Packages,
+                        name: check.name.clone(),
+                        passed,
+                        message: check.message.clone(),
+                    });
+                }
+                all_checks.extend(checks);
+                if packages > 0 {
+                    let _ = event_tx.send(HealthEvent::PhaseComplete {
+                        phase: HealthPhase::Packages,
+                    });
+                }
+            }
+            Err(e) => {
+                let _ = event_tx.send(HealthEvent::Log {
+                    message: format!("Package check error: {}", e),
+                });
+            }
+        }
+
+        // File checks
+        let workload_yaml_path = resolve_workload_path(&path_owned, None).unwrap_or_default();
+        let workload_dir = workload_yaml_path
+            .parent()
+            .unwrap_or(&workload_yaml_path)
+            .to_path_buf();
+        let file_count = workload.files.as_ref().map(|f| f.len()).unwrap_or(0);
+        if file_count > 0 {
+            let _ = event_tx.send(HealthEvent::PhaseStart {
+                phase: HealthPhase::Files,
+                total: file_count,
+            });
+        }
+
+        match check_files(&workload, &workload_dir, 0, false) {
+            Ok(checks) => {
+                for check in &checks {
+                    let passed = check.status == CheckStatus::Ok;
+                    let _ = event_tx.send(HealthEvent::ItemComplete {
+                        phase: HealthPhase::Files,
+                        name: check.name.clone(),
+                        passed,
+                        message: check.message.clone(),
+                    });
+                }
+                all_checks.extend(checks);
+                if file_count > 0 {
+                    let _ = event_tx.send(HealthEvent::PhaseComplete {
+                        phase: HealthPhase::Files,
+                    });
+                }
+            }
+            Err(e) => {
+                let _ = event_tx.send(HealthEvent::Log {
+                    message: format!("File check error: {}", e),
+                });
+            }
+        }
+
+        // Assertion checks
+        let health_config = workload.health.as_ref().cloned().unwrap_or_default();
+        if health_config.assertion_check {
+            if let Some(assertions) = &workload.assertions {
+                let _ = event_tx.send(HealthEvent::PhaseStart {
+                    phase: HealthPhase::Assertions,
+                    total: assertions.len(),
+                });
+
+                let assertion_pairs: Vec<(String, crate::conditions::Condition)> = assertions
+                    .iter()
+                    .map(|a| (a.name.clone(), a.check.clone()))
+                    .collect();
+
+                let assertion_results = crate::assertions::evaluate_assertions(&assertion_pairs);
+                let assertion_checks = crate::assertions::to_check_results(&assertion_results);
+
+                for check in &assertion_checks {
+                    let passed = check.status == CheckStatus::Ok;
+                    let _ = event_tx.send(HealthEvent::ItemComplete {
+                        phase: HealthPhase::Assertions,
+                        name: check.name.clone(),
+                        passed,
+                        message: check.message.clone(),
+                    });
+                }
+                all_checks.extend(assertion_checks);
+
+                let _ = event_tx.send(HealthEvent::PhaseComplete {
+                    phase: HealthPhase::Assertions,
+                });
+            }
+        }
+
+        let duration = start.elapsed();
+        let _ = event_tx.send(HealthEvent::Done { duration });
+
+        // Build and send the final report
+        let mut report = build_tui_health_report(&name_owned, &all_checks);
+        report.duration = duration;
+        let _ = report_tx.send(report);
+    });
+
+    crate::tui::views::health::run_health_with_events(
+        workload_name.to_string(),
+        event_rx,
+        report_rx,
+    )?;
+    Ok(())
+}
+
+/// Execute health check inline within an existing TUI session.
+///
+/// Used when launching health from the browser — stays in the same
+/// alternate screen and returns Back/Quit to the caller.
+pub fn execute_health_inline(
+    tui: &mut crate::tui::Tui,
+    workload_path: &str,
+    workload_name: &str,
+) -> Result<crate::tui::views::health::HealthOutcome> {
+    use crate::tui::events::{HealthEvent, HealthPhase};
+    use std::sync::mpsc;
+    use std::time::Instant;
+
+    let (event_tx, event_rx) = mpsc::channel::<HealthEvent>();
+    let (report_tx, report_rx) = mpsc::channel::<crate::tui::views::health::HealthReport>();
+
+    let path_owned = workload_path.to_string();
+    let name_owned = workload_name.to_string();
+
+    // Run health checks in a background thread (same logic as execute_with_tui)
+    std::thread::spawn(move || {
+        let start = Instant::now();
+        let mut config_manager = ConfigManager::new();
+
+        let workload = match config_manager.load_resolved(&path_owned) {
+            Ok(w) => w,
+            Err(e) => {
+                let _ = event_tx.send(HealthEvent::Log {
+                    message: format!("Error loading workload: {}", e),
+                });
+                let _ = event_tx.send(HealthEvent::Done {
+                    duration: start.elapsed(),
+                });
+                return;
+            }
+        };
+
+        let mut all_checks: Vec<CheckResult> = Vec::new();
+
+        // Package checks
+        let packages = workload
+            .packages
+            .as_ref()
+            .map(|p| p.winget.as_deref().unwrap_or(&[]).len())
+            .unwrap_or(0);
+        if packages > 0 {
+            let _ = event_tx.send(HealthEvent::PhaseStart {
+                phase: HealthPhase::Packages,
+                total: packages,
+            });
+        }
+        match check_packages(&workload, 0, true) {
+            Ok((checks, _, _)) => {
+                for check in &checks {
+                    let passed = check.status == CheckStatus::Ok;
+                    let _ = event_tx.send(HealthEvent::ItemComplete {
+                        phase: HealthPhase::Packages,
+                        name: check.name.clone(),
+                        passed,
+                        message: check.message.clone(),
+                    });
+                }
+                all_checks.extend(checks);
+                if packages > 0 {
+                    let _ = event_tx.send(HealthEvent::PhaseComplete {
+                        phase: HealthPhase::Packages,
+                    });
+                }
+            }
+            Err(e) => {
+                let _ = event_tx.send(HealthEvent::Log {
+                    message: format!("Package check error: {}", e),
+                });
+            }
+        }
+
+        // File checks
+        let workload_yaml_path = resolve_workload_path(&path_owned, None).unwrap_or_default();
+        let workload_dir = workload_yaml_path
+            .parent()
+            .unwrap_or(&workload_yaml_path)
+            .to_path_buf();
+        let file_count = workload.files.as_ref().map(|f| f.len()).unwrap_or(0);
+        if file_count > 0 {
+            let _ = event_tx.send(HealthEvent::PhaseStart {
+                phase: HealthPhase::Files,
+                total: file_count,
+            });
+        }
+        match check_files(&workload, &workload_dir, 0, false) {
+            Ok(checks) => {
+                for check in &checks {
+                    let passed = check.status == CheckStatus::Ok;
+                    let _ = event_tx.send(HealthEvent::ItemComplete {
+                        phase: HealthPhase::Files,
+                        name: check.name.clone(),
+                        passed,
+                        message: check.message.clone(),
+                    });
+                }
+                all_checks.extend(checks);
+                if file_count > 0 {
+                    let _ = event_tx.send(HealthEvent::PhaseComplete {
+                        phase: HealthPhase::Files,
+                    });
+                }
+            }
+            Err(e) => {
+                let _ = event_tx.send(HealthEvent::Log {
+                    message: format!("File check error: {}", e),
+                });
+            }
+        }
+
+        // Assertion checks
+        let health_config = workload.health.as_ref().cloned().unwrap_or_default();
+        if health_config.assertion_check {
+            if let Some(assertions) = &workload.assertions {
+                let _ = event_tx.send(HealthEvent::PhaseStart {
+                    phase: HealthPhase::Assertions,
+                    total: assertions.len(),
+                });
+
+                let assertion_pairs: Vec<(String, crate::conditions::Condition)> = assertions
+                    .iter()
+                    .map(|a| (a.name.clone(), a.check.clone()))
+                    .collect();
+
+                let assertion_results = crate::assertions::evaluate_assertions(&assertion_pairs);
+                let assertion_checks = crate::assertions::to_check_results(&assertion_results);
+
+                for check in &assertion_checks {
+                    let passed = check.status == CheckStatus::Ok;
+                    let _ = event_tx.send(HealthEvent::ItemComplete {
+                        phase: HealthPhase::Assertions,
+                        name: check.name.clone(),
+                        passed,
+                        message: check.message.clone(),
+                    });
+                }
+                all_checks.extend(assertion_checks);
+
+                let _ = event_tx.send(HealthEvent::PhaseComplete {
+                    phase: HealthPhase::Assertions,
+                });
+            }
+        }
+
+        let duration = start.elapsed();
+        let _ = event_tx.send(HealthEvent::Done { duration });
+
+        let mut report = build_tui_health_report(&name_owned, &all_checks);
+        report.duration = duration;
+        let _ = report_tx.send(report);
+    });
+
+    crate::tui::views::health::run_health_inline(
+        tui,
+        workload_name.to_string(),
+        event_rx,
+        report_rx,
+    )
 }

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -76,7 +76,8 @@ pub fn execute(args: &ListArgs, cli: &Cli) -> Result<()> {
         match crate::tui::views::browser::run_browser(entries)? {
             crate::tui::views::browser::BrowserOutcome::Select(name)
             | crate::tui::views::browser::BrowserOutcome::Install(name, _)
-            | crate::tui::views::browser::BrowserOutcome::DryRun(name, _) => {
+            | crate::tui::views::browser::BrowserOutcome::DryRun(name, _)
+            | crate::tui::views::browser::BrowserOutcome::Health(name, _) => {
                 println!("{}", name);
             }
             crate::tui::views::browser::BrowserOutcome::Quit => {}

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,7 +1,7 @@
-//! Install event types for TUI communication
+//! Event types for TUI communication
 //!
-//! These types define the channel-based protocol between the install
-//! logic (sender) and the TUI dashboard (receiver).
+//! These types define the channel-based protocol between the operations
+//! logic (sender) and the TUI dashboards (receiver).
 
 use std::time::Duration;
 
@@ -76,6 +76,50 @@ pub enum InstallEvent {
         summary: String,
         duration: Duration,
     },
+}
+
+/// Phases of the health check process
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthPhase {
+    Packages,
+    Files,
+    Assertions,
+}
+
+impl HealthPhase {
+    /// Human-readable label
+    pub fn label(&self) -> &str {
+        match self {
+            HealthPhase::Packages => "Packages",
+            HealthPhase::Files => "Files",
+            HealthPhase::Assertions => "Assertions",
+        }
+    }
+}
+
+/// Events sent from health check logic to the TUI
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum HealthEvent {
+    /// A phase is starting
+    PhaseStart { phase: HealthPhase, total: usize },
+
+    /// An individual item check completed
+    ItemComplete {
+        phase: HealthPhase,
+        name: String,
+        passed: bool,
+        message: Option<String>,
+    },
+
+    /// A phase completed
+    PhaseComplete { phase: HealthPhase },
+
+    /// A log message
+    Log { message: String },
+
+    /// Health check is done
+    Done { duration: Duration },
 }
 
 #[cfg(test)]

--- a/src/tui/views/browser.rs
+++ b/src/tui/views/browser.rs
@@ -49,6 +49,8 @@ pub enum BrowserOutcome {
     Install(String, String),
     /// User requested dry-run of a workload (name, path)
     DryRun(String, String),
+    /// User requested health check of a workload (name, path)
+    Health(String, String),
 }
 
 /// Browser layout mode for the list + preview panes
@@ -167,6 +169,14 @@ impl WorkloadBrowser {
             KeyCode::Char('d') if key.modifiers == KeyModifiers::NONE && !self.searching => {
                 if let Some((name, path)) = self.focused_name_and_path() {
                     self.outcome = Some(BrowserOutcome::DryRun(name, path));
+                    self.quit = true;
+                }
+            }
+
+            // Health check focused workload
+            KeyCode::Char('h') if key.modifiers == KeyModifiers::NONE && !self.searching => {
+                if let Some((name, path)) = self.focused_name_and_path() {
+                    self.outcome = Some(BrowserOutcome::Health(name, path));
                     self.quit = true;
                 }
             }

--- a/src/tui/views/detail.rs
+++ b/src/tui/views/detail.rs
@@ -10,10 +10,7 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::Style,
     text::{Line, Span},
-    widgets::{
-        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-        Tabs,
-    },
+    widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Tabs},
     Frame,
 };
 
@@ -264,22 +261,81 @@ impl DetailView {
         if items.is_empty() {
             return vec![Line::styled("  No items", self.theme.dimmed())];
         }
+
+        // For the packages tab, render as table with columns
+        if self.active_tab == TAB_PACKAGES {
+            return self.build_package_table_lines(items, highlight_style);
+        }
+
         items
             .iter()
             .enumerate()
             .map(|(i, item)| {
-                let style = if let Some(hl) = highlight_style.filter(|_| i == self.selected) {
-                    hl
+                let is_selected = i == self.selected && highlight_style.is_some();
+                let style = if is_selected {
+                    highlight_style.unwrap_or(self.theme.normal())
                 } else {
                     self.theme.normal()
                 };
+                let bg = if is_selected {
+                    Style::default().bg(self.theme.bg_inset)
+                } else {
+                    Style::default()
+                };
                 Line::from(vec![
-                    if Some(i) == Some(self.selected) && highlight_style.is_some() {
+                    if is_selected {
                         Span::styled("▌", Style::default().fg(self.theme.accent))
                     } else {
                         Span::raw(" ")
                     },
-                    Span::styled(format!(" {}", item), style),
+                    Span::styled(format!(" {}", item), style.patch(bg)),
+                ])
+            })
+            .collect()
+    }
+
+    /// Build package table rows with PACKAGE ID, VERSION, SOURCE columns
+    fn build_package_table_lines<'a>(
+        &'a self,
+        items: &'a [String],
+        highlight_style: Option<Style>,
+    ) -> Vec<Line<'a>> {
+        items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                let is_selected = i == self.selected && highlight_style.is_some();
+                let base_style = if is_selected {
+                    highlight_style.unwrap_or(self.theme.normal())
+                } else {
+                    self.theme.normal()
+                };
+                let bg = if is_selected {
+                    Style::default().bg(self.theme.bg_inset)
+                } else {
+                    Style::default()
+                };
+
+                // Package ID is the item text, version is "latest", source is "winget"
+                let id_width = 40usize;
+                let id_display = if item.len() > id_width {
+                    format!("{}…", &item[..id_width - 1])
+                } else {
+                    format!("{:<width$}", item, width = id_width)
+                };
+
+                Line::from(vec![
+                    if is_selected {
+                        Span::styled("▌", Style::default().fg(self.theme.accent))
+                    } else {
+                        Span::raw(" ")
+                    },
+                    Span::styled(format!(" {}", id_display), base_style.patch(bg)),
+                    Span::styled(
+                        format!("{:<12}", "latest"),
+                        self.theme.faint_style().patch(bg),
+                    ),
+                    Span::styled("winget", self.theme.faint_style().patch(bg)),
                 ])
             })
             .collect()
@@ -294,18 +350,26 @@ impl DetailView {
             .iter()
             .enumerate()
             .map(|(i, f)| {
-                let style = if let Some(hl) = highlight_style.filter(|_| i == self.selected) {
-                    hl
+                let is_selected = i == self.selected && highlight_style.is_some();
+                let style = if is_selected {
+                    highlight_style.unwrap_or(self.theme.normal())
                 } else {
                     self.theme.normal()
                 };
+                let bg = if is_selected {
+                    Style::default().bg(self.theme.bg_inset)
+                } else {
+                    Style::default()
+                };
+                let src = format!("{:<38}", f.source);
                 Line::from(vec![
-                    if Some(i) == Some(self.selected) && highlight_style.is_some() {
+                    if is_selected {
                         Span::styled("▌", Style::default().fg(self.theme.accent))
                     } else {
                         Span::raw(" ")
                     },
-                    Span::styled(format!(" {} → {}", f.source, f.destination), style),
+                    Span::styled(format!(" {}", src), style.patch(bg)),
+                    Span::styled(&f.destination, self.theme.faint_style().patch(bg)),
                 ])
             })
             .collect()
@@ -320,18 +384,26 @@ impl DetailView {
             .iter()
             .enumerate()
             .map(|(i, c)| {
-                let style = if let Some(hl) = highlight_style.filter(|_| i == self.selected) {
-                    hl
+                let is_selected = i == self.selected && highlight_style.is_some();
+                let style = if is_selected {
+                    highlight_style.unwrap_or(self.theme.normal())
                 } else {
                     self.theme.normal()
                 };
+                let bg = if is_selected {
+                    Style::default().bg(self.theme.bg_inset)
+                } else {
+                    Style::default()
+                };
+                let phase = format!("{:<12}", c.phase);
                 Line::from(vec![
-                    if Some(i) == Some(self.selected) && highlight_style.is_some() {
+                    if is_selected {
                         Span::styled("▌", Style::default().fg(self.theme.accent))
                     } else {
                         Span::raw(" ")
                     },
-                    Span::styled(format!(" [{}] {}", c.phase, c.name), style),
+                    Span::styled(format!(" {}", phase), self.theme.faint_style().patch(bg)),
+                    Span::styled(&c.name, style.patch(bg)),
                 ])
             })
             .collect()
@@ -416,33 +488,65 @@ impl DetailView {
         let area = frame.area();
 
         let chunks = Layout::vertical([
-            Constraint::Length(1), // branded header
+            Constraint::Length(1), // branded header with breadcrumb + version/source badges
+            Constraint::Length(1), // blank padding
+            Constraint::Length(1), // description
+            Constraint::Length(1), // path
+            Constraint::Length(1), // blank padding
             Constraint::Length(1), // tabs
-            Constraint::Length(2), // description + path strip
+            Constraint::Length(1), // hairline divider
             Constraint::Min(3),    // main content
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
         self.render_branded_header(frame, chunks[0]);
-        self.render_tabs(frame, chunks[1]);
-        self.render_info_strip(frame, chunks[2]);
-        self.render_main(frame, chunks[3]);
-        self.render_keyhints(frame, chunks[4]);
+        // chunks[1] is blank padding
+        self.render_description(frame, chunks[2]);
+        self.render_path(frame, chunks[3]);
+        // chunks[4] is blank padding
+        self.render_tabs(frame, chunks[5]);
+        self.render_divider(frame, chunks[6]);
+        self.render_main(frame, chunks[7]);
+        self.render_keyhints(frame, chunks[8]);
     }
 
-    /// Render the branded header bar with breadcrumb
+    /// Render the branded header bar with breadcrumb + right-aligned version/source badges
     fn render_branded_header(&self, frame: &mut Frame, area: Rect) {
+        let source_label = "LOCAL";
+        let source_color = self.theme.success;
+        let version_text = format!("V{}", self.detail.version);
+
         render_header(
             frame,
             area,
             &self.theme,
             &["Workloads", &self.detail.name],
-            Some(Line::from(vec![Span::styled(
-                format!("v{}", self.detail.version),
-                self.theme.dimmed(),
-            )])),
+            Some(Line::from(vec![
+                Span::styled(&version_text, Style::default().fg(self.theme.faint)),
+                Span::raw("  "),
+                Span::styled(source_label, Style::default().fg(source_color)),
+            ])),
         );
+    }
+
+    /// Render the description line
+    fn render_description(&self, frame: &mut Frame, area: Rect) {
+        let para = Paragraph::new(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(&self.detail.description, self.theme.body()),
+        ]));
+        frame.render_widget(para, area);
+    }
+
+    /// Render the path line
+    fn render_path(&self, frame: &mut Frame, area: Rect) {
+        let para = Paragraph::new(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Path: ", self.theme.faint_style()),
+            Span::styled(&self.detail.path, self.theme.running_style()),
+        ]));
+        frame.render_widget(para, area);
     }
 
     /// Render the tabs bar
@@ -452,40 +556,57 @@ impl DetailView {
             .select(self.active_tab)
             .style(self.theme.dimmed())
             .highlight_style(self.theme.brand_style())
-            .divider(Span::styled("·", self.theme.faint_style()));
-        frame.render_widget(tabs, area);
+            .divider(Span::raw("  "))
+            .padding("  ", "");
+        let padded = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: area.height,
+        };
+        frame.render_widget(tabs, padded);
     }
 
-    /// Render the description + path info strip
-    fn render_info_strip(&self, frame: &mut Frame, area: Rect) {
-        let lines = vec![
-            Line::from(vec![
-                Span::raw(" "),
-                Span::styled(&self.detail.description, self.theme.body()),
-            ]),
-            Line::from(vec![
-                Span::raw(" "),
-                Span::styled(&self.detail.path, self.theme.running_style()),
-            ]),
-        ];
-        let paragraph = Paragraph::new(lines);
-        frame.render_widget(paragraph, area);
+    /// Render a hairline divider
+    fn render_divider(&self, frame: &mut Frame, area: Rect) {
+        let divider_text = "─".repeat(area.width as usize);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                divider_text,
+                Style::default().fg(self.theme.hairline),
+            ))),
+            area,
+        );
     }
 
     /// Render the main content area for the active tab
     fn render_main(&self, frame: &mut Frame, area: Rect) {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(self.theme.border_style());
-
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-
         let highlight = self.theme.selection().bg(self.theme.bg_inset);
-        let lines = self.build_tab_lines(Some(highlight));
 
-        let visible_height = inner.height as usize;
+        // For Packages/Files/Commands/Assertions tabs, show column header + hairline + scrollable list
+        let has_column_header = matches!(
+            self.active_tab,
+            TAB_PACKAGES | TAB_FILES | TAB_COMMANDS | TAB_ASSERTIONS
+        );
+
+        let (header_area, content_area) = if has_column_header {
+            let parts = Layout::vertical([
+                Constraint::Length(1), // column header
+                Constraint::Length(1), // hairline
+                Constraint::Min(1),    // content
+            ])
+            .split(area);
+            self.render_column_header(frame, parts[0]);
+            self.render_divider(frame, parts[1]);
+            (Some(parts[0]), parts[2])
+        } else {
+            (None, area)
+        };
+
+        let _ = header_area;
+
+        let lines = self.build_tab_lines(Some(highlight));
+        let visible_height = content_area.height as usize;
         let total = lines.len();
         let max_scroll = total.saturating_sub(visible_height);
 
@@ -506,26 +627,65 @@ impl DetailView {
             .collect();
 
         let paragraph = Paragraph::new(visible_lines);
-        frame.render_widget(paragraph, inner);
+        frame.render_widget(paragraph, content_area);
 
         // Scrollbar
         if max_scroll > 0 {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
             let mut scrollbar_state = ScrollbarState::new(max_scroll).position(scroll);
-            frame.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+            frame.render_stateful_widget(scrollbar, content_area, &mut scrollbar_state);
         }
+    }
+
+    /// Render column headers for table-style tabs
+    fn render_column_header(&self, frame: &mut Frame, area: Rect) {
+        let header_style = self.theme.label_style();
+        let line = match self.active_tab {
+            TAB_PACKAGES => {
+                let id_width = (area.width as usize).saturating_sub(30);
+                Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(
+                        format!("{:<width$}", "PACKAGE ID", width = id_width),
+                        header_style,
+                    ),
+                    Span::styled(format!("{:<12}", "VERSION"), header_style),
+                    Span::styled("SOURCE", header_style),
+                ])
+            }
+            TAB_FILES => Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format!("{:<40}", "SOURCE"), header_style),
+                Span::styled("DESTINATION", header_style),
+            ]),
+            TAB_COMMANDS => Line::from(vec![
+                Span::raw("  "),
+                Span::styled(format!("{:<14}", "PHASE"), header_style),
+                Span::styled("NAME", header_style),
+            ]),
+            TAB_ASSERTIONS => Line::from(vec![
+                Span::raw("  "),
+                Span::styled("ASSERTION", header_style),
+            ]),
+            _ => Line::raw(""),
+        };
+        frame.render_widget(Paragraph::new(line), area);
     }
 
     /// Render the key hints bar
     fn render_keyhints(&self, frame: &mut Frame, area: Rect) {
         let hints = vec![
             KeyHint {
-                key: "←/→",
+                key: "↑↓",
+                desc: "navigate",
+            },
+            KeyHint {
+                key: "←→",
                 desc: "tabs",
             },
             KeyHint {
-                key: "↑/↓",
-                desc: "scroll",
+                key: "↵",
+                desc: "expand",
             },
             KeyHint {
                 key: "i",
@@ -536,12 +696,12 @@ impl DetailView {
                 desc: "dry-run",
             },
             KeyHint {
-                key: "Esc",
-                desc: "back",
+                key: "e",
+                desc: "edit yaml",
             },
             KeyHint {
-                key: "q",
-                desc: "quit",
+                key: "Esc",
+                desc: "back",
             },
         ];
 

--- a/src/tui/views/health.rs
+++ b/src/tui/views/health.rs
@@ -4,6 +4,7 @@
 //! `anvil health` with collapsible sections and expandable item details.
 
 use std::collections::HashSet;
+use std::sync::mpsc;
 use std::time::Duration;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
@@ -11,9 +12,7 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{
-        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-    },
+    widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
     Frame,
 };
 
@@ -55,6 +54,16 @@ pub struct HealthReport {
     pub duration: Duration,
 }
 
+/// The result of running the health view
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum HealthOutcome {
+    /// User went back to browser (Esc / Backspace)
+    Back,
+    /// User quit the app (q / Ctrl+C)
+    Quit,
+}
+
 /// Interactive health report viewer state
 #[allow(dead_code)]
 pub struct HealthViewer {
@@ -65,6 +74,18 @@ pub struct HealthViewer {
     filter_failures: bool,
     scroll_offset: usize,
     quit: bool,
+    outcome: Option<HealthOutcome>,
+    /// Log messages from the health check process
+    logs: Vec<String>,
+    /// Whether the health check is still running
+    checking: bool,
+    /// Current checking phase label
+    checking_phase: String,
+    /// Items checked so far / total expected
+    checked_count: usize,
+    checked_total: usize,
+    /// Animation tick
+    tick: usize,
     theme: Theme,
 }
 
@@ -79,17 +100,110 @@ impl HealthViewer {
             filter_failures: false,
             scroll_offset: 0,
             quit: false,
+            outcome: None,
+            logs: Vec::new(),
+            checking: false,
+            checking_phase: String::new(),
+            checked_count: 0,
+            checked_total: 0,
+            tick: 0,
             theme: Theme::dark(),
         }
+    }
+
+    /// Create a new health viewer in "checking" mode (no results yet)
+    pub fn new_checking(workload_name: String) -> Self {
+        Self {
+            report: HealthReport {
+                workload_name,
+                sections: Vec::new(),
+                duration: Duration::ZERO,
+            },
+            selected: 0,
+            expanded: HashSet::new(),
+            section_collapsed: HashSet::new(),
+            filter_failures: false,
+            scroll_offset: 0,
+            quit: false,
+            outcome: None,
+            logs: Vec::new(),
+            checking: true,
+            checking_phase: "Starting...".to_string(),
+            checked_count: 0,
+            checked_total: 0,
+            tick: 0,
+            theme: Theme::dark(),
+        }
+    }
+
+    /// Process a health event, updating state
+    pub fn handle_health_event(&mut self, event: crate::tui::events::HealthEvent) {
+        use crate::tui::events::HealthEvent;
+        match event {
+            HealthEvent::PhaseStart { phase, total } => {
+                self.checking_phase = format!("Checking {}...", phase.label());
+                self.checked_total += total;
+                self.logs
+                    .push(format!("Phase: {} ({} items)", phase.label(), total));
+            }
+            HealthEvent::ItemComplete {
+                phase: _,
+                name,
+                passed,
+                message,
+            } => {
+                self.checked_count += 1;
+                let icon = if passed { "✓" } else { "✗" };
+                let mut log = format!("{} {}", icon, name);
+                if let Some(msg) = &message {
+                    log.push_str(&format!(" — {}", msg));
+                }
+                self.logs.push(log);
+
+                // Keep log size bounded
+                if self.logs.len() > 200 {
+                    self.logs.remove(0);
+                }
+            }
+            HealthEvent::PhaseComplete { phase } => {
+                self.logs.push(format!("✓ {} complete", phase.label()));
+            }
+            HealthEvent::Log { message } => {
+                self.logs.push(message);
+                if self.logs.len() > 200 {
+                    self.logs.remove(0);
+                }
+            }
+            HealthEvent::Done { duration } => {
+                self.checking = false;
+                self.report.duration = duration;
+                self.logs.push(format!(
+                    "Health check complete in {:.1}s",
+                    duration.as_secs_f64()
+                ));
+            }
+        }
+    }
+
+    /// Set the full report (called when health check completes)
+    pub fn set_report(&mut self, report: HealthReport) {
+        self.report = report;
+        self.checking = false;
     }
 
     /// Handle a keyboard event
     pub fn handle_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Char('q') if key.modifiers == KeyModifiers::NONE => {
+                self.outcome = Some(HealthOutcome::Quit);
                 self.quit = true;
             }
             KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
+                self.outcome = Some(HealthOutcome::Quit);
+                self.quit = true;
+            }
+            KeyCode::Esc | KeyCode::Backspace => {
+                self.outcome = Some(HealthOutcome::Back);
                 self.quit = true;
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -121,6 +235,11 @@ impl HealthViewer {
         self.quit
     }
 
+    /// Returns the outcome after the view exits
+    pub fn outcome(&self) -> HealthOutcome {
+        self.outcome.clone().unwrap_or(HealthOutcome::Back)
+    }
+
     /// Count of visible items for navigation
     pub fn total_items(&self) -> usize {
         let mut count = 0;
@@ -140,30 +259,149 @@ impl HealthViewer {
 
     /// Render the health report view
     pub fn render(&self, frame: &mut Frame) {
+        if self.checking {
+            self.render_checking(frame);
+        } else {
+            self.render_results(frame);
+        }
+    }
+
+    /// Render the "checking in progress" view with progress + logs
+    fn render_checking(&self, frame: &mut Frame) {
         let area = frame.area();
 
         let chunks = Layout::vertical([
             Constraint::Length(1), // branded header
-            Constraint::Length(1), // summary strip
+            Constraint::Length(1), // blank padding
+            Constraint::Length(1), // progress bar
+            Constraint::Length(1), // phase label
+            Constraint::Length(1), // blank padding
+            Constraint::Length(1), // hairline divider
+            Constraint::Min(3),    // log pane
+            Constraint::Length(1), // key hints
+        ])
+        .split(area);
+
+        // Header
+        let spinner_frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+        let spinner = spinner_frames[self.tick % spinner_frames.len()];
+        render_header(
+            frame,
+            chunks[0],
+            &self.theme,
+            &["Health", &self.report.workload_name],
+            Some(Line::from(vec![Span::styled(
+                format!("{} Checking...", spinner),
+                self.theme.running_style(),
+            )])),
+        );
+
+        // Progress bar
+        let ratio = if self.checked_total > 0 {
+            self.checked_count as f64 / self.checked_total as f64
+        } else {
+            0.0
+        };
+        let pct = (ratio * 100.0) as u16;
+        let gauge_w = chunks[2].width.saturating_sub(30) as usize;
+        let filled = (ratio * gauge_w as f64) as usize;
+        let empty = gauge_w.saturating_sub(filled);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::raw("  "),
+                Span::styled("█".repeat(filled), self.theme.running_style()),
+                Span::styled("░".repeat(empty), self.theme.faint_style()),
+                Span::styled(
+                    format!(
+                        "  {}/{} checks  {}%",
+                        self.checked_count, self.checked_total, pct
+                    ),
+                    self.theme.dimmed(),
+                ),
+            ])),
+            chunks[2],
+        );
+
+        // Phase label
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(&self.checking_phase, self.theme.running_style()),
+            ])),
+            chunks[3],
+        );
+
+        // Hairline
+        self.render_hairline(frame, chunks[5]);
+
+        // Log pane
+        let log_area = chunks[6];
+        let visible_height = log_area.height as usize;
+        let log_start = self.logs.len().saturating_sub(visible_height);
+        let lines: Vec<Line> = self.logs[log_start..]
+            .iter()
+            .map(|log| {
+                let style = if log.starts_with('✓') {
+                    self.theme.success_style()
+                } else if log.starts_with('✗') {
+                    self.theme.error_style()
+                } else {
+                    self.theme.dimmed()
+                };
+                Line::styled(format!("  {}", log), style)
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(lines), log_area);
+
+        // Key hints (minimal during check)
+        render_keyhints(
+            frame,
+            chunks[7],
+            &[KeyHint {
+                key: "q",
+                desc: "cancel",
+            }],
+            &self.theme,
+        );
+    }
+
+    /// Render the results view (after checking completes)
+    fn render_results(&self, frame: &mut Frame) {
+        let area = frame.area();
+
+        let chunks = Layout::vertical([
+            Constraint::Length(1), // branded header
+            Constraint::Length(1), // blank padding
+            Constraint::Length(1), // summary gauge bar
+            Constraint::Length(1), // blank padding
+            Constraint::Length(1), // hairline divider
             Constraint::Min(3),    // main content
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
         self.render_branded_header(frame, chunks[0]);
-        self.render_summary(frame, chunks[1]);
-        self.render_main(frame, chunks[2]);
-        self.render_keyhints(frame, chunks[3]);
+        self.render_summary(frame, chunks[2]);
+        self.render_hairline(frame, chunks[4]);
+        self.render_main(frame, chunks[5]);
+        self.render_keyhints(frame, chunks[6]);
     }
 
     /// Render the branded header bar
     fn render_branded_header(&self, frame: &mut Frame, area: Rect) {
-        let (_, _pass, fail, _, _) = self.count_statuses();
-        let issues_text = format!("{} ISSUES", fail);
-        let result_badge = if fail == 0 {
-            badge("ALL PASS", self.theme.success)
+        let (_, pass, _, _, _) = self.count_statuses();
+        let total_items: usize = self.report.sections.iter().map(|s| s.items.len()).sum();
+        let pct = if total_items > 0 {
+            (pass as f64 / total_items as f64 * 100.0) as u16
         } else {
-            badge(&issues_text, self.theme.error)
+            100
+        };
+        let pct_style = if pct >= 80 {
+            self.theme.success_style()
+        } else if pct >= 50 {
+            self.theme.warning_style()
+        } else {
+            self.theme.error_style()
         };
 
         render_header(
@@ -171,66 +409,82 @@ impl HealthViewer {
             area,
             &self.theme,
             &["Health", &self.report.workload_name],
-            Some(Line::from(vec![
-                Span::styled(
-                    format!("{:.1}s", self.report.duration.as_secs_f64()),
-                    self.theme.dimmed(),
-                ),
-                Span::raw(" "),
-                result_badge,
-            ])),
+            Some(Line::from(vec![Span::styled(
+                format!("{}%", pct),
+                pct_style,
+            )])),
         );
     }
 
-    /// Render the summary strip
+    /// Render the summary gauge bar
     fn render_summary(&self, frame: &mut Frame, area: Rect) {
-        let (total, pass, fail, skip, warn) = self.count_statuses();
-        let pass_rate = if total > 0 {
-            (pass as f64 / total as f64) * 100.0
+        let (total, pass, fail, _, _) = self.count_statuses();
+        let ratio = if total > 0 {
+            pass as f64 / total as f64
         } else {
-            0.0
+            1.0
+        };
+        let pct = (ratio * 100.0) as u16;
+
+        // Build gauge bar
+        let gauge_w = 16usize;
+        let filled = (ratio * gauge_w as f64) as usize;
+        let empty = gauge_w.saturating_sub(filled);
+        let bar_filled = "█".repeat(filled);
+        let bar_empty = "░".repeat(empty);
+
+        let issues_text = format!("{} ISSUES", fail);
+        let issues_badge = if fail > 0 {
+            badge(&issues_text, self.theme.error)
+        } else {
+            badge("ALL PASS", self.theme.success)
         };
 
-        let summary_line = Line::from(vec![
-            Span::raw(" "),
-            Span::styled(format!("{total} checks"), self.theme.normal()),
+        let line = Line::from(vec![
             Span::raw("  "),
-            Span::styled(format!("{pass} pass"), self.theme.success_style()),
-            Span::raw("  "),
-            Span::styled(format!("{fail} fail"), self.theme.error_style()),
-            Span::raw("  "),
-            Span::styled(format!("{skip} skip"), self.theme.dimmed()),
-            Span::raw("  "),
-            Span::styled(format!("{warn} warn"), self.theme.warning_style()),
+            Span::styled(&bar_filled, self.theme.success_style()),
+            Span::styled(&bar_empty, self.theme.faint_style()),
             Span::raw("  "),
             Span::styled(
-                format!("{pass_rate:.0}%"),
-                if pass_rate >= 100.0 {
+                format!("{}%", pct),
+                if pct >= 100 {
                     self.theme.success_style()
-                } else if pass_rate >= 50.0 {
-                    self.theme.warning_style()
                 } else {
-                    self.theme.error_style()
+                    self.theme.normal()
                 },
             ),
+            Span::styled("  │  ", self.theme.faint_style()),
+            Span::styled(format!("{} pass", pass), self.theme.success_style()),
+            Span::raw("  "),
+            Span::styled(format!("{} fail", fail), self.theme.error_style()),
+            Span::raw("    "),
+            issues_badge,
+            Span::raw("  "),
+            Span::styled(
+                format!("{:.1}s", self.report.duration.as_secs_f64()),
+                self.theme.dimmed(),
+            ),
         ]);
+        frame.render_widget(Paragraph::new(line), area);
+    }
 
-        let paragraph = Paragraph::new(summary_line);
-        frame.render_widget(paragraph, area);
+    /// Render a hairline divider
+    fn render_hairline(&self, frame: &mut Frame, area: Rect) {
+        let divider_text = "─".repeat(area.width as usize);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                divider_text,
+                Style::default().fg(self.theme.hairline),
+            ))),
+            area,
+        );
     }
 
     /// Render the main content area with sections and items
     fn render_main(&self, frame: &mut Frame, area: Rect) {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(self.theme.border_style());
-
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-
         let mut lines: Vec<Line> = Vec::new();
         let mut flat_index: usize = 0;
+        let content_width = area.width as usize;
 
         for (si, section) in self.report.sections.iter().enumerate() {
             let is_collapsed = self.section_collapsed.contains(&si);
@@ -244,35 +498,48 @@ impl HealthViewer {
                 .map(|i| i.status == HealthStatus::Pass)
                 .collect();
 
-            // Section header with heatmap
+            // Section header with heatmap + right-aligned count
             let arrow = if is_collapsed { "▸" } else { "▾" };
+            let count_text = format!("{}/{}", section_pass, section_total);
             let count_style = if section_pass == section_total {
                 self.theme.success_style()
             } else {
                 self.theme.error_style()
             };
 
-            if is_selected {
-                let mut spans = vec![
-                    Span::styled("▌", Style::default().fg(self.theme.accent)),
-                    Span::styled(
-                        format!(" {} {} ", arrow, section.name),
-                        self.theme.selection().bg(self.theme.bg_inset),
-                    ),
-                ];
-                // Inline heatmap
-                for &pass in heatmap_results.iter().take(20) {
+            let heatmap_spans: Vec<Span> = heatmap_results
+                .iter()
+                .take(section_total.min(30))
+                .map(|&pass| {
                     let c = if pass {
                         self.theme.success
                     } else {
                         self.theme.error
                     };
-                    spans.push(Span::styled("▮", Style::default().fg(c)));
-                }
-                spans.push(Span::styled(
-                    format!(" {}/{}", section_pass, section_total),
-                    count_style,
-                ));
+                    Span::styled("▮", Style::default().fg(c))
+                })
+                .collect();
+
+            // Calculate padding for right-aligned count
+            let header_prefix_len = 4 + section.name.len() + 1; // "  ▾ Name "
+            let heatmap_len = heatmap_results.len().min(30);
+            let used = header_prefix_len + heatmap_len + 1 + count_text.len();
+            let pad = content_width.saturating_sub(used);
+
+            if is_selected {
+                let mut spans = vec![
+                    Span::styled("▌", Style::default().fg(self.theme.accent)),
+                    Span::styled(
+                        format!(" {} {} ", arrow, section.name),
+                        self.theme
+                            .selection()
+                            .add_modifier(Modifier::BOLD)
+                            .bg(self.theme.bg_inset),
+                    ),
+                ];
+                spans.extend(heatmap_spans);
+                spans.push(Span::raw(" ".repeat(pad)));
+                spans.push(Span::styled(count_text, count_style));
                 lines.push(Line::from(spans));
             } else {
                 let mut spans = vec![
@@ -282,18 +549,9 @@ impl HealthViewer {
                         self.theme.normal().add_modifier(Modifier::BOLD),
                     ),
                 ];
-                for &pass in heatmap_results.iter().take(20) {
-                    let c = if pass {
-                        self.theme.success
-                    } else {
-                        self.theme.error
-                    };
-                    spans.push(Span::styled("▮", Style::default().fg(c)));
-                }
-                spans.push(Span::styled(
-                    format!(" {}/{}", section_pass, section_total),
-                    count_style,
-                ));
+                spans.extend(heatmap_spans);
+                spans.push(Span::raw(" ".repeat(pad)));
+                spans.push(Span::styled(count_text, count_style));
                 lines.push(Line::from(spans));
             }
             flat_index += 1;
@@ -315,61 +573,106 @@ impl HealthViewer {
                         HealthStatus::Warn => ("⚠", self.theme.warning_style()),
                     };
 
+                    // Build the item line with right-aligned error text
+                    let name_len = item.name.len();
+                    let detail_text = if item.status == HealthStatus::Fail {
+                        item.detail.as_deref().unwrap_or("")
+                    } else {
+                        ""
+                    };
+                    let affordance = if item.status == HealthStatus::Fail && item.detail.is_some() {
+                        if is_expanded {
+                            "▾"
+                        } else {
+                            "▸"
+                        }
+                    } else {
+                        ""
+                    };
+
+                    // Truncate detail if needed
+                    let prefix_len = 6 + name_len; // indent + icon + space + name
+                    let detail_max =
+                        content_width.saturating_sub(prefix_len + 4 + affordance.len());
+                    let detail_display: String = if detail_text.len() > detail_max && detail_max > 3
+                    {
+                        format!("{}…", &detail_text[..detail_max.saturating_sub(1)])
+                    } else {
+                        detail_text.to_string()
+                    };
+
+                    let detail_pad = content_width
+                        .saturating_sub(prefix_len + detail_display.len() + affordance.len() + 2);
+
                     if is_item_selected {
                         let mut spans = vec![
-                            Span::styled("  ▌", Style::default().fg(self.theme.accent)),
+                            Span::raw("  "),
+                            Span::styled("▌", Style::default().fg(self.theme.accent)),
                             Span::styled(format!(" {} ", icon), icon_style.bg(self.theme.bg_inset)),
                             Span::styled(
                                 item.name.clone(),
                                 self.theme.selection().bg(self.theme.bg_inset),
                             ),
                         ];
-                        // Right-aligned error text for failed items
-                        if item.status == HealthStatus::Fail {
-                            if let Some(detail) = &item.detail {
-                                let affordance = if is_expanded { " ▾" } else { " ▸" };
-                                spans.push(Span::styled(
-                                    format!("  {}{}", detail, affordance),
-                                    self.theme.error_style(),
-                                ));
-                            }
+                        if !detail_display.is_empty() {
+                            spans.push(Span::raw(" ".repeat(detail_pad)));
+                            spans.push(Span::styled(detail_display, self.theme.error_style()));
+                            spans.push(Span::styled(affordance, self.theme.error_style()));
                         }
                         lines.push(Line::from(spans));
                     } else {
                         let mut spans = vec![
                             Span::raw("    "),
                             Span::styled(format!("{} ", icon), icon_style),
-                            Span::styled(&item.name, self.theme.normal()),
+                            Span::styled(item.name.clone(), self.theme.normal()),
                         ];
-                        if item.status == HealthStatus::Fail {
-                            if let Some(detail) = &item.detail {
-                                let affordance = if is_expanded { " ▾" } else { " ▸" };
-                                spans.push(Span::styled(
-                                    format!("  {}{}", detail, affordance),
-                                    self.theme.error_style(),
-                                ));
-                            }
+                        if !detail_display.is_empty() {
+                            spans.push(Span::raw(" ".repeat(detail_pad)));
+                            spans.push(Span::styled(detail_display, self.theme.error_style()));
+                            spans.push(Span::styled(affordance, self.theme.error_style()));
                         }
                         lines.push(Line::from(spans));
                     }
 
-                    // Show detail if expanded
+                    // Expanded error detail — bg_inset box
                     if is_expanded {
                         if let Some(detail) = &item.detail {
-                            lines.push(Line::from(vec![
-                                Span::raw("      "),
-                                Span::styled(detail.as_str(), self.theme.error_style()),
-                            ]));
+                            lines.push(Line::raw(""));
+                            // Wrap detail in a padded bg_inset block
+                            let box_width = content_width.saturating_sub(8);
+                            let mut remaining = detail.as_str();
+                            while !remaining.is_empty() {
+                                let chunk_len = remaining.len().min(box_width);
+                                let split = if chunk_len < remaining.len() {
+                                    remaining[..chunk_len].rfind(' ').unwrap_or(chunk_len)
+                                } else {
+                                    chunk_len
+                                };
+                                let chunk = &remaining[..split];
+                                let pad = box_width.saturating_sub(chunk.len());
+                                lines.push(Line::from(vec![
+                                    Span::raw("      "),
+                                    Span::styled(
+                                        format!(" {}{} ", chunk, " ".repeat(pad)),
+                                        self.theme.error_style().bg(self.theme.bg_inset),
+                                    ),
+                                ]));
+                                remaining = remaining[split..].trim_start();
+                            }
+                            lines.push(Line::raw(""));
                         }
                     }
 
                     flat_index += 1;
                 }
             }
+
+            // Blank line between sections
+            lines.push(Line::raw(""));
         }
 
         // Apply scroll offset
-        let visible_height = inner.height as usize;
+        let visible_height = area.height as usize;
         let max_scroll = lines.len().saturating_sub(visible_height);
         let scroll = self.scroll_offset.min(max_scroll);
         let visible_lines: Vec<Line> = lines
@@ -379,7 +682,7 @@ impl HealthViewer {
             .collect();
 
         let paragraph = Paragraph::new(visible_lines);
-        frame.render_widget(paragraph, inner);
+        frame.render_widget(paragraph, area);
 
         // Scrollbar
         if max_scroll > 0 {
@@ -399,20 +702,24 @@ impl HealthViewer {
 
         let hints = vec![
             KeyHint {
-                key: "↑/↓",
+                key: "↑↓",
                 desc: "navigate",
             },
             KeyHint {
-                key: "Enter",
-                desc: "expand",
+                key: "↵",
+                desc: "expand error",
             },
             KeyHint {
                 key: "f",
                 desc: filter_desc,
             },
             KeyHint {
-                key: "q",
-                desc: "quit",
+                key: "r",
+                desc: "re-run",
+            },
+            KeyHint {
+                key: "Esc",
+                desc: "back",
             },
         ];
 
@@ -456,7 +763,7 @@ impl HealthViewer {
 
 /// Run the interactive health report viewer
 #[allow(dead_code)]
-pub fn run_health_viewer(report: HealthReport) -> anyhow::Result<()> {
+pub fn run_health_viewer(report: HealthReport) -> anyhow::Result<HealthOutcome> {
     let mut tui = Tui::new()?;
     let mut viewer = HealthViewer::new(report);
 
@@ -475,7 +782,109 @@ pub fn run_health_viewer(report: HealthReport) -> anyhow::Result<()> {
     }
 
     tui.restore()?;
-    Ok(())
+    Ok(viewer.outcome())
+}
+
+/// Run the health viewer with live events from a channel.
+///
+/// Shows a progress view while the health check runs, then transitions
+/// to the results view when done. Returns whether the user went back or quit.
+#[allow(dead_code)]
+pub fn run_health_with_events(
+    workload_name: String,
+    rx: mpsc::Receiver<crate::tui::events::HealthEvent>,
+    report_rx: mpsc::Receiver<HealthReport>,
+) -> anyhow::Result<HealthOutcome> {
+    let mut tui = Tui::new()?;
+    let mut viewer = HealthViewer::new_checking(workload_name);
+
+    let tick_rate = Duration::from_millis(100);
+
+    loop {
+        // Drain pending health events
+        loop {
+            match rx.try_recv() {
+                Ok(event) => viewer.handle_health_event(event),
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    // Check if we got a final report
+                    if let Ok(report) = report_rx.try_recv() {
+                        viewer.set_report(report);
+                    } else if viewer.checking {
+                        viewer.checking = false;
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Check for final report
+        if let Ok(report) = report_rx.try_recv() {
+            viewer.set_report(report);
+        }
+
+        viewer.tick += 1;
+        tui.draw(|f| viewer.render(f))?;
+
+        if let Some(Event::Key(key)) = tui.poll_event(tick_rate)? {
+            viewer.handle_key(key);
+
+            if viewer.should_quit() {
+                break;
+            }
+        }
+    }
+
+    tui.restore()?;
+    Ok(viewer.outcome())
+}
+
+/// Run the health viewer inline within an existing TUI session.
+///
+/// Used when launched from the browser — keeps the same alternate screen.
+pub fn run_health_inline(
+    tui: &mut Tui,
+    workload_name: String,
+    rx: mpsc::Receiver<crate::tui::events::HealthEvent>,
+    report_rx: mpsc::Receiver<HealthReport>,
+) -> anyhow::Result<HealthOutcome> {
+    let mut viewer = HealthViewer::new_checking(workload_name);
+    let tick_rate = Duration::from_millis(100);
+
+    loop {
+        // Drain pending health events
+        loop {
+            match rx.try_recv() {
+                Ok(event) => viewer.handle_health_event(event),
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    if let Ok(report) = report_rx.try_recv() {
+                        viewer.set_report(report);
+                    } else if viewer.checking {
+                        viewer.checking = false;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if let Ok(report) = report_rx.try_recv() {
+            viewer.set_report(report);
+        }
+
+        viewer.tick += 1;
+        tui.draw(|f| viewer.render(f))?;
+
+        if let Some(Event::Key(key)) = tui.poll_event(tick_rate)? {
+            viewer.handle_key(key);
+
+            if viewer.should_quit() {
+                break;
+            }
+        }
+    }
+
+    Ok(viewer.outcome())
 }
 
 #[cfg(test)]

--- a/src/tui/views/history.rs
+++ b/src/tui/views/history.rs
@@ -1,0 +1,633 @@
+//! Install history view
+//!
+//! This view renders a full-screen TUI showing past installation
+//! runs with a detail preview pane for the selected entry.
+
+use std::time::Duration;
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    Frame,
+};
+
+use crate::tui::theme::Theme;
+use crate::tui::widgets::chrome::{badge, render_header};
+use crate::tui::widgets::keyhints::{render_keyhints, KeyHint};
+use crate::tui::Tui;
+
+/// Result status of an install run
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum InstallResult {
+    Ok,
+    Partial,
+    Fail,
+}
+
+/// A single install history entry
+#[allow(dead_code)]
+pub struct HistoryEntry {
+    pub workload: String,
+    pub version: String,
+    pub date: String,
+    pub duration: Duration,
+    pub result: InstallResult,
+    pub summary: String,
+    pub path: String,
+    pub installed: usize,
+    pub skipped: usize,
+    pub failed: usize,
+    /// Previous version if this was an upgrade
+    pub previous_version: Option<String>,
+    /// How many times this workload has been installed total
+    pub install_count: usize,
+}
+
+/// The result of running the history view
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum HistoryOutcome {
+    /// User quit (q / Ctrl+C)
+    Quit,
+    /// User went back (Esc)
+    Back,
+    /// User wants to re-install a workload (name, path)
+    Reinstall(String, String),
+    /// User wants to view the log for this entry
+    ViewLog(String),
+}
+
+/// Interactive install history viewer state
+#[allow(dead_code)]
+pub struct HistoryViewer {
+    entries: Vec<HistoryEntry>,
+    selected: usize,
+    scroll_offset: usize,
+    quit: bool,
+    outcome: Option<HistoryOutcome>,
+    theme: Theme,
+}
+
+#[allow(dead_code)]
+impl HistoryViewer {
+    /// Create a new history viewer
+    pub fn new(entries: Vec<HistoryEntry>) -> Self {
+        Self {
+            entries,
+            selected: 0,
+            scroll_offset: 0,
+            quit: false,
+            outcome: None,
+            theme: Theme::dark(),
+        }
+    }
+
+    /// Handle a keyboard event
+    pub fn handle_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') if key.modifiers == KeyModifiers::NONE => {
+                self.outcome = Some(HistoryOutcome::Quit);
+                self.quit = true;
+            }
+            KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
+                self.outcome = Some(HistoryOutcome::Quit);
+                self.quit = true;
+            }
+            KeyCode::Esc | KeyCode::Backspace => {
+                self.outcome = Some(HistoryOutcome::Back);
+                self.quit = true;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = self.selected.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.entries.is_empty() {
+                    self.selected = (self.selected + 1).min(self.entries.len() - 1);
+                }
+            }
+            // Re-install the selected workload
+            KeyCode::Char('r') if key.modifiers == KeyModifiers::NONE => {
+                if let Some(entry) = self.entries.get(self.selected) {
+                    self.outcome = Some(HistoryOutcome::Reinstall(
+                        entry.workload.clone(),
+                        entry.path.clone(),
+                    ));
+                    self.quit = true;
+                }
+            }
+            // View log for selected entry
+            KeyCode::Enter => {
+                if let Some(entry) = self.entries.get(self.selected) {
+                    self.outcome = Some(HistoryOutcome::ViewLog(entry.workload.clone()));
+                    self.quit = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Whether the view should exit
+    pub fn should_quit(&self) -> bool {
+        self.quit
+    }
+
+    /// Returns the outcome after the view exits
+    pub fn outcome(&self) -> HistoryOutcome {
+        self.outcome.clone().unwrap_or(HistoryOutcome::Quit)
+    }
+
+    /// Render the full view
+    pub fn render(&self, frame: &mut Frame) {
+        let area = frame.area();
+
+        let chunks = Layout::vertical([
+            Constraint::Length(1), // branded header
+            Constraint::Length(1), // hairline divider
+            Constraint::Length(1), // column headers
+            Constraint::Length(1), // hairline divider
+            Constraint::Min(6),    // split: table (top) + detail (bottom)
+            Constraint::Length(1), // key hints
+        ])
+        .split(area);
+
+        self.render_header(frame, chunks[0]);
+        self.render_hairline(frame, chunks[1]);
+        self.render_column_headers(frame, chunks[2]);
+        self.render_hairline(frame, chunks[3]);
+        self.render_body(frame, chunks[4]);
+        self.render_keyhints(frame, chunks[5]);
+    }
+
+    /// Render the branded header
+    fn render_header(&self, frame: &mut Frame, area: Rect) {
+        let unique_workloads: std::collections::HashSet<&str> =
+            self.entries.iter().map(|e| e.workload.as_str()).collect();
+        let right_text = format!(
+            "{} runs · {} workloads",
+            self.entries.len(),
+            unique_workloads.len()
+        );
+
+        render_header(
+            frame,
+            area,
+            &self.theme,
+            &["Install History"],
+            Some(Line::from(vec![Span::styled(
+                right_text,
+                self.theme.dimmed(),
+            )])),
+        );
+    }
+
+    /// Render a hairline divider
+    fn render_hairline(&self, frame: &mut Frame, area: Rect) {
+        let line = "─".repeat(area.width as usize);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                line,
+                Style::default().fg(self.theme.hairline),
+            ))),
+            area,
+        );
+    }
+
+    /// Render the column header row
+    fn render_column_headers(&self, frame: &mut Frame, area: Rect) {
+        let style = self.theme.label_style();
+        let line = Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{:<18}", "WORKLOAD"), style),
+            Span::styled(format!("{:<12}", "VERSION"), style),
+            Span::styled(format!("{:<18}", "DATE"), style),
+            Span::styled(format!("{:<12}", "DURATION"), style),
+            Span::styled(format!("{:<10}", "RESULT"), style),
+            Span::styled("SUMMARY", style),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
+    }
+
+    /// Render the body: table rows (top) + detail pane (bottom)
+    fn render_body(&self, frame: &mut Frame, area: Rect) {
+        // Split: table rows take ~60%, detail pane takes ~40%
+        let table_height = (area.height as usize * 55) / 100;
+        let table_height = table_height.max(3);
+        let parts = Layout::vertical([
+            Constraint::Length(table_height as u16),
+            Constraint::Length(1), // hairline
+            Constraint::Min(3),    // detail
+        ])
+        .split(area);
+
+        self.render_table(frame, parts[0]);
+        self.render_hairline(frame, parts[1]);
+        self.render_detail(frame, parts[2]);
+    }
+
+    /// Render the scrollable table rows
+    fn render_table(&self, frame: &mut Frame, area: Rect) {
+        if self.entries.is_empty() {
+            let empty = Paragraph::new(Line::styled(
+                "  No install history found",
+                self.theme.dimmed(),
+            ));
+            frame.render_widget(empty, area);
+            return;
+        }
+
+        let visible_height = area.height as usize;
+
+        // Auto-scroll to keep selected visible
+        let scroll = if self.selected >= visible_height {
+            self.selected - visible_height + 1
+        } else {
+            0
+        };
+
+        let lines: Vec<Line> = self
+            .entries
+            .iter()
+            .enumerate()
+            .skip(scroll)
+            .take(visible_height)
+            .map(|(i, entry)| {
+                let is_selected = i == self.selected;
+
+                let duration = format_duration_short(entry.duration);
+
+                let (result_text, result_style) = match entry.result {
+                    InstallResult::Ok => ("OK", self.theme.success_style()),
+                    InstallResult::Partial => ("PARTIAL", self.theme.warning_style()),
+                    InstallResult::Fail => ("FAIL", self.theme.error_style()),
+                };
+
+                let workload_style = if is_selected {
+                    self.theme
+                        .selection()
+                        .add_modifier(Modifier::BOLD)
+                        .bg(self.theme.bg_inset)
+                } else {
+                    self.theme.running_style()
+                };
+
+                let text_style = if is_selected {
+                    self.theme.normal().bg(self.theme.bg_inset)
+                } else {
+                    self.theme.normal()
+                };
+
+                let faint_style = if is_selected {
+                    self.theme.faint_style().bg(self.theme.bg_inset)
+                } else {
+                    self.theme.faint_style()
+                };
+
+                let prefix = if is_selected {
+                    Span::styled("▌ ", Style::default().fg(self.theme.accent))
+                } else {
+                    Span::raw("  ")
+                };
+
+                Line::from(vec![
+                    prefix,
+                    Span::styled(format!("{:<18}", entry.workload), workload_style),
+                    Span::styled(format!("{:<12}", entry.version), faint_style),
+                    Span::styled(format!("{:<18}", entry.date), text_style),
+                    Span::styled(format!("{:<12}", duration), faint_style),
+                    Span::styled(format!("{:<10}", result_text), result_style),
+                    Span::styled(&entry.summary, faint_style),
+                ])
+            })
+            .collect();
+
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, area);
+
+        // Scrollbar
+        let total = self.entries.len();
+        if total > visible_height {
+            let max_scroll = total.saturating_sub(visible_height);
+            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
+            let mut scrollbar_state = ScrollbarState::new(max_scroll).position(scroll);
+            frame.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+        }
+    }
+
+    /// Render the detail pane for the selected entry
+    fn render_detail(&self, frame: &mut Frame, area: Rect) {
+        if self.entries.is_empty() {
+            return;
+        }
+
+        let entry = &self.entries[self.selected];
+        let mut lines: Vec<Line> = Vec::new();
+
+        // Blank line for top padding
+        lines.push(Line::raw(""));
+
+        // Name + version badge + result badge + date + duration
+        let version_text = format!("v{}", entry.version);
+        let (result_text, result_color) = match entry.result {
+            InstallResult::Ok => ("OK", self.theme.success),
+            InstallResult::Partial => ("PARTIAL", self.theme.warning),
+            InstallResult::Fail => ("FAIL", self.theme.error),
+        };
+
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                &entry.workload,
+                self.theme.normal().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(&version_text, Style::default().fg(self.theme.faint)),
+            Span::raw("  "),
+            badge(result_text, result_color),
+            Span::styled(
+                format!(
+                    "  · {}  · {}",
+                    entry.date,
+                    format_duration_short(entry.duration)
+                ),
+                self.theme.dimmed(),
+            ),
+        ]));
+
+        // Blank line
+        lines.push(Line::raw(""));
+
+        // Path
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Path: ", self.theme.faint_style()),
+            Span::styled(&entry.path, self.theme.running_style()),
+        ]));
+
+        // Blank line
+        lines.push(Line::raw(""));
+
+        // Stats: installed / skipped / failed
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("✓ ", self.theme.success_style()),
+            Span::styled(
+                format!("{} installed", entry.installed),
+                self.theme.normal(),
+            ),
+            Span::raw("   "),
+            Span::styled("○ ", self.theme.dimmed()),
+            Span::styled(format!("{} skipped", entry.skipped), self.theme.normal()),
+            Span::raw("   "),
+            Span::styled("✗ ", self.theme.error_style()),
+            Span::styled(format!("{} failed", entry.failed), self.theme.normal()),
+        ]));
+
+        // Upgrade info
+        if let Some(prev) = &entry.previous_version {
+            lines.push(Line::raw(""));
+            let ordinal = match entry.install_count {
+                1 => "1st".to_string(),
+                2 => "2nd".to_string(),
+                3 => "3rd".to_string(),
+                n => format!("{}th", n),
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    format!(
+                        "↑ upgraded from v{} · {} install of this workload",
+                        prev, ordinal
+                    ),
+                    self.theme.dimmed(),
+                ),
+            ]));
+        } else if entry.install_count > 1 {
+            lines.push(Line::raw(""));
+            let ordinal = match entry.install_count {
+                2 => "2nd".to_string(),
+                3 => "3rd".to_string(),
+                n => format!("{}th", n),
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    format!("{} install of this workload", ordinal),
+                    self.theme.dimmed(),
+                ),
+            ]));
+        }
+
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, area);
+    }
+
+    /// Render the key hints bar
+    fn render_keyhints(&self, frame: &mut Frame, area: Rect) {
+        let hints = vec![
+            KeyHint {
+                key: "↑↓",
+                desc: "navigate",
+            },
+            KeyHint {
+                key: "↵",
+                desc: "view log",
+            },
+            KeyHint {
+                key: "r",
+                desc: "re-install",
+            },
+            KeyHint {
+                key: "Esc",
+                desc: "back",
+            },
+            KeyHint {
+                key: "q",
+                desc: "quit",
+            },
+        ];
+
+        render_keyhints(frame, area, &hints, &self.theme);
+    }
+
+    /// Run the history viewer event loop
+    pub fn run(&mut self, tui: &mut Tui) -> anyhow::Result<HistoryOutcome> {
+        let tick_rate = Duration::from_millis(100);
+
+        loop {
+            tui.draw(|f| self.render(f))?;
+
+            if let Some(Event::Key(key)) = tui.poll_event(tick_rate)? {
+                self.handle_key(key);
+
+                if self.should_quit() {
+                    break;
+                }
+            }
+        }
+
+        Ok(self.outcome())
+    }
+}
+
+/// Format a duration as "Xm Ys"
+fn format_duration_short(dur: Duration) -> String {
+    let secs = dur.as_secs();
+    let mins = secs / 60;
+    let rem = secs % 60;
+    format!("{}m {:02}s", mins, rem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entries() -> Vec<HistoryEntry> {
+        vec![
+            HistoryEntry {
+                workload: "essentials".to_string(),
+                version: "2.0.0".to_string(),
+                date: "2025-06-02 14:23".to_string(),
+                duration: Duration::from_secs(312),
+                result: InstallResult::Ok,
+                summary: "26 installed".to_string(),
+                path: "C:\\src\\winforge\\workloads\\essentials\\workload.yaml".to_string(),
+                installed: 26,
+                skipped: 0,
+                failed: 0,
+                previous_version: Some("1.9.0".to_string()),
+                install_count: 3,
+            },
+            HistoryEntry {
+                workload: "essentials".to_string(),
+                version: "2.0.0".to_string(),
+                date: "2025-05-28 09:15".to_string(),
+                duration: Duration::from_secs(161),
+                result: InstallResult::Partial,
+                summary: "22 installed, 4 skipped".to_string(),
+                path: "C:\\src\\winforge\\workloads\\essentials\\workload.yaml".to_string(),
+                installed: 22,
+                skipped: 4,
+                failed: 0,
+                previous_version: None,
+                install_count: 2,
+            },
+            HistoryEntry {
+                workload: "rust-developer".to_string(),
+                version: "1.3.0".to_string(),
+                date: "2025-05-28 09:20".to_string(),
+                duration: Duration::from_secs(63),
+                result: InstallResult::Ok,
+                summary: "3 installed".to_string(),
+                path: "C:\\workloads\\rust-developer\\workload.yaml".to_string(),
+                installed: 3,
+                skipped: 0,
+                failed: 0,
+                previous_version: None,
+                install_count: 1,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_history_initial_state() {
+        let viewer = HistoryViewer::new(sample_entries());
+        assert!(!viewer.should_quit());
+        assert_eq!(viewer.selected, 0);
+        assert_eq!(viewer.entries.len(), 3);
+    }
+
+    #[test]
+    fn test_history_navigation() {
+        let mut viewer = HistoryViewer::new(sample_entries());
+        assert_eq!(viewer.selected, 0);
+
+        viewer.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(viewer.selected, 1);
+
+        viewer.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(viewer.selected, 2);
+
+        // Can't go past end
+        viewer.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(viewer.selected, 2);
+
+        viewer.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(viewer.selected, 1);
+
+        // j/k navigation
+        viewer.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+        assert_eq!(viewer.selected, 0);
+
+        viewer.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(viewer.selected, 1);
+    }
+
+    #[test]
+    fn test_history_quit() {
+        let mut viewer = HistoryViewer::new(sample_entries());
+        viewer.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(viewer.should_quit());
+        assert_eq!(viewer.outcome(), HistoryOutcome::Quit);
+    }
+
+    #[test]
+    fn test_history_back() {
+        let mut viewer = HistoryViewer::new(sample_entries());
+        viewer.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(viewer.should_quit());
+        assert_eq!(viewer.outcome(), HistoryOutcome::Back);
+    }
+
+    #[test]
+    fn test_history_reinstall() {
+        let mut viewer = HistoryViewer::new(sample_entries());
+        viewer.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+        assert!(viewer.should_quit());
+        assert_eq!(
+            viewer.outcome(),
+            HistoryOutcome::Reinstall(
+                "essentials".to_string(),
+                "C:\\src\\winforge\\workloads\\essentials\\workload.yaml".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn test_history_view_log() {
+        let mut viewer = HistoryViewer::new(sample_entries());
+        viewer.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(viewer.should_quit());
+        assert_eq!(
+            viewer.outcome(),
+            HistoryOutcome::ViewLog("essentials".to_string())
+        );
+    }
+
+    #[test]
+    fn test_history_empty() {
+        let viewer = HistoryViewer::new(vec![]);
+        assert_eq!(viewer.entries.len(), 0);
+    }
+
+    #[test]
+    fn test_history_render_in_test_backend() {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let viewer = HistoryViewer::new(sample_entries());
+
+        terminal.draw(|f| viewer.render(f)).unwrap();
+    }
+
+    #[test]
+    fn test_format_duration_short() {
+        assert_eq!(format_duration_short(Duration::from_secs(312)), "5m 12s");
+        assert_eq!(format_duration_short(Duration::from_secs(63)), "1m 03s");
+        assert_eq!(format_duration_short(Duration::from_secs(48)), "0m 48s");
+    }
+}

--- a/src/tui/views/install.rs
+++ b/src/tui/views/install.rs
@@ -11,15 +11,13 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::Modifier,
     text::{Line, Span},
-    widgets::{
-        Block, BorderType, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-    },
+    widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
     Frame,
 };
 
 use crate::tui::events::{InstallEvent, InstallPhase, ItemResult};
 use crate::tui::theme::Theme;
-use crate::tui::widgets::chrome::{gauge, render_header};
+use crate::tui::widgets::chrome::render_header;
 use crate::tui::widgets::keyhints::{render_keyhints, KeyHint};
 use crate::tui::widgets::status::{status_line, ItemStatus};
 use crate::tui::Tui;
@@ -185,47 +183,47 @@ impl InstallDashboard {
 
         let chunks = Layout::vertical([
             Constraint::Length(1), // branded header
+            Constraint::Length(1), // blank padding
             Constraint::Length(1), // overall gauge
+            Constraint::Length(1), // blank padding
             Constraint::Length(1), // phase chips
+            Constraint::Length(1), // hairline divider
             Constraint::Min(3),    // main content (split body)
             Constraint::Length(1), // key hints
         ])
         .split(area);
 
         self.render_branded_header(frame, chunks[0]);
-        self.render_gauge(frame, chunks[1]);
-        self.render_phase_chips(frame, chunks[2]);
-        self.render_main(frame, chunks[3]);
-        self.render_keyhints(frame, chunks[4]);
+        self.render_gauge(frame, chunks[2]);
+        self.render_phase_chips(frame, chunks[4]);
+        self.render_hairline(frame, chunks[5]);
+        self.render_main(frame, chunks[6]);
+        self.render_keyhints(frame, chunks[7]);
     }
 
     /// Render the branded header bar
     fn render_branded_header(&self, frame: &mut Frame, area: Rect) {
         let status_text = if self.done { "Complete" } else { "Installing" };
 
+        let mut right_spans = vec![];
+        if let Some(dur) = self.total_duration {
+            right_spans.push(Span::styled(
+                format!("⏱ {}", crate::cli::progress::format_duration(dur)),
+                self.theme.dimmed(),
+            ));
+        } else if !self.done {
+            // Show elapsed estimate
+            right_spans.push(Span::styled(status_text, self.theme.running_style()));
+        } else {
+            right_spans.push(Span::styled(status_text, self.theme.success_style()));
+        }
+
         render_header(
             frame,
             area,
             &self.theme,
-            &["Install", &self.workload_name],
-            Some(Line::from(vec![
-                Span::styled(
-                    status_text,
-                    if self.done {
-                        self.theme.success_style()
-                    } else {
-                        self.theme.running_style()
-                    },
-                ),
-                if let Some(dur) = self.total_duration {
-                    Span::styled(
-                        format!("  {}", crate::cli::progress::format_duration(dur)),
-                        self.theme.dimmed(),
-                    )
-                } else {
-                    Span::raw("")
-                },
-            ])),
+            &[status_text, &self.workload_name],
+            Some(Line::from(right_spans)),
         );
     }
 
@@ -237,15 +235,24 @@ impl InstallDashboard {
         } else {
             0.0
         };
-        frame.render_widget(
-            gauge(
-                &self.theme,
-                ratio,
-                self.theme.accent,
-                Some(format!("{completed} / {total} items")),
-            ),
-            area,
-        );
+        let pct = (ratio * 100.0) as u16;
+        let label = format!("{} / {} packages", completed, total);
+
+        // Build: "  Overall  ████░░░░░░░  label  pct%"
+        let gauge_width = area.width.saturating_sub(30) as usize;
+        let filled = (ratio * gauge_width as f64) as usize;
+        let empty = gauge_width.saturating_sub(filled);
+        let bar_filled = "█".repeat(filled);
+        let bar_empty = "░".repeat(empty);
+
+        let line = Line::from(vec![
+            Span::styled("  Overall  ", self.theme.dimmed()),
+            Span::styled(bar_filled, self.theme.error_style()),
+            Span::styled(bar_empty, self.theme.faint_style()),
+            Span::styled(format!("  {}  ", label), self.theme.normal()),
+            Span::styled(format!("{}%", pct), self.theme.dimmed()),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
     }
 
     /// Render phase indicator chips
@@ -261,16 +268,42 @@ impl InstallDashboard {
         ];
 
         let mut spans: Vec<Span> = vec![Span::raw(" ")];
-        for phase in &all_phases {
+        for (idx, phase) in all_phases.iter().enumerate() {
             let state = self.phases.iter().find(|p| p.phase == *phase);
             let (icon, style) = match state.map(|p| p.status) {
                 Some(ItemStatus::Success) => ("✓", self.theme.success_style()),
-                Some(ItemStatus::Running) => ("⠋", self.theme.running_style()),
+                Some(ItemStatus::Running) => match self.tick % 10 {
+                    0 => ("⠋", self.theme.running_style()),
+                    1 => ("⠙", self.theme.running_style()),
+                    2 => ("⠹", self.theme.running_style()),
+                    3 => ("⠸", self.theme.running_style()),
+                    4 => ("⠼", self.theme.running_style()),
+                    5 => ("⠴", self.theme.running_style()),
+                    6 => ("⠦", self.theme.running_style()),
+                    7 => ("⠧", self.theme.running_style()),
+                    8 => ("⠇", self.theme.running_style()),
+                    _ => ("⠏", self.theme.running_style()),
+                },
                 _ => ("·", self.theme.faint_style()),
             };
-            spans.push(Span::styled(format!(" {} {} ", icon, phase.label()), style));
+            if idx > 0 {
+                spans.push(Span::styled(" · ", self.theme.faint_style()));
+            }
+            spans.push(Span::styled(format!("{} {}", icon, phase.label()), style));
         }
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    /// Render a hairline divider
+    fn render_hairline(&self, frame: &mut Frame, area: Rect) {
+        let divider_text = "─".repeat(area.width as usize);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                divider_text,
+                ratatui::style::Style::default().fg(self.theme.hairline),
+            ))),
+            area,
+        );
     }
 
     /// Compute overall completed/total across all phases
@@ -280,35 +313,40 @@ impl InstallDashboard {
         (completed, total)
     }
 
-    /// Render the main content area
+    /// Render the main content area — always split: items left, log right
     fn render_main(&self, frame: &mut Frame, area: Rect) {
-        if self.verbose && !self.logs.is_empty() {
-            // Split body: items (62%) + log (38%)
-            let body = Layout::horizontal([Constraint::Percentage(62), Constraint::Percentage(38)])
-                .split(area);
+        if self.verbose {
+            // Split body: items (60%) + divider + log (40%)
+            let body = Layout::horizontal([
+                Constraint::Percentage(60),
+                Constraint::Length(1),
+                Constraint::Percentage(40),
+            ])
+            .split(area);
 
             self.render_items(frame, body[0]);
-            self.render_log(frame, body[1]);
+
+            // Vertical divider
+            let divider_lines: Vec<Line> = (0..body[1].height)
+                .map(|_| {
+                    Line::from(Span::styled(
+                        "│",
+                        ratatui::style::Style::default().fg(self.theme.hairline),
+                    ))
+                })
+                .collect();
+            frame.render_widget(Paragraph::new(divider_lines), body[1]);
+
+            self.render_log(frame, body[2]);
         } else {
             self.render_items(frame, area);
         }
     }
 
-    /// Render the items pane
+    /// Render the items pane (no bordered block — just content)
     fn render_items(&self, frame: &mut Frame, area: Rect) {
-        let title = format!(" Installing {} ", self.workload_name);
-        let block = Block::default()
-            .title(Span::styled(title, self.theme.title_style()))
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(self.theme.border_style());
-
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
-
-        // Build content lines
         let mut lines: Vec<Line> = Vec::new();
-        let width = inner.width;
+        let width = area.width;
 
         if self.done {
             // Show completion summary
@@ -333,24 +371,34 @@ impl InstallDashboard {
         } else {
             // Show phases and items
             for ps in &self.phases {
-                lines.push(Line::raw(""));
-
                 if ps.status == ItemStatus::Running {
-                    // Active phase — show progress and items
-                    // Phase header with progress
-                    let phase_line = Line::from(vec![
-                        Span::styled(
-                            format!("  Phase: {}", ps.phase.label()),
-                            self.theme.running_style().add_modifier(Modifier::BOLD),
-                        ),
-                        Span::raw(format!("  [{}/{}]", ps.completed, ps.total)),
-                    ]);
-                    lines.push(phase_line);
+                    // Active phase header with inline mini gauge
+                    let pct = ps
+                        .total
+                        .checked_div(1)
+                        .filter(|_| ps.total > 0)
+                        .map(|_| (ps.completed as f64 / ps.total as f64 * 100.0) as u16)
+                        .unwrap_or(0);
+                    let gauge_w = 12usize;
+                    let filled = (ps.completed * gauge_w).checked_div(ps.total).unwrap_or(0);
+                    let empty = gauge_w.saturating_sub(filled);
+                    let bar = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
 
-                    // Progress bar area (rendered separately)
-                    if ps.total > 0 {
-                        lines.push(Line::raw("")); // spacer for gauge
-                    }
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            format!(
+                                "  {} Installing {} [{}/{}]  ",
+                                ItemStatus::Running.symbol(self.tick),
+                                ps.phase.label(),
+                                ps.completed,
+                                ps.total,
+                            ),
+                            self.theme.running_style(),
+                        ),
+                        Span::styled(bar, self.theme.running_style()),
+                        Span::styled(format!("  {}%", pct), self.theme.dimmed()),
+                    ]));
+                    lines.push(Line::raw(""));
 
                     // Items
                     for item in &ps.items {
@@ -364,10 +412,11 @@ impl InstallDashboard {
                         ));
                     }
 
-                    // Show pending items count if not all started
+                    // Show pending items count
                     let started = ps.items.len();
                     if started < ps.total {
                         let remaining = ps.total - started;
+                        lines.push(Line::raw(""));
                         lines.push(Line::styled(
                             format!("  ... {} more pending", remaining),
                             self.theme.dimmed(),
@@ -377,20 +426,12 @@ impl InstallDashboard {
                     // Completed phase — summary line
                     let summary = format!("  ✓ {} ({} items)", ps.phase.label(), ps.completed);
                     lines.push(Line::styled(summary, self.theme.success_style()));
-                } else {
-                    // Pending phase
-                    lines.push(Line::styled(
-                        format!("  Phase: {}  pending", ps.phase.label()),
-                        self.theme.dimmed(),
-                    ));
                 }
             }
-
-            // Future phases no longer shown inline — phase chips handle this
         }
 
         // Apply scroll offset
-        let visible_height = inner.height as usize;
+        let visible_height = area.height as usize;
         let max_scroll = lines.len().saturating_sub(visible_height);
         let scroll = self.scroll_offset.min(max_scroll);
         let visible_lines: Vec<Line> = lines
@@ -400,7 +441,7 @@ impl InstallDashboard {
             .collect();
 
         let paragraph = Paragraph::new(visible_lines);
-        frame.render_widget(paragraph, inner);
+        frame.render_widget(paragraph, area);
 
         // Scrollbar
         if max_scroll > 0 {
@@ -410,35 +451,40 @@ impl InstallDashboard {
         }
     }
 
-    /// Render the log pane (right side when verbose)
+    /// Render the log pane with header and auto-scrolling entries
     fn render_log(&self, frame: &mut Frame, area: Rect) {
-        let block = Block::default()
-            .title(Span::styled(" Log ", self.theme.dimmed()))
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(self.theme.border_style());
+        // Split: LOG header + content
+        let parts = Layout::vertical([
+            Constraint::Length(1), // LOG header
+            Constraint::Min(1),    // log content
+        ])
+        .split(area);
 
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        // LOG header
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled("  LOG", self.theme.label_style()))),
+            parts[0],
+        );
 
-        let visible_height = inner.height as usize;
+        // Log content — auto-scroll to bottom
+        let visible_height = parts[1].height as usize;
         let log_start = self.logs.len().saturating_sub(visible_height);
         let lines: Vec<Line> = self.logs[log_start..]
             .iter()
             .map(|log| {
-                let style = if log.starts_with('$') || log.starts_with('>') {
-                    self.theme.faint_style()
-                } else if log.starts_with('✓') {
+                let style = if log.contains('✓') || log.contains("installed") {
                     self.theme.success_style()
+                } else if log.starts_with('$') || log.starts_with('>') || log.contains("$ ") {
+                    self.theme.faint_style()
                 } else {
                     self.theme.dimmed()
                 };
-                Line::styled(format!(" {}", log), style)
+                Line::styled(format!("  {}", log), style)
             })
             .collect();
 
         let paragraph = Paragraph::new(lines);
-        frame.render_widget(paragraph, inner);
+        frame.render_widget(paragraph, parts[1]);
     }
 
     /// Render the key hints bar
@@ -451,16 +497,16 @@ impl InstallDashboard {
         } else {
             vec![
                 KeyHint {
-                    key: "↑/↓",
+                    key: "↑↓",
                     desc: "scroll",
                 },
                 KeyHint {
-                    key: "q",
-                    desc: "stop after current",
+                    key: "v",
+                    desc: "toggle log",
                 },
                 KeyHint {
-                    key: "v",
-                    desc: if self.verbose { "hide log" } else { "show log" },
+                    key: "q",
+                    desc: "cancel",
                 },
             ]
         };

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -3,5 +3,6 @@
 pub mod browser;
 pub mod detail;
 pub mod health;
+pub mod history;
 pub mod install;
 pub mod status;

--- a/src/tui/widgets/chrome.rs
+++ b/src/tui/widgets/chrome.rs
@@ -82,6 +82,7 @@ pub fn badge<'a>(text: &'a str, fg: ratatui::style::Color) -> Span<'a> {
 /// Build a Gauge widget styled to the theme.
 ///
 /// `ratio` in 0.0..=1.0. `color` is the fill (accent / success / running).
+#[allow(dead_code)]
 pub fn gauge<'a>(
     theme: &Theme,
     ratio: f64,


### PR DESCRIPTION
## Description

Redesign all TUI views to match the Flexoki dark theme design handoff, add inline health check with live progress, and create the install history view.

### What's included

- **Detail view redesign** — separate padded sections for description, path, and tabs with hairline dividers. Table-style tabs (Packages, Files, Commands, Assertions) show column headers (PACKAGE ID / VERSION / SOURCE) with columnar alignment.
- **Install dashboard redesign** — inline ASCII gauge bar with animated spinner per phase, `LOG` pane with auto-scrolling entries, phase chips with dot separators, no bordered blocks.
- **Health view redesign** — summary gauge bar with pass/fail counts and `N ISSUES` badge, section heatmaps with right-aligned counts, expanded error details in `bg_inset` box with word-wrapping.
- **Health check from browser** — pressing `h` runs the health check inline within the TUI session. Shows live progress (animated spinner, gauge, scrolling log) then transitions to results. `Esc` returns to browser, `q` quits the app.
- **Install history view** — new `history.rs` view with columnar table (WORKLOAD / VERSION / DATE / DURATION / RESULT / SUMMARY), detail pane showing path, stats, and upgrade info, with `r` to re-install and `↵` to view log.
- **Browser improvements** — `h` keybinding for health check, bordered panes with vertical/horizontal dividers, padding between search bar and list items.
- **Consistent navigation** — `Esc`/`Backspace` always goes back, `q` always quits across all views.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)