### PR TITLE
ci: group Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns:
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -30,3 +34,7 @@ updates:
       # MSRV check uses @1.75), not the action release. Dependabot misreads this
       # as an action tag and proposes nonexistent Rust versions, so ignore it.
       - dependency-name: "dtolnay/rust-toolchain"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

Dependabot currently opens a separate pull request for every dependency it bumps, which creates noise and a lot of individual CI runs. This enables Dependabot's grouped updates so each ecosystem produces a single consolidated PR.

Adds a `groups:` block to each `package-ecosystem` entry in `.github/dependabot.yml`:

- `cargo` -> group `cargo` with `patterns: ["*"]`
- `github-actions` -> group `github-actions` with `patterns: ["*"]`

All existing keys are preserved exactly, including the `ignore:` entry for `dtolnay/rust-toolchain` under the github-actions block. The change is config-only.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] `cargo test` passes (N/A - config-only change)
- [ ] `cargo clippy -- -D warnings` reports no warnings (N/A - config-only change)
- [ ] `cargo fmt` has been applied (N/A - config-only change)
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)